### PR TITLE
Lerna fixes and package.json updates

### DIFF
--- a/components/embl-boilerplate-page/package.json
+++ b/components/embl-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "name": "@visual-framework/embl-boilerplate-page",
   "description": "embl-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/embl-boilerplate-page/package.json
+++ b/components/embl-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "embl-boilerplate-page",
   "description": "embl-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -8,9 +8,9 @@
   "main": "build/index.js",
   "files": [],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/boilerplates/embl-boilerplate-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/embl-boilerplate-page/package.json
+++ b/components/embl-boilerplate-page/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.3",
-  "name": "embl-boilerplate-page",
+  "name": "@visual-framework/embl-boilerplate-page",
   "description": "embl-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",

--- a/components/embl-boilerplate-page/package.json
+++ b/components/embl-boilerplate-page/package.json
@@ -1,22 +1,23 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "embl-boilerplate-page",
   "description": "embl-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "main": "build/index.js",
-  "files": [
-  ],
+  "files": [],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/boilerplates/embl-boilerplate-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
-  "dependencies": {
-  },
   "keywords": [
     "fractal",
     "component"
-  ]
+  ],
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/embl-content-meta-properties/package.json
+++ b/components/embl-content-meta-properties/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.3",
-  "name": "embl-content-meta-properties",
+  "name": "@visual-framework/embl-content-meta-properties",
   "description": "embl-content-meta-properties component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",

--- a/components/embl-content-meta-properties/package.json
+++ b/components/embl-content-meta-properties/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "name": "@visual-framework/embl-content-meta-properties",
   "description": "embl-content-meta-properties component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,5 +23,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/embl-content-meta-properties/package.json
+++ b/components/embl-content-meta-properties/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "embl-content-meta-properties",
   "description": "embl-content-meta-properties component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -12,9 +12,9 @@
     "embl-content-meta-properties.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/embl-content-meta-properties",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
@@ -23,5 +23,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/embl-content-meta-properties/package.json
+++ b/components/embl-content-meta-properties/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "embl-content-meta-properties",
   "description": "embl-content-meta-properties component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -12,14 +12,16 @@
     "embl-content-meta-properties.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/embl-content-meta-properties",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
-  "dependencies": {
-  },
   "keywords": [
     "fractal",
     "component"
-  ]
+  ],
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/embl-grid/package.json
+++ b/components/embl-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/embl-grid",
   "description": "embl-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -21,12 +21,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/embl-grid/package.json
+++ b/components/embl-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/embl-grid",
   "description": "embl-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,20 +13,20 @@
     "embl-grid.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/grids/embl-grid",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/embl-grid/package.json
+++ b/components/embl-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/embl-grid",
   "description": "embl-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,17 +13,20 @@
     "embl-grid.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/grids/embl-grid",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/embl-group-page/package.json
+++ b/components/embl-group-page/package.json
@@ -1,22 +1,23 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "embl-group-page",
   "description": "embl-group-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "main": "build/index.js",
-  "files": [
-  ],
+  "files": [],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/boilerplates/embl-group-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
-  "dependencies": {
-  },
   "keywords": [
     "fractal",
     "component"
-  ]
+  ],
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/embl-group-page/package.json
+++ b/components/embl-group-page/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.3",
-  "name": "embl-group-page",
+  "name": "@visual-framework/embl-group-page",
   "description": "embl-group-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",

--- a/components/embl-group-page/package.json
+++ b/components/embl-group-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "embl-group-page",
   "description": "embl-group-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -8,9 +8,9 @@
   "main": "build/index.js",
   "files": [],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/boilerplates/embl-group-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/embl-group-page/package.json
+++ b/components/embl-group-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "name": "@visual-framework/embl-group-page",
   "description": "embl-group-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/embl-subsite-page/package.json
+++ b/components/embl-subsite-page/package.json
@@ -1,22 +1,23 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "embl-subsite-page",
   "description": "embl-subsite-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "main": "build/index.js",
-  "files": [
-  ],
+  "files": [],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/boilerplates/embl-subsite-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
-  "dependencies": {
-  },
   "keywords": [
     "fractal",
     "component"
-  ]
+  ],
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/embl-subsite-page/package.json
+++ b/components/embl-subsite-page/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.3",
-  "name": "embl-subsite-page",
+  "name": "@visual-framework/embl-subsite-page",
   "description": "embl-subsite-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",

--- a/components/embl-subsite-page/package.json
+++ b/components/embl-subsite-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "name": "@visual-framework/embl-subsite-page",
   "description": "embl-subsite-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/embl-subsite-page/package.json
+++ b/components/embl-subsite-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "embl-subsite-page",
   "description": "embl-subsite-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -8,9 +8,9 @@
   "main": "build/index.js",
   "files": [],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/boilerplates/embl-subsite-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-activity-group/package.json
+++ b/components/vf-activity-group/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-activity-group",
   "description": "vf-activity-group component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,23 @@
     "vf-activity-group.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-activity-group",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-activity-list": "^0.0.16",
-    "@visual-framework/vf-grid": "^0.0.15",
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-activity-list": "^0.0.17",
+    "@visual-framework/vf-grid": "^0.0.16",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-activity-group/package.json
+++ b/components/vf-activity-group/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-activity-group.scss",
     "vf-activity-group.css",
-    "vf-activity-group.hbs"
+    "vf-activity-group.hbs",
+    "vf-activity-group.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-activity-group/package.json
+++ b/components/vf-activity-group/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-activity-group",
   "description": "vf-activity-group component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,23 +14,23 @@
     "vf-activity-group.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-activity-group",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-activity-list": "^0.0.17",
-    "@visual-framework/vf-grid": "^0.0.16",
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-activity-list": "^0.0.18",
+    "@visual-framework/vf-grid": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-activity-group/package.json
+++ b/components/vf-activity-group/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-activity-group",
   "description": "vf-activity-group component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,15 +23,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-activity-list": "^0.0.18",
-    "@visual-framework/vf-grid": "^0.0.17",
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-activity-list": "^0.0.19",
+    "@visual-framework/vf-grid": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-activity-list/package.json
+++ b/components/vf-activity-list/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-activity-list.scss",
     "vf-activity-list.css",
-    "vf-activity-list.hbs"
+    "vf-activity-list.hbs",
+    "vf-activity-list.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-activity-list/package.json
+++ b/components/vf-activity-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-activity-list",
   "description": "vf-activity-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,19 +14,22 @@
     "vf-activity-list.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-activity-list",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.15",
-    "@visual-framework/vf-list": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-blockquote": "^0.0.16",
+    "@visual-framework/vf-list": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-activity-list/package.json
+++ b/components/vf-activity-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-activity-list",
   "description": "vf-activity-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.17",
-    "@visual-framework/vf-list": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-blockquote": "^0.0.18",
+    "@visual-framework/vf-list": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-activity-list/package.json
+++ b/components/vf-activity-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-activity-list",
   "description": "vf-activity-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,22 +14,22 @@
     "vf-activity-list.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-activity-list",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.16",
-    "@visual-framework/vf-list": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-blockquote": "^0.0.17",
+    "@visual-framework/vf-list": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-article-meta-information/package.json
+++ b/components/vf-article-meta-information/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "vf-article-meta-information",
   "description": "vf-article-meta-information component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,15 +13,19 @@
     "vf-article-meta-information.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/vf-article-meta-information",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12"
+    "@visual-framework/vf-sass-config": "^0.0.13"
   },
   "keywords": [
     "fractal",
     "component"
-  ]
+  ],
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-article-meta-information/package.json
+++ b/components/vf-article-meta-information/package.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.0.3",
-  "name": "vf-article-meta-information",
+  "version": "0.0.4",
+  "name": "@visual-framework/vf-article-meta-information",
   "description": "vf-article-meta-information component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
