### PR TITLE
Fix code to use monospace

### DIFF
--- a/components/vf-code-example/vf-code-example.scss
+++ b/components/vf-code-example/vf-code-example.scss
@@ -6,10 +6,7 @@
 .vf-code-example__pre,
 .vf-code-example {
   // pre and code should always be monospace
-  @if $use-global-typography == true {
-    font-family: $vf-font-family-monospace;
-  }
-  @include set-type(body--s);
+  @include set-type(body--s,$vf-font-family-monospace);
 }
 
 .vf-code-example {

--- a/components/vf-font-plex-mono/vf-font-plex-mono.scss
+++ b/components/vf-font-plex-mono/vf-font-plex-mono.scss
@@ -1,8 +1,7 @@
 // vf-font-plex-mono
 
 // $use-global-typography: false;
-$vf-font-family-monospace: 'IBM Plex Mono', Monaco, Consolas, 'Lucida Console',
-  monospace;
+// $vf-font-family-monospace: 'IBM Plex Mono', Monaco, Consolas, 'Lucida Console', monospace;
 
 // html,
 // button {

--- a/components/vf-font-plex-mono/vf-font-plex-mono.scss
+++ b/components/vf-font-plex-mono/vf-font-plex-mono.scss
@@ -1,12 +1,4 @@
 // vf-font-plex-mono
 
-// $use-global-typography: false;
-// $vf-font-family-monospace: 'IBM Plex Mono', Monaco, Consolas, 'Lucida Console', monospace;
-
-// html,
-// button {
-//   font-family: $vf-font-family-monospace;
-// }
-
 $font-prefix: '../assets/vf-font-plex-mono/assets' !default;
 @import 'assets/scss/ibm-plex.scss'

--- a/components/vf-font-plex-sans/vf-font-plex-sans.scss
+++ b/components/vf-font-plex-sans/vf-font-plex-sans.scss
@@ -1,11 +1,4 @@
 // vf-font-plex-mono
 
-// $use-global-typography: false;
-$vf-font-family-sans-serif: 'IBM Plex Sans', Helvetica, Arial, sans-serif;
-
-// html, button {
-//   font-family: $vf-font-family-monospace;
-// }
-
 $font-prefix: '../assets/vf-font-plex-sans/assets' !default;
 @import 'assets/scss/ibm-plex.scss'


### PR DESCRIPTION
Was being unset by `set-type` not receiving a font family and thus using the global (plex sans)