### PR TITLE
adds vf-form__helper to vf_form and other things

### DIFF
--- a/components/embl-boilerplate-page/package.json
+++ b/components/embl-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.5",
   "name": "@visual-framework/embl-boilerplate-page",
   "description": "embl-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/embl-content-meta-properties/package.json
+++ b/components/embl-content-meta-properties/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.5",
   "name": "@visual-framework/embl-content-meta-properties",
   "description": "embl-content-meta-properties component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,5 +23,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/embl-grid/package.json
+++ b/components/embl-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/embl-grid",
   "description": "embl-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -21,12 +21,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/embl-group-page/package.json
+++ b/components/embl-group-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.5",
   "name": "@visual-framework/embl-group-page",
   "description": "embl-group-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/embl-subsite-page/package.json
+++ b/components/embl-subsite-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.5",
   "name": "@visual-framework/embl-subsite-page",
   "description": "embl-subsite-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-activity-group/package.json
+++ b/components/vf-activity-group/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-activity-group",
   "description": "vf-activity-group component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,15 +23,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-activity-list": "^0.0.19",
-    "@visual-framework/vf-grid": "^0.0.18",
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-activity-list": "^0.0.20",
+    "@visual-framework/vf-grid": "^0.0.19",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-activity-list/package.json
+++ b/components/vf-activity-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-activity-list",
   "description": "vf-activity-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.18",
-    "@visual-framework/vf-list": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-blockquote": "^0.0.19",
+    "@visual-framework/vf-list": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-article-meta-information/package.json
+++ b/components/vf-article-meta-information/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.5",
   "name": "@visual-framework/vf-article-meta-information",
   "description": "vf-article-meta-information component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -22,11 +22,11 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15"
+    "@visual-framework/vf-sass-config": "^0.0.16"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-banner/package.json
+++ b/components/vf-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.5",
   "name": "@visual-framework/vf-banner",
   "description": "vf-banner component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,12 +24,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "@visual-framework/vf-tag": "^0.0.12"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-blockquote/package.json
+++ b/components/vf-blockquote/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-blockquote",
   "description": "vf-blockquote component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-boilerplate-page/package.json
+++ b/components/vf-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.5",
   "name": "@visual-framework/vf-boilerplate-page",
   "description": "vf-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -19,5 +19,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-box/package.json
+++ b/components/vf-box/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-box",
   "description": "vf-box component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-breadcrumbs/package.json
+++ b/components/vf-breadcrumbs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-breadcrumbs",
   "description": "vf-breadcrumbs component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,13 +23,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-list": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-button/package.json
+++ b/components/vf-button/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-button",
   "description": "vf-button component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -27,12 +27,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-code-example/package.json
+++ b/components/vf-code-example/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-code-example",
   "description": "vf-code-example component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-contact/package.json
+++ b/components/vf-contact/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-contact",
   "description": "vf-contact component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -32,5 +32,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-content/package.json
+++ b/components/vf-content/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-content",
   "description": "vf-content component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,23 +23,23 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.18",
-    "@visual-framework/vf-box": "^0.0.18",
-    "@visual-framework/vf-button": "^0.0.18",
-    "@visual-framework/vf-divider": "^0.0.18",
-    "@visual-framework/vf-figure": "^0.0.18",
-    "@visual-framework/vf-form": "^0.0.19",
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-link": "^0.0.18",
-    "@visual-framework/vf-list": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-tag": "^0.0.18",
-    "@visual-framework/vf-text": "^0.0.18",
+    "@visual-framework/vf-blockquote": "^0.0.19",
+    "@visual-framework/vf-box": "^0.0.19",
+    "@visual-framework/vf-button": "^0.0.19",
+    "@visual-framework/vf-divider": "^0.0.19",
+    "@visual-framework/vf-figure": "^0.0.19",
+    "@visual-framework/vf-form": "^0.0.20",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-link": "^0.0.19",
+    "@visual-framework/vf-list": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-tag": "^0.0.19",
+    "@visual-framework/vf-text": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-data-protection-banner/package.json
+++ b/components/vf-data-protection-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-data-protection-banner",
   "description": "vf-data-protection-banner component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -25,15 +25,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.18",
