### PR TITLE
Fix link to favicon

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -31,7 +31,7 @@ fractal.web.set('server.syncOptions', {
 const mandelbrot = require('@frctl/mandelbrot');
 
 const VFTheme = mandelbrot({
-  favicon: '/assets/favicon.ico',
+  favicon: 'https://dev.assets.emblstatic.net/vf/assets/vf-favicon/assets/favicon.ico',
   styles: [
     '/css/local.css'
   ],

--- a/fractal.js
+++ b/fractal.js
@@ -31,7 +31,7 @@ fractal.web.set('server.syncOptions', {
 const mandelbrot = require('@frctl/mandelbrot');
 
 const VFTheme = mandelbrot({
-  favicon: 'https://dev.assets.emblstatic.net/vf/assets/vf-favicon/assets/favicon.ico',
+  // favicon: 'https://dev.assets.emblstatic.net/vf/assets/vf-favicon/assets/favicon.ico',
   styles: [
     '/css/local.css'
   ],

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/head.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/head.nunj
@@ -1,3 +1,6 @@
-<link rel="shortcut icon" href="{{ path(frctl.theme.get('favicon')) }}" type="image/ico">
+{% set rendered = frctl.components.find('@vf-favicon').render(null, renderEnv, { preview: withLayout, collate: withCollation }) | async(true) %}
+{{ rendered }}
+
+
 {% include 'partials/stylesheets.nunj' %}
 <title>{% if page.title %}{{ page.title }} | {% endif %}{{ frctl.get('project.title') }}</title>


### PR DESCRIPTION
Link was broken. Ideally this should look to the local path when `gulp dev`, but there's more work to do here around using the vf-favicon pattern inside frctl, so for now pointing to https://dev.assets.emblstatic.net/vf/assets/vf-favicon/assets/favicon.ico generally is much better.