@@ -22,11 +22,11 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14"
+    "@visual-framework/vf-sass-config": "^0.0.15"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-article-meta-information/package.json
+++ b/components/vf-article-meta-information/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "vf-article-meta-information",
   "description": "vf-article-meta-information component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,19 +13,19 @@
     "vf-article-meta-information.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/vf-article-meta-information",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13"
+    "@visual-framework/vf-sass-config": "^0.0.14"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-article-meta-information/package.json
+++ b/components/vf-article-meta-information/package.json
@@ -10,7 +10,8 @@
   "main": "build/index.js",
   "files": [
     "index.scss",
-    "vf-article-meta-information.css"
+    "vf-article-meta-information.css",
+    "vf-article-meta-information..config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-banner/package.json
+++ b/components/vf-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "vf-banner",
   "description": "vf-banner component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,16 +13,20 @@
     "vf-banner.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/vf-banner",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "@visual-framework/vf-tag": "^0.0.12"
   },
   "keywords": [
     "fractal",
     "component"
-  ]
+  ],
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-banner/package.json
+++ b/components/vf-banner/package.json
@@ -10,7 +10,10 @@
   "main": "build/index.js",
   "files": [
     "index.scss",
-    "vf-banner.css"
+    "vf-banner.css",
+    "vf-banner.scss",
+    "vf-banner.hbs",
+    "vf-banner.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-banner/package.json
+++ b/components/vf-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "vf-banner",
   "description": "vf-banner component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,20 +13,20 @@
     "vf-banner.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/vf-banner",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "@visual-framework/vf-tag": "^0.0.12"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-banner/package.json
+++ b/components/vf-banner/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.3",
-  "name": "vf-banner",
+  "name": "@visual-framework/vf-banner",
   "description": "vf-banner component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",

--- a/components/vf-banner/package.json
+++ b/components/vf-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "name": "@visual-framework/vf-banner",
   "description": "vf-banner component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,12 +24,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "@visual-framework/vf-tag": "^0.0.12"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-blockquote/package.json
+++ b/components/vf-blockquote/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-blockquote.scss",
     "vf-blockquote.css",
-    "vf-blockquote.hbs"
+    "vf-blockquote.hbs",
+    "vf-blockquote.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-blockquote/package.json
+++ b/components/vf-blockquote/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-blockquote",
   "description": "vf-blockquote component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,17 +14,20 @@
     "vf-blockquote.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-blockquote",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-blockquote/package.json
+++ b/components/vf-blockquote/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-blockquote",
   "description": "vf-blockquote component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-blockquote/package.json
+++ b/components/vf-blockquote/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-blockquote",
   "description": "vf-blockquote component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,20 @@
     "vf-blockquote.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-blockquote",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-boilerplate-page/package.json
+++ b/components/vf-boilerplate-page/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.3",
-  "name": "vf-boilerplate-page",
+  "name": "@visual-framework/vf-boilerplate-page",
   "description": "vf-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",

--- a/components/vf-boilerplate-page/package.json
+++ b/components/vf-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "vf-boilerplate-page",
   "description": "vf-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -8,9 +8,9 @@
   "main": "build/index.js",
   "files": [],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/boilerplates/vf-boilerplate-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-boilerplate-page/package.json
+++ b/components/vf-boilerplate-page/package.json
@@ -1,22 +1,23 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "vf-boilerplate-page",
   "description": "vf-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "main": "build/index.js",
-  "files": [
-  ],
+  "files": [],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/boilerplates/vf-boilerplate-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
-  "dependencies": {
-  },
   "keywords": [
     "fractal",
     "component"
-  ]
+  ],
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-boilerplate-page/package.json
+++ b/components/vf-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "name": "@visual-framework/vf-boilerplate-page",
   "description": "vf-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-box/package.json
+++ b/components/vf-box/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-box",
   "description": "vf-box component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,17 +14,20 @@
     "vf-box.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-box",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-box/package.json
+++ b/components/vf-box/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-box.scss",
     "vf-box.css",
-    "vf-box.hbs"
+    "vf-box.hbs",
+    "vf-box.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-box/package.json
+++ b/components/vf-box/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-box",
   "description": "vf-box component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,20 @@
     "vf-box.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-box",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-box/package.json
+++ b/components/vf-box/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-box",
   "description": "vf-box component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-breadcrumbs/package.json
+++ b/components/vf-breadcrumbs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-breadcrumbs",
   "description": "vf-breadcrumbs component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,18 +14,21 @@
     "vf-breadcrumbs.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-breadcrumbs",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-list": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-breadcrumbs/package.json
+++ b/components/vf-breadcrumbs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-breadcrumbs",
   "description": "vf-breadcrumbs component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,13 +23,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-list": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-breadcrumbs/package.json
+++ b/components/vf-breadcrumbs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-breadcrumbs",
   "description": "vf-breadcrumbs component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,21 +14,21 @@
     "vf-breadcrumbs.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-breadcrumbs",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-list": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-breadcrumbs/package.json
+++ b/components/vf-breadcrumbs/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-breadcrumbs.scss",
     "vf-breadcrumbs.css",
-    "vf-breadcrumbs.hbs"
+    "vf-breadcrumbs.hbs",
+    "vf-breadcrumbs.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-button/package.json
+++ b/components/vf-button/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-button",
   "description": "vf-button component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -27,12 +27,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-button/package.json
+++ b/components/vf-button/package.json
@@ -15,7 +15,8 @@
     "vf-button--styles.hbs",
     "vf-button--sizes.hbs",
     "vf-button--outline.hbs",
-    "vf-button--variant.hbs"
+    "vf-button--variant.hbs",
+    "vf-button.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-button/package.json
+++ b/components/vf-button/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-button",
   "description": "vf-button component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -18,17 +18,20 @@
     "vf-button--variant.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-button",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-button/package.json
+++ b/components/vf-button/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-button",
   "description": "vf-button component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -18,20 +18,20 @@
     "vf-button--variant.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-button",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-code-example/package.json
+++ b/components/vf-code-example/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-code-example",
   "description": "vf-code-example component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-code-example/package.json
+++ b/components/vf-code-example/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-code-example",
   "description": "vf-code-example component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,17 +14,20 @@
     "vf-code-example.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-code-example",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-code-example/package.json
+++ b/components/vf-code-example/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-code-example.scss",
     "vf-code-example.css",
-    "vf-code-example.hbs"
+    "vf-code-example.hbs",
+    "vf-code-example.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-code-example/package.json
+++ b/components/vf-code-example/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-code-example",
   "description": "vf-code-example component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,20 @@
     "vf-code-example.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-code-example",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-contact/package.json
+++ b/components/vf-contact/package.json
@@ -13,7 +13,8 @@
     "vf-contact.css",
     "vf-contact.hbs",
     "vf-contact--simple.hbs",
-    "vf-contact--horizontal.hbs"
+    "vf-contact--horizontal.hbs",
+    "vf-contact.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-contact/package.json
+++ b/components/vf-contact/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.13",
+  "version": "0.0.14",
   "name": "@visual-framework/vf-contact",
   "description": "vf-contact component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -16,9 +16,9 @@
     "vf-contact--horizontal.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-contact",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -31,5 +31,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-contact/package.json
+++ b/components/vf-contact/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.12",
+  "version": "0.0.13",
   "name": "@visual-framework/vf-contact",
   "description": "vf-contact component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -16,6 +16,9 @@
     "vf-contact--horizontal.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-contact",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -28,5 +31,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-contact/package.json
+++ b/components/vf-contact/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "name": "@visual-framework/vf-contact",
   "description": "vf-contact component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -32,5 +32,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-content/package.json