-    "@visual-framework/vf-grid": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-text": "^0.0.18",
+    "@visual-framework/vf-button": "^0.0.19",
+    "@visual-framework/vf-grid": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-text": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-divider/package.json
+++ b/components/vf-divider/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-divider",
   "description": "vf-divider component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-factoid/package.json
+++ b/components/vf-factoid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-factoid",
   "description": "vf-factoid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-text": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-text": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-favicon/package.json
+++ b/components/vf-favicon/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-favison",
   "description": "vf-favison component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,12 +24,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-figure/package.json
+++ b/components/vf-figure/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-figure",
   "description": "vf-figure component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,12 +24,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-font-plex-mono/package.json
+++ b/components/vf-font-plex-mono/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-plex-mono-font",
   "description": "vf-plex-mono-font component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,5 +24,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-font-plex-sans/package.json
+++ b/components/vf-font-plex-sans/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-plex-sans-font",
   "description": "vf-plex-sans-font component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,5 +24,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-footer/package.json
+++ b/components/vf-footer/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.5",
   "name": "@visual-framework/vf-footer",
   "description": "vf-footer component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-form",
   "description": "vf-form component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -33,12 +33,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -13,6 +13,7 @@
     "vf-form__helper",
     "vf-form__input",
     "vf-form__item",
+    "vf-form__helper",
     "vf-form__label",
     "vf-form__radio",
     "vf-form__select",

--- a/components/vf-form/vf-form.config.yml
+++ b/components/vf-form/vf-form.config.yml
@@ -1,4 +1,4 @@
 collated: true
 preview: '@preview--elements'
 context:
-  pattern-type: element
+  pattern-type: block

--- a/components/vf-form/vf-form__checkbox/package.json
+++ b/components/vf-form/vf-form__checkbox/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-form__checkbox",
   "description": "vf-form__checkbox component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.19",
