### PR TITLE
updates grid system to new layout

### DIFF
--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -9,6 +9,7 @@
  */
 $use-global-typography: true !default;
 
+@import 'vf-global-custom-properties.scss';
 @import 'vf-global-variables.scss';
 @import 'vf-variables.scss';
 @import 'vf-functions.scss';
@@ -86,6 +87,8 @@ html, button {
 @import 'vf-activity-group/vf-activity-group.scss';
 @import 'vf-intro/vf-intro.scss';
 @import 'vf-banner/vf-banner.scss';
+@import 'vf-news-container/vf-news-container.scss';
+@import 'vf-video-container/vf-video-container.scss';
 @import 'vf-footer/vf-footer.scss';
 
 /* All Visual Framework Utility Classes */

--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -1,115 +1,27 @@
 .embl-grid {
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
-}
-.embl-grid > * {
-  flex-basis: 100%;
-}
-@supports (display: grid) {
-  .embl-grid {
-    display: grid;
-    grid-column: main-start / main-end;
-    grid-column-gap: 16px;
-  }
-  .embl-grid--full {
-    grid-column: 1 / -1;
-    grid-template-columns: 0 1fr 0;
-    > * {
-      grid-column: 2 / -2;
-    }
-    @media (min-width: 1024px) {
-      grid-template-columns: auto 250px 738px auto;
-      > * {
-        grid-column: 3 / 4;
-      }
-      > :first-child {
-        grid-column: 2;
-      }
-    }
-    @media (min-width: 1280px) {
-      grid-template-columns: auto 250px 640px 350px auto;
-      > * {
-        grid-column-end: 5;
-      }
-    }
-  }
-  .embl-grid > * {
-    align-self: flex-start;
+  display: grid;
+  grid-column: main;
+  grid-column-gap: var(--page-grid-gap);
+  grid-template-columns:
+    calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser))
+    repeat(auto-fit, minmax(288px, 1fr))
+  ;
+  & > :first-child {
+    margin-right: var(--embl-grid-spacing-normaliser);
   }
 }
 