+++ b/components/vf-content/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-content",
   "description": "vf-content component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,28 +14,31 @@
     "vf-content.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-content",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.15",
-    "@visual-framework/vf-box": "^0.0.15",
-    "@visual-framework/vf-button": "^0.0.15",
-    "@visual-framework/vf-divider": "^0.0.15",
-    "@visual-framework/vf-figure": "^0.0.15",
-    "@visual-framework/vf-form": "^0.0.16",
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-link": "^0.0.15",
-    "@visual-framework/vf-list": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-tag": "^0.0.15",
-    "@visual-framework/vf-text": "^0.0.15",
+    "@visual-framework/vf-blockquote": "^0.0.16",
+    "@visual-framework/vf-box": "^0.0.16",
+    "@visual-framework/vf-button": "^0.0.16",
+    "@visual-framework/vf-divider": "^0.0.16",
+    "@visual-framework/vf-figure": "^0.0.16",
+    "@visual-framework/vf-form": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-link": "^0.0.16",
+    "@visual-framework/vf-list": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-tag": "^0.0.16",
+    "@visual-framework/vf-text": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-content/package.json
+++ b/components/vf-content/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-content",
   "description": "vf-content component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,23 +23,23 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.17",
-    "@visual-framework/vf-box": "^0.0.17",
-    "@visual-framework/vf-button": "^0.0.17",
-    "@visual-framework/vf-divider": "^0.0.17",
-    "@visual-framework/vf-figure": "^0.0.17",
-    "@visual-framework/vf-form": "^0.0.18",
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-link": "^0.0.17",
-    "@visual-framework/vf-list": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-tag": "^0.0.17",
-    "@visual-framework/vf-text": "^0.0.17",
+    "@visual-framework/vf-blockquote": "^0.0.18",
+    "@visual-framework/vf-box": "^0.0.18",
+    "@visual-framework/vf-button": "^0.0.18",
+    "@visual-framework/vf-divider": "^0.0.18",
+    "@visual-framework/vf-figure": "^0.0.18",
+    "@visual-framework/vf-form": "^0.0.19",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-link": "^0.0.18",
+    "@visual-framework/vf-list": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-tag": "^0.0.18",
+    "@visual-framework/vf-text": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-content/package.json
+++ b/components/vf-content/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-content",
   "description": "vf-content component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,31 +14,31 @@
     "vf-content.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-content",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.16",
-    "@visual-framework/vf-box": "^0.0.16",
-    "@visual-framework/vf-button": "^0.0.16",
-    "@visual-framework/vf-divider": "^0.0.16",
-    "@visual-framework/vf-figure": "^0.0.16",
-    "@visual-framework/vf-form": "^0.0.17",
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-link": "^0.0.16",
-    "@visual-framework/vf-list": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-tag": "^0.0.16",
-    "@visual-framework/vf-text": "^0.0.16",
+    "@visual-framework/vf-blockquote": "^0.0.17",
+    "@visual-framework/vf-box": "^0.0.17",
+    "@visual-framework/vf-button": "^0.0.17",
+    "@visual-framework/vf-divider": "^0.0.17",
+    "@visual-framework/vf-figure": "^0.0.17",
+    "@visual-framework/vf-form": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-link": "^0.0.17",
+    "@visual-framework/vf-list": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-tag": "^0.0.17",
+    "@visual-framework/vf-text": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-content/package.json
+++ b/components/vf-content/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-content.scss",
     "vf-content.css",
-    "vf-content.hbs"
+    "vf-content.hbs",
+    "vf-content.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-data-protection-banner/package.json
+++ b/components/vf-data-protection-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-data-protection-banner",
   "description": "vf-data-protection-banner component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -16,20 +16,23 @@
     "vf-data-protection-banner.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-data-protection-banner",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.15",
-    "@visual-framework/vf-grid": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-text": "^0.0.15",
+    "@visual-framework/vf-button": "^0.0.16",
+    "@visual-framework/vf-grid": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-text": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-data-protection-banner/package.json
+++ b/components/vf-data-protection-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-data-protection-banner",
   "description": "vf-data-protection-banner component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -25,15 +25,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.17",
-    "@visual-framework/vf-grid": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-text": "^0.0.17",
+    "@visual-framework/vf-button": "^0.0.18",
+    "@visual-framework/vf-grid": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-text": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-data-protection-banner/package.json
+++ b/components/vf-data-protection-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-data-protection-banner",
   "description": "vf-data-protection-banner component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -16,23 +16,23 @@
     "vf-data-protection-banner.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-data-protection-banner",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.16",
-    "@visual-framework/vf-grid": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-text": "^0.0.16",
+    "@visual-framework/vf-button": "^0.0.17",
+    "@visual-framework/vf-grid": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-text": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-data-protection-banner/package.json
+++ b/components/vf-data-protection-banner/package.json
@@ -13,7 +13,8 @@
     "vf-data-protection-banner.scss",
     "vf-data-protection-banner.css",
     "vf-data-protection-banner.js",
-    "vf-data-protection-banner.hbs"
+    "vf-data-protection-banner.hbs",
+    "vf-data-protection-banner.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-divider/package.json
+++ b/components/vf-divider/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-divider.scss",
     "vf-divider.css",
-    "vf-divider.hbs"
+    "vf-divider.hbs",
+    "vf-divider.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-divider/package.json
+++ b/components/vf-divider/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-divider",
   "description": "vf-divider component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,20 @@
     "vf-divider.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-divider",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-divider/package.json
+++ b/components/vf-divider/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-divider",
   "description": "vf-divider component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,17 +14,20 @@
     "vf-divider.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-divider",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-divider/package.json
+++ b/components/vf-divider/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-divider",
   "description": "vf-divider component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-factoid/package.json
+++ b/components/vf-factoid/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-factoid.scss",
     "vf-factoid.css",
-    "vf-factoid.hbs"
+    "vf-factoid.hbs",
+    "vf-factoid.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-factoid/package.json
+++ b/components/vf-factoid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-factoid",
   "description": "vf-factoid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,22 +14,22 @@
     "vf-factoid.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-factoid",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-text": "^0.0.16",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-text": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-factoid/package.json
+++ b/components/vf-factoid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-factoid",
   "description": "vf-factoid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-text": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-text": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-factoid/package.json
+++ b/components/vf-factoid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-factoid",
   "description": "vf-factoid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,19 +14,22 @@
     "vf-factoid.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-factoid",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-text": "^0.0.15",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-text": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-favicon/package.json
+++ b/components/vf-favicon/package.json
@@ -12,7 +12,8 @@
     "index.scss",
     "vf-favison.scss",
     "vf-favison.css",
-    "vf-favison.hbs"
+    "vf-favison.hbs",
+    "vf-favicon.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-favicon/package.json
+++ b/components/vf-favicon/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-favison",
   "description": "vf-favison component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,17 +15,20 @@
     "vf-favison.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-favicon",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-favicon/package.json
+++ b/components/vf-favicon/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-favison",
   "description": "vf-favison component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,20 +15,20 @@
     "vf-favison.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-favicon",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-favicon/package.json
+++ b/components/vf-favicon/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-favison",
   "description": "vf-favison component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,12 +24,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-figure/package.json
+++ b/components/vf-figure/package.json
@@ -12,7 +12,8 @@
     "index.scss",
     "vf-figure.scss",
     "vf-figure.css",
-    "vf-figure.hbs"
+    "vf-figure.hbs",
+    "vf-figure.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-figure/package.json
+++ b/components/vf-figure/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-figure",
   "description": "vf-figure component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,20 +15,20 @@
     "vf-figure.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-figure",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-figure/package.json