-    "@visual-framework/vf-form__label": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-form__item": "^0.0.20",
+    "@visual-framework/vf-form__label": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/vf-form__checkbox/package.json
+++ b/components/vf-form/vf-form__checkbox/package.json
@@ -8,7 +8,11 @@
   "style": "vf-form__checkbox.css",
   "sass": "index.scss",
   "files": [
-    "index.scss"
+    "index.scss",
+    "vf-form__checkbox.scss",
+    "vf-form__checkbox.css",
+    "vf-form__checkbox.hbs",
+    "vf-form__checkbox.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-form/vf-form__helper/package.json
+++ b/components/vf-form/vf-form__helper/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-form__helper",
   "description": "vf-form__helper component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/vf-form__helper/package.json
+++ b/components/vf-form/vf-form__helper/package.json
@@ -8,7 +8,11 @@
   "style": "vf-form__helper.css",
   "sass": "index.scss",
   "files": [
-    "index.scss"
+    "index.scss",
+    "vf-form__helper.scss",
+    "vf-form__helper.css",
+    "vf-form__helper.hbs",
+    "vf-form__helper.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-form/vf-form__input/package.json
+++ b/components/vf-form/vf-form__input/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-form__input",
   "description": "vf-form__input component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.19",
-    "@visual-framework/vf-form__label": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-form__item": "^0.0.20",
+    "@visual-framework/vf-form__label": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/vf-form__input/package.json
+++ b/components/vf-form/vf-form__input/package.json
@@ -8,7 +8,11 @@
   "style": "vf-form__input.css",
   "sass": "index.scss",
   "files": [
-    "index.scss"
+    "index.scss",
+    "vf-form__input.scss",
+    "vf-form__input.css",
+    "vf-form__input.hbs",
+    "vf-form__input.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-form__item",
   "description": "vf-form__item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,16 +23,16 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__helper": "^0.0.18",
-    "@visual-framework/vf-form__input": "^0.0.19",
-    "@visual-framework/vf-form__item": "^0.0.19",
-    "@visual-framework/vf-form__label": "^0.0.15",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-form__helper": "^0.0.19",
+    "@visual-framework/vf-form__input": "^0.0.20",
+    "@visual-framework/vf-form__item": "^0.0.20",
+    "@visual-framework/vf-form__label": "^0.0.16",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -8,7 +8,11 @@
   "style": "vf-form__item.css",
   "sass": "index.scss",
   "files": [
-    "index.scss"
+    "index.scss",
+    "vf-form__item.scss",
+    "vf-form__item.css",
+    "vf-form__item.hbs",
+    "vf-form__item.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-form/vf-form__label/package.json
+++ b/components/vf-form/vf-form__label/package.json
@@ -8,7 +8,11 @@
   "style": "vf-form__label.css",
   "sass": "index.scss",
   "files": [
-    "index.scss"
+    "index.scss",
+    "vf-form__label.scss",
+    "vf-form__label.css",
+    "vf-form__label.hbs",
+    "vf-form__label.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-form/vf-form__label/package.json
+++ b/components/vf-form/vf-form__label/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-form__label",
   "description": "vf-form__label component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/vf-form__radio/package.json
+++ b/components/vf-form/vf-form__radio/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-form__radio",
   "description": "vf-form__radio component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/vf-form__radio/package.json
+++ b/components/vf-form/vf-form__radio/package.json
@@ -8,7 +8,11 @@
   "style": "vf-form__radio.css",
   "sass": "index.scss",
   "files": [
-    "index.scss"
+    "index.scss",
+    "vf-form__radio.scss",
+    "vf-form__radio.css",
+    "vf-form__radio.hbs",
+    "vf-form__radio.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-form/vf-form__select/package.json
+++ b/components/vf-form/vf-form__select/package.json
@@ -8,7 +8,11 @@
   "style": "vf-form__select.css",
   "sass": "index.scss",
   "files": [
-    "index.scss"
+    "index.scss",
+    "vf-form__select.scss",
+    "vf-form__select.css",
+    "vf-form__select.hbs",
+    "vf-form__select.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-form/vf-form__select/package.json
+++ b/components/vf-form/vf-form__select/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-form__select",
   "description": "vf-form__select component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/vf-form__textarea/package.json
+++ b/components/vf-form/vf-form__textarea/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-form__textarea",
   "description": "vf-form__textarea component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-form/vf-form__textarea/package.json
+++ b/components/vf-form/vf-form__textarea/package.json
@@ -8,7 +8,11 @@
   "style": "vf-form__textarea.css",
   "sass": "index.scss",
   "files": [
-    "index.scss"
+    "index.scss",
+    "vf-form__textarea.scss",
+    "vf-form__textarea.css",
+    "vf-form__textarea.hbs",
+    "vf-form__textarea.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-global-header/package.json
+++ b/components/vf-global-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-global-header",
   "description": "vf-global-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-logo": "^0.0.18",
-    "@visual-framework/vf-navigation": "^0.0.19",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-logo": "^0.0.19",
+    "@visual-framework/vf-navigation": "^0.0.20",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-grid-page/package.json
+++ b/components/vf-grid-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-grid-page",
   "description": "vf-grid-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -22,12 +22,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-grid/package.json
+++ b/components/vf-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-grid",
   "description": "vf-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -22,12 +22,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-header/package.json
+++ b/components/vf-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-header",
   "description": "vf-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,15 +23,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-global-header": "^0.0.19",
-    "@visual-framework/vf-masthead": "^0.0.19",
-    "@visual-framework/vf-navigation": "^0.0.19",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-global-header": "^0.0.20",
+    "@visual-framework/vf-masthead": "^0.0.20",
+    "@visual-framework/vf-navigation": "^0.0.20",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-heading/package.json
+++ b/components/vf-heading/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-heading",
   "description": "vf-heading component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-intro/package.json
+++ b/components/vf-intro/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-intro",
   "description": "vf-intro component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-text": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-text": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-job-description/package.json
+++ b/components/vf-job-description/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-job-description",
   "description": "vf-job-description component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,15 +24,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.18",
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-text": "^0.0.18",
+    "@visual-framework/vf-button": "^0.0.19",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-text": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-link-list/package.json
+++ b/components/vf-link-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-link-list",
   "description": "vf-link-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,13 +24,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-link/package.json
+++ b/components/vf-link/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-link",
   "description": "vf-link component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-list/package.json
+++ b/components/vf-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-list",
   "description": "vf-list component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,12 +26,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-logo/package.json
+++ b/components/vf-logo/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-logo",
   "description": "vf-logo component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,12 +24,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-masthead/package.json
+++ b/components/vf-masthead/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-masthead",
   "description": "vf-masthead component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,13 +24,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-grid": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-navigation/package.json
+++ b/components/vf-navigation/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-navigation",
   "description": "vf-navigation component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,13 +26,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-list": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-news-container/package.json
+++ b/components/vf-news-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-news-container",
   "description": "vf-news-container component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,15 +23,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.18",
-    "@visual-framework/vf-news-item": "^0.0.19",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-section-header": "^0.0.19",
+    "@visual-framework/vf-grid": "^0.0.19",
+    "@visual-framework/vf-news-item": "^0.0.20",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-section-header": "^0.0.20",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-news-item/package.json
+++ b/components/vf-news-item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-news-item",
   "description": "vf-news-item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,15 +26,15 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-link": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-text": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-link": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-text": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-no-js/package.json
+++ b/components/vf-no-js/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.5",
   "name": "@visual-framework/vf-no-js",
   "description": "vf-no-js component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,5 +23,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-page-header/package.json
+++ b/components/vf-page-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-page-header",
   "description": "vf-page-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,13 +23,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-sass-config/package.json
+++ b/components/vf-sass-config/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.15",
+  "version": "0.0.16",
   "name": "@visual-framework/vf-sass-config",
   "description": "vf-sass-config",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,5 +26,5 @@
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-section-header/package.json
+++ b/components/vf-section-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-section-header",
   "description": "vf-section-header component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,13 +24,13 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-snippet/package.json
+++ b/components/vf-snippet/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-snippet",
   "description": "vf-snippet component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,14 +23,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-text": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-text": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-summary-container/package.json
+++ b/components/vf-summary-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-summary-container",
   "description": "vf-summary component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,16 +23,16 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.18",
-    "@visual-framework/vf-grid": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-section-header": "^0.0.19",
-    "@visual-framework/vf-summary": "^0.0.19",
+    "@visual-framework/embl-grid": "^0.0.19",
+    "@visual-framework/vf-grid": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-section-header": "^0.0.20",
+    "@visual-framework/vf-summary": "^0.0.20",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-summary",
   "description": "vf-summary component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -26,14 +26,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-text": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-text": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-tabs/package.json
+++ b/components/vf-tabs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-tabs",
   "description": "vf-tabs component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -25,12 +25,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-tag/package.json
+++ b/components/vf-tag/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-tag",
   "description": "vf-tag component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -27,12 +27,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-text/package.json
+++ b/components/vf-text/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-text",
   "description": "vf-text component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-utility-classes/package.json
+++ b/components/vf-utility-classes/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-utility-classes",
   "description": "A set of utility classes to help quickly prototype, and 'tweak' design.",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -21,12 +21,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-video-container/package.json
+++ b/components/vf-video-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-video-container",
   "description": "vf-video-container component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,16 +23,16 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
-    "@visual-framework/vf-section-header": "^0.0.19",
-    "@visual-framework/vf-video": "^0.0.18",
-    "@visual-framework/vf-video-teaser": "^0.0.19",
+    "@visual-framework/embl-grid": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
+    "@visual-framework/vf-section-header": "^0.0.20",
+    "@visual-framework/vf-video": "^0.0.19",
+    "@visual-framework/vf-video-teaser": "^0.0.20",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-video-teaser/package.json
+++ b/components/vf-video-teaser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.19",
+  "version": "0.0.20",
   "name": "@visual-framework/vf-video-teaser",
   "description": "vf-video-teaser component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,14 +24,14 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.18",
-    "@visual-framework/vf-link": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-heading": "^0.0.19",
+    "@visual-framework/vf-link": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/components/vf-video/package.json
+++ b/components/vf-video/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-video",
   "description": "vf-video component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,12 +23,12 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.15",
+    "@visual-framework/vf-sass-config": "^0.0.16",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",
     "component"
   ],
-  "gitHead": "762fb3f355166edb2f848aab797d224b27e67e84"
+  "gitHead": "0870c59d720332b4708085c82674775eca9e0398"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,6 @@
 {
   "lerna": "0.0.1",
   "packages": [
-    "assets/*",
     "components/**"
   ],
   "version": "independent"


### PR DESCRIPTION
adds vf-form__helper as something that is installed when installing vf-form

adds relevant files to package.json for all form elements so they can be installed separately

changes form to a block as it's comprised of elements

removes `assets/*` from where lerna looks for packages.