### PR TITLE
updates factoid

### DIFF
--- a/components/vf-factoid/vf-factoid.scss
+++ b/components/vf-factoid/vf-factoid.scss
@@ -2,15 +2,17 @@
 
 $vf-factoid-color--background: set-color(vf-color-azure-dark) !default;
 $vf-factoid-color--foreground: set-color(vf-color-white) !default;
-$vf-factoid-spacing: map-get($vf-spacing-map, vf-spacing-r) !default;
+$vf-factoid-inner-spacing: map-get($vf-spacing-map, vf-spacing-r) !default;
+$vf-factoid-outer-spacing: map-get($vf-spacing-map, vf-spacing-xl) !default;
 $vf-factoid-box-sizing: border-box !default;
 
 .vf-factoid {
-  @include padding(all, $vf-factoid-spacing);
+  @include padding(all, $vf-factoid-inner-spacing);
 
   background-color: $vf-factoid-color--background;
   box-sizing: $vf-factoid-box-sizing;
   color: $vf-factoid-color--foreground;
+  margin-bottom: $vf-factoid-outer-spacing;
 
   // we don't want the the last element within the component to have a bottom margin.
   & :last-child {


### PR DESCRIPTION
adds a 24px margin-bottom to the factoid. 

With this and the embl-grid container and vf-divider spacing added yesterday we're

a) pushing down
b) needing to standardise the spacing
  - element
  - block
  - container

c) last-child - does it have a margin or not, or does it rely on it's parents padding / bottom margin?