### PR TITLE
updates to remove the iframe preview padding

### DIFF
--- a/assets/scss/_shame.scss
+++ b/assets/scss/_shame.scss
@@ -2,7 +2,7 @@
 
 .Preview-iframe {
   border: 1px solid #b3b3b3;
-  padding: 12px 0 0 12px;
+  padding: 0;
 }
 .Tree-depth-2 > h4 {
   font-size: 24px;


### PR DESCRIPTION
This removes the 12px left/top padding that is on the preview iframe.

This closes #37 