+++ b/components/vf-figure/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-figure",
   "description": "vf-figure component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,12 +24,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-figure/package.json
+++ b/components/vf-figure/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-figure",
   "description": "vf-figure component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,17 +15,20 @@
     "vf-figure.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-figure",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-font-plex-mono/package.json
+++ b/components/vf-font-plex-mono/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.12",
+  "version": "0.0.13",
   "name": "@visual-framework/vf-plex-mono-font",
   "description": "vf-plex-mono-font component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,6 +13,9 @@
     "vf-plex-mono-font.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-corecomponents/blocks/vf-font-plex-mono",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -21,5 +24,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-font-plex-mono/package.json
+++ b/components/vf-font-plex-mono/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.13",
+  "version": "0.0.14",
   "name": "@visual-framework/vf-plex-mono-font",
   "description": "vf-plex-mono-font component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,9 +13,9 @@
     "vf-plex-mono-font.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-corecomponents/blocks/vf-font-plex-mono",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -24,5 +24,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-font-plex-mono/package.json
+++ b/components/vf-font-plex-mono/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "name": "@visual-framework/vf-plex-mono-font",
   "description": "vf-plex-mono-font component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,5 +24,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-font-plex-sans/package.json
+++ b/components/vf-font-plex-sans/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.13",
+  "version": "0.0.14",
   "name": "@visual-framework/vf-plex-sans-font",
   "description": "vf-plex-sans-font component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,9 +13,9 @@
     "vf-plex-sans-font.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-font-plex-sans",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -24,5 +24,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-font-plex-sans/package.json
+++ b/components/vf-font-plex-sans/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "name": "@visual-framework/vf-plex-sans-font",
   "description": "vf-plex-sans-font component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,5 +24,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-font-plex-sans/package.json
+++ b/components/vf-font-plex-sans/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.12",
+  "version": "0.0.13",
   "name": "@visual-framework/vf-plex-sans-font",
   "description": "vf-plex-sans-font component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,6 +13,9 @@
     "vf-plex-sans-font.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-font-plex-sans",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -21,5 +24,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-footer/package.json
+++ b/components/vf-footer/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.3",
-  "name": "vf-footer",
+  "name": "@visual-framework/vf-footer",
   "description": "vf-footer component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",

--- a/components/vf-footer/package.json
+++ b/components/vf-footer/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "vf-footer",
   "description": "vf-footer component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -12,14 +12,16 @@
     "vf-footer.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-footer",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
-  "dependencies": {
-  },
   "keywords": [
     "fractal",
     "component"
-  ]
+  ],
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-footer/package.json
+++ b/components/vf-footer/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "vf-footer",
   "description": "vf-footer component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -12,9 +12,9 @@
     "vf-footer.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-footer",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
