### PR TITLE
refactor global-header and divider so that they are full width

### DIFF
--- a/components/vf-divider/README.md
+++ b/components/vf-divider/README.md
@@ -2,6 +2,8 @@
 
 ## About
 
+The `vf-divider` pattern creates a horizontal dividing line to help separate content into their own container chunks.
+
 ## Installation and Implementation
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-divider` with this command.
@@ -17,3 +19,7 @@ The source files included are written in [Sass](http://sass-lang.com)(`scss`). Y
 ```
 
 _Make sure you import any requirements along with the modules._
+
+## Usage
+
+The `vf-divider` does not have to be implemented inside it's own grid container and should rely on the parent `vf-body` to fill the width of the page.

--- a/components/vf-divider/vf-divider.scss
+++ b/components/vf-divider/vf-divider.scss
@@ -3,5 +3,7 @@
 .vf-divider {
   @include divider;
 
+  grid-column: 1 / -1;
+
   margin-bottom: 24px;
 }

--- a/components/vf-global-header/vf-global-header.hbs
+++ b/components/vf-global-header/vf-global-header.hbs
@@ -1,5 +1,11 @@
 <div class="vf-global-header">
-  {{render '@vf-logo--responsive'}}
 
-  {{render '@vf-navigation--tertiary'}}
+  <div class="vf-global-header__inner">
+
+    {{render '@vf-logo--responsive'}}
+
+    {{render '@vf-navigation--tertiary'}}
+
+  </div>
+  
 </div>

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -7,20 +7,21 @@ $vf-global-header__link-text--color: set-color(vf-color-black);
   align-items: center;
   background-color: $vf-global-header-background--color;
   border-bottom: solid 1px set-color(vf-color-gray);
-  display: flex;
   grid-column: 1 / -1;
   height: auto;
-  margin-bottom: .25rem;
-  margin-top: .25rem;
-  padding-bottom: .5rem;
+  margin-bottom: .5rem;
+  padding: .5rem 0;
 }
 
 .vf-global-header__inner {
+  display: flex;
   max-width: 76.5em;
 }
 
 .vf-global-header {
+
   [class*='navigation'] {
+    align-self: center;
     margin-left: auto;
   }
 }

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -6,11 +6,17 @@ $vf-global-header__link-text--color: set-color(vf-color-black);
 .vf-global-header {
   align-items: center;
   background-color: $vf-global-header-background--color;
+  border-bottom: solid 1px set-color(vf-color-gray);
   display: flex;
-  grid-column: 2 / -2;
+  grid-column: 1 / -1;
   height: auto;
   margin-bottom: .25rem;
   margin-top: .25rem;
+  padding-bottom: .5rem;
+}
+
+.vf-global-header__inner {
+  max-width: 76.5em;
 }
 
 .vf-global-header {

--- a/components/vf-snippet/vf-snippet.config.yml
+++ b/components/vf-snippet/vf-snippet.config.yml
@@ -1,6 +1,8 @@
 title: The Snippet
 label: Snippet
 preview: '@preview--blocks'
+hidden: true
+status: deprecated
 context:
   pattern-type: block
   snippet-heading: EMBL's top social media posts of 2017 and what we learned from them

--- a/components/vf-summary/vf-summary--article.hbs
+++ b/components/vf-summary/vf-summary--article.hbs
@@ -1,0 +1,15 @@
+<article class="vf-summary vf-summary--article">
+
+  <h3 class="vf-summary__title | vf-text vf-text--heading-r">
+    <a href="JavaScript:Void(0);" class="vf-link">EMBL's top social media posts of 2017 and what we learned from them</a>
+  </h3>
+
+  <div class="vf-summary__meta">
+    <a href="JavaScript:Void(0);" class="vf-summary__author | vf-link | vf-text vf-text--body-r">Laura Howes</a>
+    <p class="vf-summary__date | vf-text--body-r">06 February 2018</p>
+    <a href="JavaScript:Void(0);" class="vf-link | vf-text vf-text--body-r">Leave Comment</a>
+  </div>
+
+  <p class="vf-summary__text | vf-text vf-text--body-l">I want to take a look back at my first full year as EMBL's social media manager. So what worked best over 2017 and what can I learn from this? My basic goals for VF’s social media are to build community and develop a shared understanding of who we as an organisation are. Consequently, I care about what resonates on the different social sites much more than driving traffic back to Visual Framework websites, although traffic is obviously a by-product.</p>
+
+</article>

--- a/components/vf-summary/vf-summary--news-has-image.hbs
+++ b/components/vf-summary/vf-summary--news-has-image.hbs
@@ -4,7 +4,7 @@
       {{ summary__title }}
     </a>
   </h3>
-  <p class="vf-summary__text | vf-text vf-text--body--l">
+  <p class="vf-summary__text | vf-text vf-text--body-l">
     Combinations of cancer drugs can be quickly and cheaply tested using a novel microfluidic device.
   </p>
   <span class="vf-summary__date | vf-text vf-text--body-s">22 June 2018</span>

--- a/components/vf-summary/vf-summary--news.hbs
+++ b/components/vf-summary/vf-summary--news.hbs
@@ -4,7 +4,7 @@
       {{ summary__title }}
     </a>
   </h3>
-  <p class="vf-summary__text | vf-text vf-text--body--l">
+  <p class="vf-summary__text | vf-text vf-text--body-l">
     Combinations of cancer drugs can be quickly and cheaply tested using a novel microfluidic device.
     <span class="vf-summary__category | vf-text--body vf-text--body-s">
       General

--- a/components/vf-summary/vf-summary.scss
+++ b/components/vf-summary/vf-summary.scss
@@ -88,3 +88,39 @@
     grid-column: 1 / -1;
   }
 }
+
+.vf-summary--article {
+  .vf-summary__meta {
+    align-items: center;
+    display: flex;
+    margin-bottom: 24px;
+
+    > * {
+      margin: 0;
+    }
+  }
+  .vf-summary__author {
+    margin-right: 12px;
+    position: relative;
+    &::after {
+      color: set-color(vf-color-black);
+      content: ',';
+      font-family: inherit;
+      font-size: inherit;
+      position: absolute;
+      right: -6px;
+    }
+  }
+  .vf-summary__date {
+    margin-right: 24px;
+    position: relative;
+
+    &::after {
+      content: ' — ';
+      font-family: inherit;
+      font-size: inherit;
+      position: absolute;
+      right: -18px;
+    }
+  }
+}


### PR DESCRIPTION
note:

The global-header now has a bottom border and is full-width. The global-header also has.a inner container for content as the bottom border needs to be full-width.

the vf-divider does not need a containing grid div, it should rely on the parent - so for landing pages it should rely on `vf-body` to determine that it should be full-width without the need for extra 'tag soup'