### PR TITLE
fix/vf-masthead-no-embl-grid

### DIFF
--- a/components/vf-masthead/vf-masthead--with-title-block.hbs
+++ b/components/vf-masthead/vf-masthead--with-title-block.hbs
@@ -1,4 +1,4 @@
-<div class="vf-masthead vf-masthead--with-title-block | embl-grid" style="background-image: url('{{ path '/assets/vf-masthead/assets/group-bg.png' }}')">
+<div class="vf-masthead vf-masthead--with-title-block" style="background-image: url('{{ path '/assets/vf-masthead/assets/group-bg.png' }}')">
   <div class="vf-masthead__title">
     <div class="vf-masthead__title-inner">
       <h1 class="vf-masthead__heading">

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -26,7 +26,7 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
   .vf-masthead__title {
     align-self: unset;
     display: inline-flex;
-    grid-column: 2 / span 2;
+    grid-column: 2 / span 1;
     padding-right: 16px;
 
     .vf-masthead__title-inner {

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
@@ -5,7 +5,7 @@
 
   </div>
 
-  <div class="vf-masthead vf-masthead--with-title-block | embl-grid" style="background-image: url('{{ path('/assets/vf-masthead/assets/group-bg.png') }}')">
+  <div class="vf-masthead vf-masthead--with-title-block" style="background-image: url('{{ path('/assets/vf-masthead/assets/group-bg.png') }}')">
     <div class="vf-masthead__title">
       <div class="vf-masthead__title-inner">
         <h1 class="vf-masthead__heading">


### PR DESCRIPTION
No need for embl-grid on the vf-masthead pattern (as it has its own grid), and embl-grid causes an unneeded margin inside the header:

![image](https://user-images.githubusercontent.com/928100/49574652-360fdd80-f941-11e8-813f-73d752c39a4b.png)