@@ -23,5 +23,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-footer/package.json
+++ b/components/vf-footer/package.json
@@ -9,7 +9,10 @@
   "main": "build/index.js",
   "files": [
     "index.scss",
-    "vf-footer.css"
+    "vf-footer.css",
+    "vf-footer.scss",
+    "vf-footer.hbs",
+    "vf-footer.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-footer/package.json
+++ b/components/vf-footer/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "name": "@visual-framework/vf-footer",
   "description": "vf-footer component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -21,6 +21,7 @@
     "vf-form.scss",
     "vf-form.css",
     "vf-form.hbs"
+    "vf-form.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-form",
   "description": "vf-form component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -20,7 +20,7 @@
     "index.scss",
     "vf-form.scss",
     "vf-form.css",
-    "vf-form.hbs"
+    "vf-form.hbs",
     "vf-form.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
@@ -32,12 +32,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-form",
   "description": "vf-form component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,17 +23,20 @@
     "vf-form.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-form",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-form",
   "description": "vf-form component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,20 +23,20 @@
     "vf-form.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-form",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-form/vf-form__checkbox/package.json
+++ b/components/vf-form/vf-form__checkbox/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-form__checkbox",
   "description": "vf-form__checkbox component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,19 +11,22 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.16",
-    "@visual-framework/vf-form__label": "^0.0.12",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-form__item": "^0.0.17",
+    "@visual-framework/vf-form__label": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-form/vf-form__checkbox/package.json
+++ b/components/vf-form/vf-form__checkbox/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-form__checkbox",
   "description": "vf-form__checkbox component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,14 +19,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.18",
-    "@visual-framework/vf-form__label": "^0.0.14",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-form__item": "^0.0.19",
+    "@visual-framework/vf-form__label": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-form/vf-form__checkbox/package.json
+++ b/components/vf-form/vf-form__checkbox/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-form__checkbox",
   "description": "vf-form__checkbox component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,22 +11,22 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.17",
-    "@visual-framework/vf-form__label": "^0.0.13",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-form__item": "^0.0.18",
+    "@visual-framework/vf-form__label": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-form/vf-form__helper/package.json
+++ b/components/vf-form/vf-form__helper/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-form__helper",
   "description": "vf-form__helper component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,17 +11,20 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-form/vf-form__helper/package.json
+++ b/components/vf-form/vf-form__helper/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-form__helper",
   "description": "vf-form__helper component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,12 +19,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-form/vf-form__helper/package.json
+++ b/components/vf-form/vf-form__helper/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-form__helper",
   "description": "vf-form__helper component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,20 +11,20 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-form/vf-form__input/package.json
+++ b/components/vf-form/vf-form__input/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-form__input",
   "description": "vf-form__input component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,22 +11,22 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.17",
-    "@visual-framework/vf-form__label": "^0.0.13",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-form__item": "^0.0.18",
+    "@visual-framework/vf-form__label": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-form/vf-form__input/package.json
+++ b/components/vf-form/vf-form__input/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-form__input",
   "description": "vf-form__input component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,14 +19,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.18",
-    "@visual-framework/vf-form__label": "^0.0.14",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-form__item": "^0.0.19",
+    "@visual-framework/vf-form__label": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-form/vf-form__input/package.json
+++ b/components/vf-form/vf-form__input/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-form__input",
   "description": "vf-form__input component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,19 +11,22 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.16",
-    "@visual-framework/vf-form__label": "^0.0.12",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-form__item": "^0.0.17",
+    "@visual-framework/vf-form__label": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-form__item",
   "description": "vf-form__item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,24 +11,24 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__helper": "^0.0.16",
-    "@visual-framework/vf-form__input": "^0.0.17",
-    "@visual-framework/vf-form__item": "^0.0.17",
-    "@visual-framework/vf-form__label": "^0.0.13",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-form__helper": "^0.0.17",
+    "@visual-framework/vf-form__input": "^0.0.18",
+    "@visual-framework/vf-form__item": "^0.0.18",
+    "@visual-framework/vf-form__label": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-form__item",
   "description": "vf-form__item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,21 +11,24 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__helper": "^0.0.15",
-    "@visual-framework/vf-form__input": "^0.0.16",
-    "@visual-framework/vf-form__item": "^0.0.16",
-    "@visual-framework/vf-form__label": "^0.0.12",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-form__helper": "^0.0.16",
+    "@visual-framework/vf-form__input": "^0.0.17",
+    "@visual-framework/vf-form__item": "^0.0.17",
+    "@visual-framework/vf-form__label": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-form__item",
   "description": "vf-form__item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,16 +19,16 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__helper": "^0.0.17",
-    "@visual-framework/vf-form__input": "^0.0.18",
-    "@visual-framework/vf-form__item": "^0.0.18",
-    "@visual-framework/vf-form__label": "^0.0.14",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-form__helper": "^0.0.18",
+    "@visual-framework/vf-form__input": "^0.0.19",
+    "@visual-framework/vf-form__item": "^0.0.19",
+    "@visual-framework/vf-form__label": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-form/vf-form__label/package.json
+++ b/components/vf-form/vf-form__label/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.12",
+  "version": "0.0.13",
   "name": "@visual-framework/vf-form__label",
   "description": "vf-form__label component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,6 +11,9 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -19,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-form/vf-form__label/package.json
+++ b/components/vf-form/vf-form__label/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "name": "@visual-framework/vf-form__label",
   "description": "vf-form__label component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -22,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-form/vf-form__label/package.json
+++ b/components/vf-form/vf-form__label/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.13",
+  "version": "0.0.14",
   "name": "@visual-framework/vf-form__label",
   "description": "vf-form__label component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,9 +11,9 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -22,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-form/vf-form__radio/package.json
+++ b/components/vf-form/vf-form__radio/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.12",
+  "version": "0.0.13",
   "name": "@visual-framework/vf-form__radio",
   "description": "vf-form__radio component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,6 +11,9 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -19,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-form/vf-form__radio/package.json
+++ b/components/vf-form/vf-form__radio/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.13",
+  "version": "0.0.14",
   "name": "@visual-framework/vf-form__radio",
   "description": "vf-form__radio component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,9 +11,9 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -22,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-form/vf-form__radio/package.json
+++ b/components/vf-form/vf-form__radio/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "name": "@visual-framework/vf-form__radio",
   "description": "vf-form__radio component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -22,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-form/vf-form__select/package.json
+++ b/components/vf-form/vf-form__select/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "name": "@visual-framework/vf-form__select",
   "description": "vf-form__select component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -22,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-form/vf-form__select/package.json
+++ b/components/vf-form/vf-form__select/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.13",
+  "version": "0.0.14",
   "name": "@visual-framework/vf-form__select",
   "description": "vf-form__select component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,9 +11,9 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -22,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-form/vf-form__select/package.json
+++ b/components/vf-form/vf-form__select/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.12",
+  "version": "0.0.13",
   "name": "@visual-framework/vf-form__select",
   "description": "vf-form__select component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,6 +11,9 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -19,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-form/vf-form__textarea/package.json
+++ b/components/vf-form/vf-form__textarea/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.13",
+  "version": "0.0.14",
   "name": "@visual-framework/vf-form__textarea",
   "description": "vf-form__textarea component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,9 +11,9 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -22,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-form/vf-form__textarea/package.json
+++ b/components/vf-form/vf-form__textarea/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.12",
+  "version": "0.0.13",
   "name": "@visual-framework/vf-form__textarea",
   "description": "vf-form__textarea component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -11,6 +11,9 @@
     "index.scss"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -19,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-form/vf-form__textarea/package.json
+++ b/components/vf-form/vf-form__textarea/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "name": "@visual-framework/vf-form__textarea",
   "description": "vf-form__textarea component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -22,5 +22,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-global-header/package.json
+++ b/components/vf-global-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-global-header",
   "description": "vf-global-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,22 +14,22 @@
     "vf-global-header.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-global-header",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-logo": "^0.0.16",
-    "@visual-framework/vf-navigation": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-logo": "^0.0.17",
+    "@visual-framework/vf-navigation": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-global-header/package.json
+++ b/components/vf-global-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-global-header",
   "description": "vf-global-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,19 +14,22 @@
     "vf-global-header.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-global-header",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-logo": "^0.0.15",
-    "@visual-framework/vf-navigation": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-logo": "^0.0.16",
+    "@visual-framework/vf-navigation": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-global-header/package.json
+++ b/components/vf-global-header/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-global-header.scss",
     "vf-global-header.css",
-    "vf-global-header.hbs"
+    "vf-global-header.hbs",
+    "vf-global-header.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-global-header/package.json
+++ b/components/vf-global-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-global-header",
   "description": "vf-global-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-logo": "^0.0.17",
-    "@visual-framework/vf-navigation": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-logo": "^0.0.18",
+    "@visual-framework/vf-navigation": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-grid-page/package.json
+++ b/components/vf-grid-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-grid-page",
   "description": "vf-grid-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,20 +13,20 @@
     "vf-grid-page.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/grids/vf-grid-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-grid-page/package.json
+++ b/components/vf-grid-page/package.json
@@ -10,7 +10,8 @@
   "files": [
     "index.scss",
     "vf-grid-page.scss",
-    "vf-grid-page.css"
+    "vf-grid-page.css",
+    "vf-grid-page.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-grid-page/package.json
+++ b/components/vf-grid-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-grid-page",
   "description": "vf-grid-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,17 +13,20 @@
     "vf-grid-page.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/grids/vf-grid-page",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-grid-page/package.json
+++ b/components/vf-grid-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-grid-page",
   "description": "vf-grid-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -22,12 +22,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-grid/package.json
+++ b/components/vf-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-grid",
   "description": "vf-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -22,12 +22,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-grid/package.json
+++ b/components/vf-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-grid",
   "description": "vf-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,20 +13,20 @@
     "vf-grid.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/grids/vf-grid",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-grid/package.json
+++ b/components/vf-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-grid",
   "description": "vf-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,17 +13,20 @@
     "vf-grid.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/grids/vf-grid",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-grid/package.json
+++ b/components/vf-grid/package.json
@@ -10,7 +10,8 @@
   "files": [
     "index.scss",
     "vf-grid.scss",
-    "vf-grid.css"
+    "vf-grid.css",
+    "vf-grid.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-header/package.json
+++ b/components/vf-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-header",
   "description": "vf-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,23 +14,23 @@
     "vf-header.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-header",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-global-header": "^0.0.17",
-    "@visual-framework/vf-masthead": "^0.0.17",
-    "@visual-framework/vf-navigation": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-global-header": "^0.0.18",
+    "@visual-framework/vf-masthead": "^0.0.18",
+    "@visual-framework/vf-navigation": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-header/package.json
+++ b/components/vf-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-header",
   "description": "vf-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,23 @@
     "vf-header.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-header",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-global-header": "^0.0.16",
-    "@visual-framework/vf-masthead": "^0.0.16",
-    "@visual-framework/vf-navigation": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-global-header": "^0.0.17",
+    "@visual-framework/vf-masthead": "^0.0.17",
+    "@visual-framework/vf-navigation": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-header/package.json
+++ b/components/vf-header/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-header.scss",
     "vf-header.css",
-    "vf-header.hbs"
+    "vf-header.hbs",
+    "vf-header.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-header/package.json
+++ b/components/vf-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-header",
   "description": "vf-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,15 +23,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-global-header": "^0.0.18",
-    "@visual-framework/vf-masthead": "^0.0.18",
-    "@visual-framework/vf-navigation": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-global-header": "^0.0.19",
+    "@visual-framework/vf-masthead": "^0.0.19",
+    "@visual-framework/vf-navigation": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-heading/package.json
+++ b/components/vf-heading/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-heading",
   "description": "vf-heading component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,20 @@
     "vf-heading.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-heading",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-heading/package.json
+++ b/components/vf-heading/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-heading",
   "description": "vf-heading component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-heading/package.json
+++ b/components/vf-heading/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-heading.scss",
     "vf-heading.css",
-    "vf-heading.hbs"
+    "vf-heading.hbs",
+    "vf-heading.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-heading/package.json
+++ b/components/vf-heading/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-heading",
   "description": "vf-heading component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,17 +14,20 @@
     "vf-heading.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-heading",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-intro/package.json
+++ b/components/vf-intro/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-intro",
   "description": "vf-intro component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,19 +14,22 @@
     "vf-intro.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-intro",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-text": "^0.0.15",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-text": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-intro/package.json
+++ b/components/vf-intro/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-intro.scss",
     "vf-intro.css",
-    "vf-intro.hbs"
+    "vf-intro.hbs",
+    "vf-intro.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-intro/package.json
+++ b/components/vf-intro/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-intro",
   "description": "vf-intro component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,22 +14,22 @@
     "vf-intro.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-intro",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-text": "^0.0.16",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-text": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-intro/package.json
+++ b/components/vf-intro/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-intro",
   "description": "vf-intro component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-text": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-text": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-job-description/package.json
+++ b/components/vf-job-description/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-job-description",
   "description": "vf-job-description component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,15 +24,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.17",
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-text": "^0.0.17",
+    "@visual-framework/vf-button": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-text": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-job-description/package.json
+++ b/components/vf-job-description/package.json
@@ -12,7 +12,8 @@
     "vf-job-description.scss",
     "vf-job-description.css",
     "vf-job-description.hbs",
-    "vf-job-description--snippet.hbs"
+    "vf-job-description--snippet.hbs",
+    "vf-job-description.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-job-description/package.json
+++ b/components/vf-job-description/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-job-description",
   "description": "vf-job-description component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,23 +15,23 @@
     "vf-job-description--snippet.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-job-description",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.16",
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-text": "^0.0.16",
+    "@visual-framework/vf-button": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-text": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-job-description/package.json
+++ b/components/vf-job-description/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-job-description",
   "description": "vf-job-description component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,20 +15,23 @@
     "vf-job-description--snippet.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-job-description",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.15",
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-text": "^0.0.15",
+    "@visual-framework/vf-button": "^0.0.16",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-text": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-link-list/package.json
+++ b/components/vf-link-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-link-list",
   "description": "vf-link-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,13 +24,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-link-list/package.json
+++ b/components/vf-link-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-link-list",
   "description": "vf-link-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,21 +15,21 @@
     "vf-link-list--tight.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-link-list",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-link-list/package.json
+++ b/components/vf-link-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-link-list",
   "description": "vf-link-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,18 +15,21 @@
     "vf-link-list--tight.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-link-list",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-link-list/package.json
+++ b/components/vf-link-list/package.json
@@ -12,7 +12,8 @@
     "vf-link-list.scss",
     "vf-link-list.css",
     "vf-link-list.hbs",
-    "vf-link-list--tight.hbs"
+    "vf-link-list--tight.hbs",
+    "vf-link-list.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-link/package.json
+++ b/components/vf-link/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-link",
   "description": "vf-link component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,17 +14,20 @@
     "vf-link.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-link",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-link/package.json
+++ b/components/vf-link/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-link.scss",
     "vf-link.css",
-    "vf-link.hbs"
+    "vf-link.hbs",
+    "vf-link.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-link/package.json
+++ b/components/vf-link/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-link",
   "description": "vf-link component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-link/package.json
+++ b/components/vf-link/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-link",
   "description": "vf-link component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,20 @@
     "vf-link.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-link",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-list/package.json
+++ b/components/vf-list/package.json
@@ -14,7 +14,8 @@
     "vf-list.hbs",
     "vf-list--inline.hbs",
     "vf-list--ordered.hbs",
-    "vf-list--unordered.hbs"
+    "vf-list--unordered.hbs",
+    "vf-list.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-list/package.json
+++ b/components/vf-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-list",
   "description": "vf-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -17,17 +17,20 @@
     "vf-list--unordered.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-list",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-list/package.json
+++ b/components/vf-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-list",
   "description": "vf-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,12 +26,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-list/package.json
+++ b/components/vf-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-list",
   "description": "vf-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -17,20 +17,20 @@
     "vf-list--unordered.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-list",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-logo/package.json
+++ b/components/vf-logo/package.json
@@ -12,7 +12,8 @@
     "index.scss",
     "vf-logo.scss",
     "vf-logo.css",
-    "vf-logo.hbs"
+    "vf-logo.hbs",
+    "vf-logo.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-logo/package.json
+++ b/components/vf-logo/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-logo",
   "description": "vf-logo component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,12 +24,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-logo/package.json
+++ b/components/vf-logo/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-logo",
   "description": "vf-logo component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,17 +15,20 @@
     "vf-logo.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-logo",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-logo/package.json
+++ b/components/vf-logo/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-logo",
   "description": "vf-logo component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,20 +15,20 @@
     "vf-logo.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-logo",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-masthead/package.json
+++ b/components/vf-masthead/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-masthead",
   "description": "vf-masthead component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,18 +15,21 @@
     "vf-masthead.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-masthead",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-grid": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-masthead/package.json
+++ b/components/vf-masthead/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-masthead",
   "description": "vf-masthead component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,21 +15,21 @@
     "vf-masthead.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-masthead",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-grid": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-masthead/package.json
+++ b/components/vf-masthead/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-masthead",
   "description": "vf-masthead component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,13 +24,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-grid": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-masthead/package.json
+++ b/components/vf-masthead/package.json
@@ -12,7 +12,8 @@
     "index.scss",
     "vf-masthead.scss",
     "vf-masthead.css",
-    "vf-masthead.hbs"
+    "vf-masthead.hbs",
+    "vf-masthead.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-navigation/package.json
+++ b/components/vf-navigation/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-navigation",
   "description": "vf-navigation component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -17,21 +17,21 @@
     "vf-navigation--tertiary.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-navigation",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-list": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-navigation/package.json
+++ b/components/vf-navigation/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-navigation",
   "description": "vf-navigation component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,13 +26,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-list": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-navigation/package.json
+++ b/components/vf-navigation/package.json
@@ -14,7 +14,8 @@
     "vf-navigation.hbs",
     "vf-navigation--primary.hbs",
     "vf-navigation--secondary.hbs",
-    "vf-navigation--tertiary.hbs"
+    "vf-navigation--tertiary.hbs",
+    "vf-navigation.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-navigation/package.json
+++ b/components/vf-navigation/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-navigation",
   "description": "vf-navigation component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -17,18 +17,21 @@
     "vf-navigation--tertiary.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-navigation",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-list": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-news-container/package.json
+++ b/components/vf-news-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-news-container",
   "description": "vf-news-container component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,23 @@
     "vf-news-container.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-news-container",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.15",
-    "@visual-framework/vf-news-item": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-section-header": "^0.0.16",
+    "@visual-framework/vf-grid": "^0.0.16",
+    "@visual-framework/vf-news-item": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-section-header": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-news-container/package.json
+++ b/components/vf-news-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-news-container",
   "description": "vf-news-container component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,23 +14,23 @@
     "vf-news-container.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-news-container",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.16",
-    "@visual-framework/vf-news-item": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-section-header": "^0.0.17",
+    "@visual-framework/vf-grid": "^0.0.17",
+    "@visual-framework/vf-news-item": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-section-header": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-news-container/package.json
+++ b/components/vf-news-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-news-container",
   "description": "vf-news-container component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,15 +23,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.17",
-    "@visual-framework/vf-news-item": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-section-header": "^0.0.18",
+    "@visual-framework/vf-grid": "^0.0.18",
+    "@visual-framework/vf-news-item": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-section-header": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-news-container/package.json
+++ b/components/vf-news-container/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-news-container.scss",
     "vf-news-container.css",
-    "vf-news-container.hbs"
+    "vf-news-container.hbs",
+    "vf-news-container.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-news-item/package.json
+++ b/components/vf-news-item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-news-item",
   "description": "vf-news-item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -17,20 +17,23 @@
     "vf-news-item--with-image.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-news-item",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-link": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-text": "^0.0.15",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-link": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-text": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-news-item/package.json
+++ b/components/vf-news-item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-news-item",
   "description": "vf-news-item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,15 +26,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-link": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-text": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-link": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-text": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-news-item/package.json
+++ b/components/vf-news-item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-news-item",
   "description": "vf-news-item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -17,23 +17,23 @@
     "vf-news-item--with-image.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-news-item",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-link": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-text": "^0.0.16",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-link": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-text": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-news-item/package.json
+++ b/components/vf-news-item/package.json
@@ -14,7 +14,8 @@
     "vf-news-item.css",
     "vf-news-item.hbs",
     "vf-news-item--snippet.hbs",
-    "vf-news-item--with-image.hbs"
+    "vf-news-item--with-image.hbs",
+    "vf-news-item.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-no-js/package.json
+++ b/components/vf-no-js/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "vf-no-js",
   "description": "vf-no-js component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -12,14 +12,16 @@
     "vf-no-js.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-no-js",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
-  "dependencies": {
-  },
   "keywords": [
     "fractal",
     "component"
-  ]
+  ],
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-no-js/package.json
+++ b/components/vf-no-js/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "vf-no-js",
   "description": "vf-no-js component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -12,9 +12,9 @@
     "vf-no-js.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-no-js",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
@@ -23,5 +23,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-no-js/package.json
+++ b/components/vf-no-js/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "name": "@visual-framework/vf-no-js",
   "description": "vf-no-js component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,5 +23,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-no-js/package.json
+++ b/components/vf-no-js/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.3",
-  "name": "vf-no-js",
+  "name": "@visual-framework/vf-no-js",
   "description": "vf-no-js component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",

--- a/components/vf-page-header/package.json
+++ b/components/vf-page-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-page-header",
   "description": "vf-page-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,21 +14,21 @@
     "vf-page-header.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-page-header",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-page-header/package.json
+++ b/components/vf-page-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-page-header",
   "description": "vf-page-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,13 +23,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-page-header/package.json
+++ b/components/vf-page-header/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-page-header.scss",
     "vf-page-header.css",
-    "vf-page-header.hbs"
+    "vf-page-header.hbs",
+    "vf-page-header.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-page-header/package.json
+++ b/components/vf-page-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-page-header",
   "description": "vf-page-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,18 +14,21 @@
     "vf-page-header.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-page-header",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-sass-config/package.json
+++ b/components/vf-sass-config/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.12",
+  "version": "0.0.13",
   "name": "@visual-framework/vf-sass-config",
   "description": "vf-sass-config",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -12,6 +12,9 @@
     "mixins"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -23,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-sass-config/package.json
+++ b/components/vf-sass-config/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "name": "@visual-framework/vf-sass-config",
   "description": "vf-sass-config",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-sass-config/package.json
+++ b/components/vf-sass-config/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.13",
+  "version": "0.0.14",
   "name": "@visual-framework/vf-sass-config",
   "description": "vf-sass-config",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -12,9 +12,9 @@
     "mixins"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
@@ -26,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-section-header/package.json
+++ b/components/vf-section-header/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-section-header.scss",
     "vf-section-header.css",
-    "vf-section-header.hbs"
+    "vf-section-header.hbs",
+    "vf-section-header.config.yml"
   ],
   "private": false,
   "test": "echo \"Error: no test specified\" && exit 1",

--- a/components/vf-section-header/package.json
+++ b/components/vf-section-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-section-header",
   "description": "vf-section-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,18 +15,21 @@
   ],
   "private": false,
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-section-header",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-section-header/package.json
+++ b/components/vf-section-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-section-header",
   "description": "vf-section-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,13 +24,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-section-header/package.json
