### PR TITLE
Add new responsive logo pattern variant

### DIFF
--- a/components/blocks/vf-global-header/vf-global-header.hbs
+++ b/components/blocks/vf-global-header/vf-global-header.hbs
@@ -1,5 +1,5 @@
 <div class="vf-global-header">
-  {{render '@vf-logo'}}
+  {{render '@vf-logo--responsive'}}
 
   {{render '@vf-navigation--tertiary'}}
 </div>

--- a/components/blocks/vf-global-header/vf-global-header.scss
+++ b/components/blocks/vf-global-header/vf-global-header.scss
@@ -8,7 +8,9 @@ $vf-global-header__link-text--color: set-color(vf-color-black);
   background-color: $vf-global-header-background--color;
   display: flex;
   grid-column: 2 / -2;
-  height: 56px; // this should may change
+  height: auto;
+  margin-top: .25rem;
+  margin-bottom: .25rem;
 }
 
 .vf-global-header {

--- a/components/blocks/vf-masthead/vf-masthead.hbs
+++ b/components/blocks/vf-masthead/vf-masthead.hbs
@@ -1,5 +1,3 @@
-
-
 <div class="vf-masthead | embl-grid embl-grid--with-sidebar" style="background-image: url('{{ path '/assets/blocks/vf-masthead/assets/group-bg.png' }}')">
   <div class="vf-masthead__title">
     <div class="vf-masthead__title-inner">
@@ -10,7 +8,6 @@
       </h2>
     </div>
   </div>
-
 
   <form action="" class="vf-masthead__form--search">
     <div class="vf-masthead__form__item">

--- a/components/elements/vf-logo/assets/logo-medium.svg
+++ b/components/elements/vf-logo/assets/logo-medium.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 35.3 17" style="enable-background:new 0 0 35.3 17;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#63B155;}
+	.st1{fill:#E11B2D;}
+</style>
+<circle class="st0" cx="32.2" cy="11.6" r="0.8"/>
+<circle class="st0" cx="30.4" cy="12.6" r="0.8"/>
+<circle class="st0" cx="32.2" cy="9.5" r="0.8"/>
+<circle class="st0" cx="30.4" cy="10.5" r="0.8"/>
+<circle class="st0" cx="32.2" cy="7.5" r="0.8"/>
+<circle class="st0" cx="30.4" cy="8.5" r="0.8"/>
+<circle class="st0" cx="32.2" cy="5.4" r="0.8"/>
+<circle class="st0" cx="30.4" cy="6.4" r="0.8"/>
+<circle class="st0" cx="30.4" cy="4.4" r="0.8"/>
+<circle class="st0" cx="28.5" cy="13.7" r="0.8"/>
+<circle class="st0" cx="28.5" cy="11.6" r="0.8"/>
+<circle class="st0" cx="26.7" cy="12.6" r="0.8"/>
+<circle class="st0" cx="26.7" cy="14.7" r="0.8"/>
+<circle class="st0" cx="28.5" cy="9.5" r="0.8"/>
+<circle class="st0" cx="26.7" cy="10.5" r="0.8"/>
+<circle class="st0" cx="28.5" cy="7.5" r="0.8"/>
+<circle class="st0" cx="26.7" cy="8.5" r="0.8"/>
+<circle class="st0" cx="28.5" cy="5.4" r="0.8"/>
+<circle class="st0" cx="26.7" cy="6.4" r="0.8"/>
+<circle class="st0" cx="28.5" cy="3.4" r="0.8"/>
+<circle class="st0" cx="26.7" cy="4.4" r="0.8"/>
+<circle class="st0" cx="26.7" cy="2.4" r="0.8"/>
+<circle class="st0" cx="21.3" cy="11.5" r="0.8"/>
+<circle class="st0" cx="21.3" cy="9.5" r="0.8"/>
+<circle class="st0" cx="21.3" cy="7.4" r="0.8"/>
+<circle class="st0" cx="21.3" cy="5.4" r="0.8"/>
+<circle class="st0" cx="24.9" cy="13.7" r="0.8"/>
+<circle class="st0" cx="24.9" cy="11.6" r="0.8"/>
+<circle class="st0" cx="23.1" cy="12.6" r="0.8"/>
+<circle class="st0" cx="24.9" cy="9.5" r="0.8"/>
+<circle class="st1" cx="23.1" cy="10.5" r="0.8"/>
+<circle class="st0" cx="24.9" cy="7.5" r="0.8"/>
+<circle class="st0" cx="23.1" cy="8.5" r="0.8"/>
+<circle class="st0" cx="24.9" cy="5.4" r="0.8"/>
+<circle class="st0" cx="23.1" cy="6.4" r="0.8"/>
+<circle class="st0" cx="24.9" cy="3.4" r="0.8"/>
+<circle class="st0" cx="23.1" cy="4.4" r="0.8"/>
+<g>
+	<path d="M0.3,6.2h3.4v0.7H1.1v1.2h2.4v0.7H1.1v1.4h2.6v0.7H0.3V6.2z"/>
+	<path d="M4.4,6.2h1.2l1.3,3.7h0l1.3-3.7h1.1v4.7H8.5V7.2h0l-1.3,3.6H6.5L5.2,7.2h0v3.6H4.4V6.2z"/>
+	<path d="M10.2,6.2h2.3c0.4,0,0.8,0.1,1,0.3c0.3,0.2,0.4,0.5,0.4,0.9c0,0.2-0.1,0.4-0.2,0.6c-0.1,0.2-0.3,0.3-0.5,0.4v0
+		c0.3,0.1,0.5,0.2,0.7,0.4C14,9,14.1,9.2,14.1,9.5c0,0.2,0,0.4-0.1,0.5c-0.1,0.2-0.2,0.3-0.3,0.4c-0.1,0.1-0.3,0.2-0.5,0.3
+		c-0.2,0.1-0.5,0.1-0.8,0.1h-2.1V6.2z M11.1,8.1h1.3c0.2,0,0.4-0.1,0.5-0.2c0.1-0.1,0.2-0.3,0.2-0.5c0-0.2-0.1-0.4-0.2-0.5
+		c-0.1-0.1-0.3-0.1-0.5-0.1h-1.3V8.1z M11.1,10.2h1.4c0.2,0,0.4-0.1,0.6-0.2c0.1-0.1,0.2-0.3,0.2-0.5c0-0.2-0.1-0.4-0.2-0.5
+		c-0.1-0.1-0.3-0.2-0.6-0.2h-1.4V10.2z"/>
+	<path d="M14.9,6.2h0.8v4h2.4v0.7h-3.2V6.2z"/>
+</g>
+</svg>

--- a/components/elements/vf-logo/assets/logo-small.svg
+++ b/components/elements/vf-logo/assets/logo-small.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 35.1 17" style="enable-background:new 0 0 35.1 17;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#63B155;}
+	.st1{fill:#E11B2D;}
+</style>
+<circle class="st0" cx="26.6" cy="11.4" r="1.1"/>
+<circle class="st0" cx="26.6" cy="14.3" r="1.1"/>
+<circle class="st0" cx="26.6" cy="8.4" r="1.1"/>
+<circle class="st0" cx="26.6" cy="5.6" r="1.1"/>
+<circle class="st0" cx="26.6" cy="2.6" r="1.1"/>
+<circle class="st0" cx="29.2" cy="13" r="1.1"/>
+<circle class="st0" cx="29.2" cy="10" r="1.1"/>
+<circle class="st0" cx="29.2" cy="7.1" r="1.1"/>
+<circle class="st0" cx="29.2" cy="4.2" r="1.1"/>
+<circle class="st0" cx="31.8" cy="11.4" r="1.1"/>
+<circle class="st0" cx="31.8" cy="8.6" r="1.1"/>
+<circle class="st0" cx="31.8" cy="5.6" r="1.1"/>
+<circle class="st0" cx="21.4" cy="11.4" r="1.1"/>
+<circle class="st0" cx="21.4" cy="8.4" r="1.1"/>
+<circle class="st0" cx="21.4" cy="5.6" r="1.1"/>
+<circle class="st0" cx="24" cy="13" r="1.1"/>
+<circle class="st1" cx="24" cy="10" r="1.1"/>
+<circle class="st0" cx="24" cy="7.1" r="1.1"/>
+<circle class="st0" cx="24" cy="4.2" r="1.1"/>
+<g>
+	<path d="M0.2,6h3.4v0.7H1V8h2.4v0.7H1V10h2.6v0.7H0.2V6z"/>
+	<path d="M4.3,6h1.2l1.3,3.7h0L8,6h1.1v4.7H8.4V7.1h0l-1.3,3.6H6.4L5.1,7.1h0v3.6H4.3V6z"/>
+	<path d="M10.2,6h2.3c0.4,0,0.8,0.1,1,0.3c0.3,0.2,0.4,0.5,0.4,0.9c0,0.2-0.1,0.4-0.2,0.6c-0.1,0.2-0.3,0.3-0.5,0.4v0
+		c0.3,0.1,0.5,0.2,0.7,0.4C14,8.8,14,9.1,14,9.4c0,0.2,0,0.4-0.1,0.5c-0.1,0.2-0.2,0.3-0.3,0.4c-0.1,0.1-0.3,0.2-0.5,0.3
+		c-0.2,0.1-0.5,0.1-0.8,0.1h-2.1V6z M11,8h1.3c0.2,0,0.4-0.1,0.5-0.2C12.9,7.7,13,7.5,13,7.3c0-0.2-0.1-0.4-0.2-0.5
+		c-0.1-0.1-0.3-0.1-0.5-0.1H11V8z M11,10h1.4c0.2,0,0.4-0.1,0.6-0.2c0.1-0.1,0.2-0.3,0.2-0.5c0-0.2-0.1-0.4-0.2-0.5
+		c-0.1-0.1-0.3-0.2-0.6-0.2H11V10z"/>
+	<path d="M14.8,6h0.8v4H18v0.7h-3.2V6z"/>
+</g>
+</svg>

--- a/components/elements/vf-logo/assets/logo.svg
+++ b/components/elements/vf-logo/assets/logo.svg
@@ -1,1 +1,82 @@
-<svg width="163" height="180" xmlns="http://www.w3.org/2000/svg"><g fill-rule="nonzero" fill="none"><circle cx="8" cy="8" r="7.5" transform="translate(37 20.1)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(37 40.7)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(37 61.2)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(37 81.7)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(37 122.9)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(37 143.5)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(0 40.6)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(0 61.3)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(0 81.7)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(0 102.3)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(0 122.8)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(19 30.4)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(19 51)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(19 71.5)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(19 92)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(19 112.5)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(19 133)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(146.7 40.6)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(146.7 61)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(146.7 81.7)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(146.7 102)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(146.7 123)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(128 30.4)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(128 51)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(128 71.5)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(128 92)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(128 112.5)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(128 133)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(110 20)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(110 40.7)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(110 61)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(110 81.7)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(110 102)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(110 123)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(110 143.5)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(37 102)" fill="#DA0F21"/><circle cx="8" cy="8" r="7.5" transform="translate(92 10)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(92 30)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(92 51)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(92 71)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(92 92)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(92 112.5)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(92 133)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(92 153.6)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(73.5 -.5)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(73.5 20)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(73.5 40.6)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(73.5 61)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(73.5 82)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(73.5 102.3)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(73.5 123)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(73.5 143.4)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(55 9.7)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(55 30.3)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(55 50.8)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(55 71.4)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(55 92)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(55 112.5)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(55 133)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(55 153.6)" fill="#6DAB49"/><circle cx="8" cy="8" r="7.5" transform="translate(73.5 164)" fill="#6DAB49"/></g></svg>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 418.5 179.5" style="enable-background:new 0 0 418.5 179.5;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#6DAB49;}
+	.st1{fill:#DA0F21;}
+</style>
+<g>
+	<path d="M0,59.2h43.2v9.1H10.5V84h30.2v8.6H10.5v17.6h33.3v9.1H0V59.2z"/>
+	<path d="M52.8,59.2h14.8l16.6,47h0.2l16.1-47H115v60h-10V72.9h-0.2l-16.6,46.3h-8.7L62.9,72.9h-0.2v46.3h-10V59.2z"/>
+	<path d="M127.6,59.2h29.2c5.4,0,9.7,1.2,12.9,3.7c3.2,2.5,4.9,6.2,4.9,11.2c0,3-0.7,5.6-2.2,7.8c-1.5,2.2-3.6,3.8-6.3,5V87
+		c3.7,0.8,6.5,2.5,8.4,5.3c1.9,2.7,2.9,6.1,2.9,10.2c0,2.4-0.4,4.6-1.3,6.6c-0.8,2-2.2,3.8-3.9,5.3c-1.8,1.5-4.1,2.7-6.9,3.5
+		c-2.8,0.9-6.1,1.3-10,1.3h-27.6V59.2z M138.1,84.3h17.1c2.5,0,4.6-0.7,6.3-2.1c1.7-1.4,2.5-3.5,2.5-6.2c0-3-0.8-5.2-2.3-6.4
+		c-1.5-1.2-3.7-1.8-6.6-1.8h-17.1V84.3z M138.1,110.6h18.6c3.2,0,5.7-0.8,7.4-2.5c1.8-1.7,2.6-4,2.6-7c0-3-0.9-5.3-2.6-6.8
+		c-1.8-1.6-4.2-2.4-7.4-2.4h-18.6V110.6z"/>
+	<path d="M186.8,59.2h10.5v50.9h30.5v9.1h-41V59.2z"/>
+</g>
+<g>
+	<circle class="st0" cx="301.3" cy="28.1" r="7.5"/>
+	<circle class="st0" cx="301.3" cy="48.7" r="7.5"/>
+	<circle class="st0" cx="301.3" cy="69.2" r="7.5"/>
+	<circle class="st0" cx="301.3" cy="89.7" r="7.5"/>
+	<circle class="st0" cx="301.3" cy="130.9" r="7.5"/>
+	<circle class="st0" cx="301.3" cy="151.5" r="7.5"/>
+	<circle class="st0" cx="264.3" cy="48.6" r="7.5"/>
+	<circle class="st0" cx="264.3" cy="69.3" r="7.5"/>
+	<circle class="st0" cx="264.3" cy="89.7" r="7.5"/>
+	<circle class="st0" cx="264.3" cy="110.3" r="7.5"/>
+	<circle class="st0" cx="264.3" cy="130.8" r="7.5"/>
+	<circle class="st0" cx="283.3" cy="38.4" r="7.5"/>
+	<circle class="st0" cx="283.3" cy="59" r="7.5"/>
+	<circle class="st0" cx="283.3" cy="79.5" r="7.5"/>
+	<circle class="st0" cx="283.3" cy="100" r="7.5"/>
+	<circle class="st0" cx="283.3" cy="120.5" r="7.5"/>
+	<circle class="st0" cx="283.3" cy="141" r="7.5"/>
+	<circle class="st0" cx="411" cy="48.6" r="7.5"/>
+	<circle class="st0" cx="411" cy="69" r="7.5"/>
+	<circle class="st0" cx="411" cy="89.7" r="7.5"/>
+	<circle class="st0" cx="411" cy="110" r="7.5"/>
+	<circle class="st0" cx="411" cy="131" r="7.5"/>
+	<circle class="st0" cx="392.3" cy="38.4" r="7.5"/>
+	<circle class="st0" cx="392.3" cy="59" r="7.5"/>
+	<circle class="st0" cx="392.3" cy="79.5" r="7.5"/>
+	<circle class="st0" cx="392.3" cy="100" r="7.5"/>
+	<circle class="st0" cx="392.3" cy="120.5" r="7.5"/>
+	<circle class="st0" cx="392.3" cy="141" r="7.5"/>
+	<circle class="st0" cx="374.3" cy="28" r="7.5"/>
+	<circle class="st0" cx="374.3" cy="48.7" r="7.5"/>
+	<circle class="st0" cx="374.3" cy="69" r="7.5"/>
+	<circle class="st0" cx="374.3" cy="89.7" r="7.5"/>
+	<circle class="st0" cx="374.3" cy="110" r="7.5"/>
+	<circle class="st0" cx="374.3" cy="131" r="7.5"/>
+	<circle class="st0" cx="374.3" cy="151.5" r="7.5"/>
+	<circle class="st1" cx="301.3" cy="110" r="7.5"/>
+	<circle class="st0" cx="356.3" cy="18" r="7.5"/>
+	<circle class="st0" cx="356.3" cy="38" r="7.5"/>
+	<circle class="st0" cx="356.3" cy="59" r="7.5"/>
+	<circle class="st0" cx="356.3" cy="79" r="7.5"/>
+	<circle class="st0" cx="356.3" cy="100" r="7.5"/>
+	<circle class="st0" cx="356.3" cy="120.5" r="7.5"/>
+	<circle class="st0" cx="356.3" cy="141" r="7.5"/>
+	<circle class="st0" cx="356.3" cy="161.6" r="7.5"/>
+	<circle class="st0" cx="337.8" cy="7.5" r="7.5"/>
+	<circle class="st0" cx="337.8" cy="28" r="7.5"/>
+	<circle class="st0" cx="337.8" cy="48.6" r="7.5"/>
+	<circle class="st0" cx="337.8" cy="69" r="7.5"/>
+	<circle class="st0" cx="337.8" cy="90" r="7.5"/>
+	<circle class="st0" cx="337.8" cy="110.3" r="7.5"/>
+	<circle class="st0" cx="337.8" cy="131" r="7.5"/>
+	<circle class="st0" cx="337.8" cy="151.4" r="7.5"/>
+	<circle class="st0" cx="319.3" cy="17.7" r="7.5"/>
+	<circle class="st0" cx="319.3" cy="38.3" r="7.5"/>
+	<circle class="st0" cx="319.3" cy="58.8" r="7.5"/>
+	<circle class="st0" cx="319.3" cy="79.4" r="7.5"/>
+	<circle class="st0" cx="319.3" cy="100" r="7.5"/>
+	<circle class="st0" cx="319.3" cy="120.5" r="7.5"/>
+	<circle class="st0" cx="319.3" cy="141" r="7.5"/>
+	<circle class="st0" cx="319.3" cy="161.6" r="7.5"/>
+	<circle class="st0" cx="337.8" cy="172" r="7.5"/>
+</g>
+</svg>

--- a/components/elements/vf-logo/vf-logo--responsive.hbs
+++ b/components/elements/vf-logo/vf-logo--responsive.hbs
@@ -1,0 +1,1 @@
+<a href="/" class="vf-logo--responsive"></a>

--- a/components/elements/vf-logo/vf-logo.scss
+++ b/components/elements/vf-logo/vf-logo.scss
@@ -7,12 +7,23 @@
   text-decoration: none;
 }
 
-.vf-logo__text {
-  align-self: center;
-  left: 100px;
-  position: relative;
 
-  @media (max-width: 767px) {
-    display: none;
+.vf-logo--responsive {
+  min-width: 100px;
+  height: 30px;
+  display: flex;
+  background-repeat: no-repeat;
+  background-image: url('../assets/elements/vf-logo/assets/logo-small.svg');
+  background-size: auto 100%;
+}
+
+@media (min-width: 500px) {
+  .vf-logo--responsive {
+    background-image: url('../assets/elements/vf-logo/assets/logo-medium.svg');
+  }
+}
+@media (min-width: 999px) {
+  .vf-logo--responsive {
+    background-image: url('../assets/elements/vf-logo/assets/logo.svg');
   }
 }

--- a/components/elements/vf-logo/vf-logo.scss
+++ b/components/elements/vf-logo/vf-logo.scss
@@ -15,15 +15,18 @@
   background-repeat: no-repeat;
   background-image: url('../assets/elements/vf-logo/assets/logo-small.svg');
   background-size: auto 100%;
+  height: 25px;
 }
 
 @media (min-width: 500px) {
   .vf-logo--responsive {
     background-image: url('../assets/elements/vf-logo/assets/logo-medium.svg');
+    height: 28px;
   }
 }
 @media (min-width: 999px) {
   .vf-logo--responsive {
     background-image: url('../assets/elements/vf-logo/assets/logo.svg');
+    height: 30px;
   }
 }

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
@@ -1,7 +1,6 @@
 <header class="vf-header">
   <div class="vf-global-header">
-  <a href="http://www.embl.de" class="vf-logo">
-    <img src="../../assets/elements/vf-logo/assets/logo.png" alt="European Molecular Biology Laboratory Home">
+  <a href="http://www.embl.de" class="vf-logo--responsive">
   </a>
 
   </div>


### PR DESCRIPTION
Specifically done to test Tabea's new compact logo styles, but could see this approach being useful to other users of the VF.

![resize-logo](https://user-images.githubusercontent.com/928100/48782280-27d58680-ecde-11e8-9d6d-0bce4e7c3edd.gif)
