### PR TITLE
adds initial vertical spacing for job description (snippets)

### DIFF
--- a/components/blocks/vf-job-description/vf-job-description.scss
+++ b/components/blocks/vf-job-description/vf-job-description.scss
@@ -1,8 +1,12 @@
 // vf-job-description
 
 .vf-job-description {
-
+  @include margin--block(bottom, 40px);
+  @media (min-width: $vf-breakpoint-l) {
+    @include margin--block(bottom, 48px);
+  }
 }
+
 .vf-job-description__dates {
   display: inline;
   span {


### PR DESCRIPTION
we add 40px bottom margin to `vf-job-description` unless it it's at 1024px or wider where we are at 48px.

This will fix #12 