+++ b/components/vf-section-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-section-header",
   "description": "vf-section-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,21 +15,21 @@
   ],
   "private": false,
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-section-header",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-snippet/package.json
+++ b/components/vf-snippet/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-snippet.scss",
     "vf-snippet.css",
-    "vf-snippet.hbs"
+    "vf-snippet.hbs",
+    "vf-snippet.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-snippet/package.json
+++ b/components/vf-snippet/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-snippet",
   "description": "vf-snippet component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-text": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-text": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-snippet/package.json
+++ b/components/vf-snippet/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-snippet",
   "description": "vf-snippet component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,19 +14,22 @@
     "vf-snippet.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-snippet",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-text": "^0.0.15",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-text": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-snippet/package.json
+++ b/components/vf-snippet/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-snippet",
   "description": "vf-snippet component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,22 +14,22 @@
     "vf-snippet.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-snippet",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-text": "^0.0.16",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-text": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-summary-container/package.json
+++ b/components/vf-summary-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-summary-container",
   "description": "vf-summary component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,24 +14,24 @@
     "vf-summary.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-summary-container",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.16",
-    "@visual-framework/vf-grid": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-section-header": "^0.0.17",
-    "@visual-framework/vf-summary": "^0.0.17",
+    "@visual-framework/embl-grid": "^0.0.17",
+    "@visual-framework/vf-grid": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-section-header": "^0.0.18",
+    "@visual-framework/vf-summary": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-summary-container/package.json
+++ b/components/vf-summary-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-summary-container",
   "description": "vf-summary component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,16 +23,16 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.17",