-@media (min-width: 63.9375em) {
-  @supports (display: grid) {
-    .embl-grid--labeled-with-sidebar {
-      grid-template-columns: 8.5fr minmax(350px, 3.5fr);
-    }
-    .embl-grid--labeled-with-sidebar > *:nth-child(2) {
-      margin-right: 0;
-    }
-  }
-}
-@media (max-width: 81.1875em) {
-  @supports (display: grid) {
-    .embl-grid--labeled-with-sidebar > *:first-child {
-      grid-column: 1 / -1;
-    }
-    .embl-grid--labeled-with-sidebar > :nth-child(2) {
-      grid-column: 1;
-    }
-  }
-}
+.embl-grid--has-centered-content {
+  --embl-grid-spacing-normaliser: 0; // removes margin from first child
+  --page-grid-gap: 36px; //
 
-@media (min-width: 81.25em) {
-  @supports (display: grid) {
-    .embl-grid--labeled-with-sidebar {
-      grid-template-columns: minmax(250px, 2.5fr) 7fr minmax(350px, 3.5fr);
-    }
-    .embl-grid--labeled-with-sidebar > *:nth-child(1) {
-      grid-column: 1;
-    }
-  }
-}
+  grid-template-columns:
+    var(--embl-grid-module--prime)
+    auto
+    var(--embl-grid-module--prime)
+  ;
 
-@media (min-width: 63.9375em) {
-  .embl-grid--with-sidebar > *:nth-child(1) {
-    flex: 8.5;
-    margin-right: 20px;
-  }
-  .embl-grid--with-sidebar > *:nth-child(2) {
-    flex: 3.5;
-  }
-  @supports (display: grid) {
-    .embl-grid--with-sidebar {
-      grid-template-columns: 8.5fr 350px;
-    }
-    .embl-grid--with-sidebar > *:nth-child(1) {
-      margin-right: 0;
-    }
-  }
-}
-
-@media (max-width: 81.1875em) {
-  .embl-grid--with-label > *:first-child {
-    grid-column: 1 / -1;
-  }
-}
-@media (min-width: 81.25em) {
-  .embl-grid--with-label > *:first-child {
-    grid-column: 1;
-    flex: 2.5;
-    margin-right: 20px;
-  }
-  .embl-grid--with-label > *:nth-child(2) {
-    flex: 9.5;
-  }
-  @supports (display: grid) {
-    .embl-grid--with-label {
-      grid-template-columns: 250px 9.5fr;
-    }
-
-    .embl-grid--with-label > *:nth-child(1) {
-      margin-right: 0;
-    }
+  & > * {
+    grid-column: 2 / span 1;
   }
 }

--- a/components/vf-activity-group/vf-activity-group.hbs
+++ b/components/vf-activity-group/vf-activity-group.hbs
@@ -1,4 +1,4 @@
-<section class="vf-activity-group | embl-grid embl-grid--full">
+<section class="vf-activity-group | embl-grid">
   <h3 class="vf-activity-group__heading | vf-text--heading">Recent activity</h3>
   {{render '@vf-activity-list'}}
   {{render '@vf-activity-list'}}

--- a/components/vf-activity-group/vf-activity-group.scss
+++ b/components/vf-activity-group/vf-activity-group.scss
@@ -8,3 +8,7 @@
   @include set-type(heading--r);
   @include margin--block(bottom, 16px);
 }
+
+.vf-activity {
+  grid-column: 2 / auto;
+}

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -19,7 +19,7 @@ $vf-banner-color--link: inherit;
 .vf-banner--fixed {
   display: grid;
   grid-column: 1 / -1;
-  grid-template-columns: [full-start] minmax(1em, auto) [main-start] minmax(18em, 81.25em) [main-end] minmax(1em, auto) [full-end];
+  grid-template-columns: minmax(var(--page-grid-gap), auto) [main-start] minmax(288px, 76.5em) [main-end] minmax(var(--page-grid-gap), auto);
   left: 0;
   padding: 0;
   position: fixed;

--- a/components/vf-grid-page/vf-grid-page.scss
+++ b/components/vf-grid-page/vf-grid-page.scss
@@ -20,7 +20,7 @@ html {
 
 .vf-body {
   margin: 0 auto;
-  max-width: 81.25em;
+  max-width: 76.5em;
 }
 
 // If the browser does support grid it will get this
@@ -32,7 +32,7 @@ html {
 
   .vf-body {
     display: grid;
-    grid-template-columns: [full-start] minmax(1em, auto) [main-start] minmax(300px, 81.25em) [main-end] minmax(1em, auto) [full-end];
+    grid-template-columns: minmax(var(--page-grid-gap), auto) [main-start] minmax(288px, 76.5em) [main-end] minmax(var(--page-grid-gap), auto);
     margin: unset;
     max-width: unset;
   }

--- a/components/vf-header/vf-header.scss
+++ b/components/vf-header/vf-header.scss
@@ -6,7 +6,6 @@
   box-sizing: border-box;
   display: grid;
   grid-column: 1 / -1;
-  // grid-auto-rows: min-content;
-  grid-template-columns: minmax(1em, 1fr) 58.1875em 21.8125em minmax(1em, 1fr);
+  grid-template-columns: minmax(var(--page-grid-gap), auto) minmax(auto, 76.5em) minmax(var(--page-grid-gap), auto);
   height: 266px;
 }

--- a/components/vf-intro/vf-intro.hbs
+++ b/components/vf-intro/vf-intro.hbs
@@ -1,4 +1,4 @@
-<div class="vf-intro">
+<div class="vf-intro | embl-grid embl-grid--has-centered-content">
   <h1 class="vf-intro__heading | vf-text--display vf-text--display-xl">Cancer</h1>
   <p class="vf-lede | vf-text--display vf-text--display-l">Cancer is a generic term for lots of different diseases in which cells divide many more times than usual. This abnormal growth can affect many cell types in almost any part of the body.</p>
   <p class="vf-intro__text | vf-text--body vf-text--body-r">Cancer is a multi-stage process. Normal cells begin to divide abnormally, spreading beyond their normal boundaries, and abnormal tissue growth causes swellings called tumours to form. Tumours can be benign – with no harmful effect on the body – or malignant, invading healthy tissue and interfering with normal bodily functions.</p>

--- a/components/vf-masthead/vf-masthead--with-title-block.hbs
+++ b/components/vf-masthead/vf-masthead--with-title-block.hbs
@@ -1,4 +1,4 @@
-<div class="vf-masthead vf-masthead--with-title-block | embl-grid embl-grid--with-sidebar" style="background-image: url('{{ path '/assets/vf-masthead/assets/group-bg.png' }}')">
+<div class="vf-masthead vf-masthead--with-title-block | embl-grid" style="background-image: url('{{ path '/assets/vf-masthead/assets/group-bg.png' }}')">
   <div class="vf-masthead__title">
     <div class="vf-masthead__title-inner">
       <h1 class="vf-masthead__heading">

--- a/components/vf-masthead/vf-masthead.config.yml
+++ b/components/vf-masthead/vf-masthead.config.yml
@@ -2,4 +2,4 @@ title: Masthead
 label: Masthead
 preview: '@preview--nogrid'
 context:
-  pattern-type: container
+  pattern-type: block

--- a/components/vf-masthead/vf-masthead.hbs
+++ b/components/vf-masthead/vf-masthead.hbs
@@ -1,20 +1,22 @@
-<div class="vf-masthead | embl-grid embl-grid--with-sidebar" style="background-image: url('{{ path '/assets/vf-masthead/assets/group-bg.png' }}')">
-  <div class="vf-masthead__title">
-    <div class="vf-masthead__title-inner">
-      <h1 class="vf-masthead__heading">Strategy &amp; Communications</h1>
-      <h2 class="vf-masthead__subheading">
-        <span class="vf-masthead__location">VF Hamburg</span>
-        <span class="vf-masthead__group">Structural Biology</span>
-      </h2>
+<div class="vf-masthead" style="background-image: url('{{ path '/assets/vf-masthead/assets/group-bg.png' }}')">
+  <div class="vf-masthead__inner">
+    <div class="vf-masthead__title">
+      <div class="vf-masthead__title-inner">
+        <h1 class="vf-masthead__heading">Strategy &amp; Communications</h1>
+        <h2 class="vf-masthead__subheading">
+          <span class="vf-masthead__location">VF Hamburg</span>
+          <span class="vf-masthead__group">Structural Biology</span>
+        </h2>
+      </div>
     </div>
-  </div>
 
-  <form action="" class="vf-masthead__form--search">
-    <div class="vf-masthead__form__item">
-      <label for="" class="vf-masthead__form__label">Search This Project</label>
-      <input type="text" class="vf-masthead__form__input--text" placeholder="Enter gene query…">
-      <button class="vf-masthead__button vf-u-text-replacement"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 451 451"><path d="M447.05 428l-109.6-109.6c29.4-33.8 47.2-77.9 47.2-126.1C384.65 86.2 298.35 0 192.35 0 86.25 0 .05 86.3.05 192.3s86.3 192.3 192.3 192.3c48.2 0 92.3-17.8 126.1-47.2L428.05 447c2.6 2.6 6.1 4 9.5 4s6.9-1.3 9.5-4c5.2-5.2 5.2-13.8 0-19zM26.95 192.3c0-91.2 74.2-165.3 165.3-165.3 91.2 0 165.3 74.2 165.3 165.3s-74.1 165.4-165.3 165.4c-91.1 0-165.3-74.2-165.3-165.4z"/></svg></button>
-    </div>
-    <span class="search-examples">Examples: <a href="">ASPM</a>, <a href="">Apoptosis</a>, <a href="">ENSMUSG00000021789</a></span>
-  </form>
+    <form action="" class="vf-masthead__form--search">
+      <div class="vf-masthead__form__item">
+        <label for="" class="vf-masthead__form__label">Search This Project</label>
+        <input type="text" class="vf-masthead__form__input--text" placeholder="Enter gene query…">
+        <button class="vf-masthead__button vf-u-text-replacement"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 451 451"><path d="M447.05 428l-109.6-109.6c29.4-33.8 47.2-77.9 47.2-126.1C384.65 86.2 298.35 0 192.35 0 86.25 0 .05 86.3.05 192.3s86.3 192.3 192.3 192.3c48.2 0 92.3-17.8 126.1-47.2L428.05 447c2.6 2.6 6.1 4 9.5 4s6.9-1.3 9.5-4c5.2-5.2 5.2-13.8 0-19zM26.95 192.3c0-91.2 74.2-165.3 165.3-165.3 91.2 0 165.3 74.2 165.3 165.3s-74.1 165.4-165.3 165.4c-91.1 0-165.3-74.2-165.3-165.4z"/></svg></button>
+      </div>
+      <span class="search-examples">Examples: <a href="">ASPM</a>, <a href="">Apoptosis</a>, <a href="">ENSMUSG00000021789</a></span>
+    </form>
+  </div>
 </div>

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -5,7 +5,16 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
 .vf-masthead {
   display: grid;
   grid-column: 1 / -1;
-  grid-template-columns: minmax(16px, 1fr) 59.375em 21.875em minmax(16px, 1fr);
+  grid-template-columns:
+    minmax(var(--page-grid-gap), auto)
+    minmax(auto, 76.5em)
+    minmax(var(--page-grid-gap), auto);
+}
+.vf-masthead__inner {
+  display: grid;
+  grid-column: 2 / -2;
+  grid-template-columns: calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser))
+  repeat(auto-fit, minmax(288px, 1fr));
   grid-template-rows: 48px 1fr;
 }
 
@@ -18,24 +27,10 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
     grid-row: 2 / 2;
   }
 
