### PR TITLE
Remove left padding on bullet-less list

### DIFF
--- a/components/vf-sass-config/mixins/_lists.scss
+++ b/components/vf-sass-config/mixins/_lists.scss
@@ -3,7 +3,7 @@
 @mixin list($classname, $type: null) {
   @if $type == null {
     list-style-type: none;
-    padding: 0 0 0 16px;
+    padding: 0;
   }
   margin: 0;
 


### PR DESCRIPTION
No need for left padding when there is no bullet/ordinal.

Currently: 
http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/components/detail/vf-list.html

After: 
![image](https://user-images.githubusercontent.com/928100/49646999-4eefc000-fa21-11e8-90fb-98fb5821daf6.png)