-    "@visual-framework/vf-grid": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-section-header": "^0.0.18",
-    "@visual-framework/vf-summary": "^0.0.18",
+    "@visual-framework/embl-grid": "^0.0.18",
+    "@visual-framework/vf-grid": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-section-header": "^0.0.19",
+    "@visual-framework/vf-summary": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-summary-container/package.json
+++ b/components/vf-summary-container/package.json
@@ -9,9 +9,10 @@
   "sass": "index.scss",
   "files": [
     "index.scss",
-    "vf-summary.scss",
-    "vf-summary.css",
-    "vf-summary.hbs"
+    "vf-summary-container.scss",
+    "vf-summary-container.css",
+    "vf-summary-container.hbs",
+    "vf-summary-container.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-summary-container/package.json
+++ b/components/vf-summary-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-summary-container",
   "description": "vf-summary component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,21 +14,24 @@
     "vf-summary.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-summary-container",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.15",
-    "@visual-framework/vf-grid": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-section-header": "^0.0.16",
-    "@visual-framework/vf-summary": "^0.0.16",
+    "@visual-framework/embl-grid": "^0.0.16",
+    "@visual-framework/vf-grid": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-section-header": "^0.0.17",
+    "@visual-framework/vf-summary": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-summary",
   "description": "vf-summary component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,19 +14,22 @@
     "vf-summary.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-summary",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-text": "^0.0.15",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-text": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-summary",
   "description": "vf-summary component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,14 +26,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-text": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-text": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -11,7 +11,11 @@
     "index.scss",
     "vf-summary.scss",
     "vf-summary.css",
-    "vf-summary.hbs"
+    "vf-summary.hbs",
+    "vf-summary--job.hbs",
+    "vf-summary--mews-has-image.hbs",
+    "vf-summary--news.hbs",
+    "vf-summary.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-summary",
   "description": "vf-summary component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,22 +14,22 @@
     "vf-summary.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-summary",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-text": "^0.0.16",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-text": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-tabs/package.json
+++ b/components/vf-tabs/package.json
@@ -13,7 +13,8 @@
     "vf-tabs.scss",
     "vf-tabs.css",
     "vf-tabs.js",
-    "vf-tabs.hbs"
+    "vf-tabs.hbs",
+    "vf-tabs.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-tabs/package.json
+++ b/components/vf-tabs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-tabs",
   "description": "vf-tabs component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -16,20 +16,20 @@
     "vf-tabs.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-tabs",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-tabs/package.json
+++ b/components/vf-tabs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-tabs",
   "description": "vf-tabs component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -25,12 +25,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-tabs/package.json
+++ b/components/vf-tabs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-tabs",
   "description": "vf-tabs component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -16,17 +16,20 @@
     "vf-tabs.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-tabs",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-tag/package.json
+++ b/components/vf-tag/package.json
@@ -15,7 +15,8 @@
     "vf-tag--outline.hbs",
     "vf-tag--sizes.hbs",
     "vf-tag--styles.hbs",
-    "vf-tag--variants.hbs"
+    "vf-tag--variants.hbs",
+    "vf-tag.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-tag/package.json
+++ b/components/vf-tag/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-tag",
   "description": "vf-tag component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -18,17 +18,20 @@
     "vf-tag--variants.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-tag",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-tag/package.json
+++ b/components/vf-tag/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-tag",
   "description": "vf-tag component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -27,12 +27,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-tag/package.json
+++ b/components/vf-tag/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-tag",
   "description": "vf-tag component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -18,20 +18,20 @@
     "vf-tag--variants.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-tag",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-text/package.json
+++ b/components/vf-text/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-text.scss",
     "vf-text.css",
-    "vf-text.hbs"
+    "vf-text.hbs",
+    "vf-text.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-text/package.json
+++ b/components/vf-text/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-text",
   "description": "vf-text component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,20 @@
     "vf-text.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-text",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-text/package.json
+++ b/components/vf-text/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-text",
   "description": "vf-text component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-text/package.json
+++ b/components/vf-text/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-text",
   "description": "vf-text component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,17 +14,20 @@
     "vf-text.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-text",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-utility-classes/package.json
+++ b/components/vf-utility-classes/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-utility-classes",
   "description": "A set of utility classes to help quickly prototype, and 'tweak' design.",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,20 +13,20 @@
     "vf-utility-classes.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/elements/vf-utility-classes",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-utility-classes/package.json
+++ b/components/vf-utility-classes/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-utility-classes",
   "description": "A set of utility classes to help quickly prototype, and 'tweak' design.",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -13,17 +13,20 @@
     "vf-utility-classes.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/elements/vf-utility-classes",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-utility-classes/package.json
+++ b/components/vf-utility-classes/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-utility-classes",
   "description": "A set of utility classes to help quickly prototype, and 'tweak' design.",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -21,12 +21,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-video-container/package.json
+++ b/components/vf-video-container/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-video-container.scss",
     "vf-video-container.css",
-    "vf-video-container.hbs"
+    "vf-video-container.hbs",
+    "vf-video-container.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-video-container/package.json
+++ b/components/vf-video-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-video-container",
   "description": "vf-video-container component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,24 +14,24 @@
     "vf-video-container.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-video-container",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
-    "@visual-framework/vf-section-header": "^0.0.17",
-    "@visual-framework/vf-video": "^0.0.16",
-    "@visual-framework/vf-video-teaser": "^0.0.17",
+    "@visual-framework/embl-grid": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-section-header": "^0.0.18",
+    "@visual-framework/vf-video": "^0.0.17",
+    "@visual-framework/vf-video-teaser": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-video-container/package.json
+++ b/components/vf-video-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-video-container",
   "description": "vf-video-container component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,21 +14,24 @@
     "vf-video-container.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/containers/vf-video-container",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
-    "@visual-framework/vf-section-header": "^0.0.16",
-    "@visual-framework/vf-video": "^0.0.15",
-    "@visual-framework/vf-video-teaser": "^0.0.16",
+    "@visual-framework/embl-grid": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-section-header": "^0.0.17",
+    "@visual-framework/vf-video": "^0.0.16",
+    "@visual-framework/vf-video-teaser": "^0.0.17",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-video-container/package.json
+++ b/components/vf-video-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-video-container",
   "description": "vf-video-container component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,16 +23,16 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
-    "@visual-framework/vf-section-header": "^0.0.18",
-    "@visual-framework/vf-video": "^0.0.17",
-    "@visual-framework/vf-video-teaser": "^0.0.18",
+    "@visual-framework/embl-grid": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-section-header": "^0.0.19",
+    "@visual-framework/vf-video": "^0.0.18",
+    "@visual-framework/vf-video-teaser": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-video-teaser/package.json
+++ b/components/vf-video-teaser/package.json
@@ -12,7 +12,8 @@
     "index.scss",
     "vf-video-teaser.scss",
     "vf-video-teaser.css",
-    "vf-video-teaser.hbs"
+    "vf-video-teaser.hbs",
+    "vf-video-teaser.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-video-teaser/package.json
+++ b/components/vf-video-teaser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-video-teaser",
   "description": "vf-video-teaser component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,14 +24,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.17",
-    "@visual-framework/vf-link": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-heading": "^0.0.18",
+    "@visual-framework/vf-link": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/components/vf-video-teaser/package.json
+++ b/components/vf-video-teaser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-video-teaser",
   "description": "vf-video-teaser component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,22 +15,22 @@
     "vf-video-teaser.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-video-teaser",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.16",
-    "@visual-framework/vf-link": "^0.0.16",
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-heading": "^0.0.17",
+    "@visual-framework/vf-link": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-video-teaser/package.json
+++ b/components/vf-video-teaser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-video-teaser",
   "description": "vf-video-teaser component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -15,19 +15,22 @@
     "vf-video-teaser.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-video-teaser",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.15",
-    "@visual-framework/vf-link": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-heading": "^0.0.16",
+    "@visual-framework/vf-link": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-video/package.json
+++ b/components/vf-video/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "@visual-framework/vf-video",
   "description": "vf-video component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,20 +14,20 @@
     "vf-video.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-video",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.13",
+    "@visual-framework/vf-sass-config": "^0.0.14",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
+  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
 }

