### PR TITLE
fix/vf-content-p-spacing

### DIFF
--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -58,7 +58,7 @@
 
   p {
     @include set-type(body--r);
-    margin: 13px 0 24px 0;
+    margin: 0 0 24px 0;
     + p {
       margin: 0;
     }


### PR DESCRIPTION
When dealing with pre-rendered content, it's often more disruptive to have margin on the first p tag.