-  // &::after {
-  //   content: '';
-  //   position: relative;
-  //   grid-row: 2;
-  //   grid-column: 1;
-  //   left: 16px;
-  //   z-index: 5150;
-  //   width: 0;
-  //   height: 0;
-  //   border-style: solid;
-  //   border-width: 32px 50px 0 50px;
-  //   border-color: transparent black black black;
-  //   background-image: url('/assets/vf-masthead/assets/group-bg.png');
-  // }
-
   .vf-masthead__title {
     align-self: unset;
     display: inline-flex;
+    grid-column: 2 / span 2;
     padding-right: 16px;
 
     .vf-masthead__title-inner {
@@ -43,7 +38,7 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
       display: inline-flex;
       flex-direction: column-reverse;
       grid-auto-columns: max-content;
-      grid-column: 2 / -2;
+      grid-column: 3 / -2;
       padding-left: 16px;
     }
   }
@@ -51,7 +46,7 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
 
 .vf-masthead__title {
   color: $vf-masthead__title-text--color;
-  grid-column: 2 / -3;
+  grid-column: 2 / span 3;
   grid-row: 2;
   position: relative;
 
@@ -96,7 +91,6 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
 
 .vf-masthead__form--search {
   align-self: flex-end;
-  grid-column: 3 / -2;
   grid-row: 2;
   justify-content: flex-end;
   margin-bottom: 12px;

--- a/components/vf-navigation/vf-navigation.scss
+++ b/components/vf-navigation/vf-navigation.scss
@@ -20,7 +20,8 @@
   background-color: set-color(vf-color-black);
   display: grid;
   grid-column: 1 / -1;
-  grid-template-columns: minmax(1em, 1fr) minmax(auto, 80em) minmax(1em, 1fr);
+  grid-column-gap: var(--page-grid-gap);
+  grid-template-columns: minmax(var(--page-grid-gap), auto) minmax(auto, 76.5em) minmax(var(--page-grid-gap), auto);
   height: 60px;
 
   & > .vf-navigation {
@@ -69,7 +70,7 @@
 
     display: block;
     text-decoration: none;
-    
+
     &:visited {
       color: set-color(vf-color-white);
     }
@@ -83,8 +84,9 @@
   border-width: 1px 0 1px 0;
   display: grid;
   grid-column: 1 / -1;
+  grid-column-gap: var(--page-grid-gap);
   grid-row: 2;
-  grid-template-columns: minmax(1em, 1fr) minmax(auto, 80em) minmax(1em, 1fr);
+  grid-template-columns: minmax(var(--page-grid-gap), auto) minmax(auto, 76.5em) minmax(var(--page-grid-gap), auto);
   padding: 4px 0;
   text-transform: uppercase;
 }

--- a/components/vf-news-container/vf-news-container.hbs
+++ b/components/vf-news-container/vf-news-container.hbs
@@ -1,4 +1,4 @@
-<section class="vf-news-container | embl-grid embl-grid--labeled-with-sidebar">
+<section class="vf-news-container | embl-grid">
 
   {{> '@vf-section-header'}}
 

--- a/components/vf-news-container/vf-news-container.scss
+++ b/components/vf-news-container/vf-news-container.scss
@@ -1,1 +1,5 @@
 // vf-news-container
+
+.vf-news-container__content {
+  grid-column: span 2;
+}

--- a/components/vf-sass-config/variables/vf-global-custom-properties.scss
+++ b/components/vf-sass-config/variables/vf-global-custom-properties.scss
@@ -1,0 +1,8 @@
+:root {
+  --page-grid-gap: 16px;
+  --embl-grid-module--prime: 200px;
+  --embl-grid-spacing-normaliser: 6px;
+  @media (min-width: 1200px) {
+    --page-grid-gap: 30px;
+  }
+}

--- a/components/vf-summary-container/vf-summary-container.hbs
+++ b/components/vf-summary-container/vf-summary-container.hbs
@@ -1,4 +1,4 @@
-<section class="vf-summary-container | embl-grid embl-grid--with-label">
+<section class="vf-summary-container | embl-grid">
 
   {{> '@vf-section-header'}}
 

--- a/components/vf-video-container/vf-video-container.hbs
+++ b/components/vf-video-container/vf-video-container.hbs
@@ -1,5 +1,7 @@
 <section class="vf-video-container | embl-grid embl-grid--labeled-with-sidebar">
   {{> '@vf-section-header'}}
-  {{ render '@vf-video' }}
+  <div class="vf-video-container__content">
+    {{ render '@vf-video' }}
+  </div>
   {{ render '@vf-video-teaser'}}
 </section>

--- a/components/vf-video-container/vf-video-container.scss
+++ b/components/vf-video-container/vf-video-container.scss
@@ -1,1 +1,5 @@
 // vf-video-container
+
+.vf-video-container__content {
+  grid-column: span 2;
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -321,7 +321,7 @@ gulp.task('CSSGen', function(done) {
 gulp.task('watch', function(done) {
   fractal.watch();
   gulp.watch('./**/*.scss', gulp.series(['css', 'scss-lint'])).on('change', reload);
-  gulp.watch('./assets/images', gulp.series('watch-images')).on('change', reload);
+
   gulp.watch(['./assets/scripts/**/*.js','./components/**/*.js'], gulp.series('scripts')).on('change', reload);
   gulp.watch('./components/**/**/assets/*', gulp.series('pattern-assets')).on('change', reload);
 });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4212,7 +4212,7 @@
       "dependencies": {
         "finalhandler": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "requires": {
             "debug": "2.6.9",
@@ -10699,7 +10699,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -13550,7 +13550,6 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -13568,7 +13567,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -13764,7 +13762,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -13776,7 +13773,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -13836,8 +13832,7 @@
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "optional": true
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-glob": {
           "version": "4.0.0",
@@ -13852,7 +13847,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -13861,7 +13855,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -13871,14 +13864,12 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "optional": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "optional": true
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "micromatch": {
           "version": "3.1.10",
@@ -18799,7 +18790,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "ansi-regex": {
@@ -22227,7 +22218,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "ansi-regex": {
@@ -22301,7 +22292,7 @@
         },
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "requires": {
             "array-union": "^1.0.1",

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
@@ -5,7 +5,7 @@
 
   </div>
 
-  <div class="vf-masthead vf-masthead--with-title-block | embl-grid embl-grid--with-sidebar" style="background-image: url('{{ path('/assets/vf-masthead/assets/group-bg.png') }}')">
+  <div class="vf-masthead vf-masthead--with-title-block | embl-grid" style="background-image: url('{{ path('/assets/vf-masthead/assets/group-bg.png') }}')">
     <div class="vf-masthead__title">
       <div class="vf-masthead__title-inner">
         <h1 class="vf-masthead__heading">


### PR DESCRIPTION
This PR:

- updates the grid system to be a little more permissive.
- makes the initial column have a larger grid-gap (using margin-right)
- removes `embl-grid--with-label` etc.
- creates `embl-grid--has-centered-content` for things like page intro and long form content
- normalising the page grid with similar spacing
- makes use of CSS custom properties where needed for more consistent global size decisions
- creates a `vf-global-custom-properties.scss` file for things like the item above.
- updates patterns to make use of this system.
- removes Flexbox fallback from embl-grid (for now)
- leaves vf-grid 'as is'.