--- a/components/vf-video/package.json
+++ b/components/vf-video/package.json
@@ -11,7 +11,8 @@
     "index.scss",
     "vf-video.scss",
     "vf-video.css",
-    "vf-video.hbs"
+    "vf-video.hbs",
+    "vf-video.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-video/package.json
+++ b/components/vf-video/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-video",
   "description": "vf-video component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -14,17 +14,20 @@
     "vf-video.hbs"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/blocks/vf-video",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12",
+    "@visual-framework/vf-sass-config": "^0.0.13",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "af1286565e13dd1bc0f8c24d2f3b66abe7275b0c"
+  "gitHead": "ed317a4db111737f1e02354aabb5dc449db15701"
 }

--- a/components/vf-video/package.json
+++ b/components/vf-video/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-video",
   "description": "vf-video component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.14",
+    "@visual-framework/vf-sass-config": "^0.0.15",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "0a379ff5c9c6e169cfe686a073a96eb0282f9313"
+  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
 }

--- a/tools/component-generator/templates/_package.json
+++ b/tools/component-generator/templates/_package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.1",
-  "name": "<%= componentName %>",
+  "name": "@visual-framework/<%= componentName %>",
   "description": "<%= componentName %> component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
@@ -10,7 +10,10 @@
   "main": "build/index.js",
   "files": [
     "index.scss",
-    "<%= componentName %>.css"
+    "<%= componentName %>.scss",
+    "<%= componentName %>.css",
+    "<%= componentName %>.hbs",
+    "<%= componentName %>.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
 "publishConfig": {

--- a/tools/component-generator/templates/_package.json
+++ b/tools/component-generator/templates/_package.json
@@ -13,6 +13,9 @@
     "<%= componentName %>.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
+"publishConfig": {
+  "access": "public"
+},
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/<%= componentName %>",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"


### PR DESCRIPTION
- fixes npm package names that missed `@visual-framework/`.
- adds `publishConfig` so patterns are known as 'not private' for publishing
- adds yml and SCSS files where appropriate for packages
- updates all package son for version numbers

- updates generator tool
  - adds `@visual-framework/` to name
  - adds `config.yml`, and `.scss` files to `files: []` section
