### PR TITLE
updates pattern generator

### DIFF
--- a/tools/component-generator/index.js
+++ b/tools/component-generator/index.js
@@ -28,7 +28,7 @@ module.exports = class extends Generator {
       chalk.white("https://git.VF.de/grp-stratcom/visual-framework-tooling-prototype/blob/setup/initial-installs/README.md#creating-a-new-component")
     ));
 
-    var componentType = ['elements', 'blocks', 'containers', 'grids', 'boilerplates'];
+    var componentType = ['element', 'block', 'container', 'grid', 'boilerplate'];
     var DepartmentType = ['VF Global', 'EMBL', 'EMBL-EBI'];
 
     var prompts = [{
@@ -77,8 +77,8 @@ module.exports = class extends Generator {
       var namespace = "ebi-";
       break;
     }
-
-    var totalPath = path + this.props.type + "/" + namespace + this.props.componentName + "/";
+    var patternType = this.props.type;
+    var totalPath = path + namespace + this.props.componentName + "/";
     var fileName = namespace + this.props.componentName;
 
 
@@ -119,6 +119,7 @@ module.exports = class extends Generator {
       this.templatePath('_component.config.yml'),
       this.destinationPath(totalPath + outputFile),
       {
+        componentType: patternType,
         componentName: fileName
       }
     );

--- a/tools/component-generator/templates/_component.config.yml
+++ b/tools/component-generator/templates/_component.config.yml
@@ -1,2 +1,4 @@
 title: <%= componentName %>
 label: <%= componentName %>
+context:
+  pattern-type: <%= componentType %>

--- a/tools/component-generator/templates/_index.scss
+++ b/tools/component-generator/templates/_index.scss
@@ -1,10 +1,10 @@
 // setup files required
 
 // sass-lint:disable clean-import-paths
-@import '../assets/scss/variables/vf-global-variables.scss';
-@import '../assets/scss/variables/variables.scss';
-@import '../assets/scss/functions/functions.scss';
-@import '../assets/scss/mixins/mixins.scss';
+@import '../vf-utilities/variables/vf-global-variables.scss';
+@import '../vf-utilities/variables/variables.scss';
+@import '../vf-utilities/functions/functions.scss';
+@import '../vf-utilities/mixins/mixins.scss';
 
 // pattern specific styles
 

--- a/tools/component-generator/templates/_package.json
+++ b/tools/component-generator/templates/_package.json
@@ -6,17 +6,19 @@
   "author": "VF",
   "license": "Apache 2.0",
   "style": "<%= componentName %>.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "files": [
     "index.scss",
     "<%= componentName %>.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-  "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/elements/<%= componentName %>",
+  "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/<%= componentName %>",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
+    "@visual-framework/vf-sass-config": "^0.0.12"
   },
   "keywords": [
     "fractal",


### PR DESCRIPTION
This PR updates the pattern generator we use to create new patterns it

removes:
- the blocks/elements/containers folder structure when creating files
- the blocks/elements/containers mentioned anywhere in the files for GitHub or other resources

updates:
- the file paths for the Sass config files in `index.scss`

adds:
- add the `pattern-type` to the `package.json` and prefills it depending on how the user answers question 2 (pattern type)

