### PR TITLE
Fix/vf tabs

### DIFF
--- a/components/vf-tabs/vf-tabs.hbs
+++ b/components/vf-tabs/vf-tabs.hbs
@@ -1,5 +1,5 @@
 <div class="vf-tabs">
-  <ul class="vf-tabs__list" data-vf-tbas_list>
+  <ul class="vf-tabs__list" data-vf-js-tabs>
     <li class="vf-tabs__item">
       <a class="vf-tabs__link" href="#vf-tabs__section--1">Section</a>
     </li>
@@ -15,7 +15,7 @@
   </ul>
 </div>
 
-<div class="vf-tabs-content">
+<div class="vf-tabs-content" data-vf-js-tabs-content>
   <section class="vf-tabs__section" id="vf-tabs__section--1">
     <h2>Section 1</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam euismod, tortor nec pharetra ultricies, ante erat imperdiet velit, nec laoreet enim lacus a velit. <a href="#">Nam luctus</a>, enim in interdum condimentum, nisl diam iaculis lorem, vel volutpat mi leo sit amet lectus. Praesent non odio bibendum magna bibendum accumsan.</p>
@@ -33,7 +33,7 @@
     <p>Nam luctus, enim in interdum condimentum, nisl diam iaculis lorem, vel volutpat mi leo sit amet lectus. Praesent non odio bibendum magna bibendum accumsan. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam euismod, tortor nec pharetra ultricies, ante erat imperdiet velit, nec laoreet enim lacus a velit. </p>
 
     <div class="vf-tabs">
-      <ul class="vf-tabs__list" data-vf-tbas_list>
+      <ul class="vf-tabs__list" data-vf-js-tabs>
         <li class="vf-tabs__item">
           <a class="vf-tabs__link" href="#vf-tabs__section-nested--1">Nested tab 1</a>
         </li>
@@ -43,7 +43,7 @@
       </ul>
     </div>
 
-    <div class="vf-tabs-content">
+    <div class="vf-tabs-content" data-vf-js-tabs-content>
       <section class="vf-tabs__section" id="vf-tabs__section-nested--1">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam euismod, tortor nec pharetra ultricies, ante erat imperdiet velit, nec laoreet enim lacus a velit. <a href="#">Nam luctus</a>, enim in interdum condimentum, nisl diam iaculis lorem, vel volutpat mi leo sit amet lectus. Praesent non odio bibendum magna bibendum accumsan.</p>
       </section>
@@ -58,7 +58,7 @@
 
 
 <div class="vf-tabs">
-  <ul class="vf-tabs__list" data-vf-tbas_list>
+  <ul class="vf-tabs__list" data-vf-js-tabs>
     <li class="vf-tabs__item">
       <a class="vf-tabs__link" href="#vf-tabs__section--10">Second tab set</a>
     </li>
@@ -68,7 +68,7 @@
   </ul>
 </div>
 
-<div class="vf-tabs-content">
+<div class="vf-tabs-content" data-vf-js-tabs-content>
   <section class="vf-tabs__section" id="vf-tabs__section--10">
     <h2>Section 10</h2>
   </section>

--- a/components/vf-tabs/vf-tabs.hbs
+++ b/components/vf-tabs/vf-tabs.hbs
@@ -1,5 +1,5 @@
 <div class="vf-tabs">
-  <ul class="vf-tabs__list">
+  <ul class="vf-tabs__list" data-vf-tbas_list>
     <li class="vf-tabs__item">
       <a class="vf-tabs__link" href="#vf-tabs__section--1">Section</a>
     </li>
@@ -33,7 +33,7 @@
     <p>Nam luctus, enim in interdum condimentum, nisl diam iaculis lorem, vel volutpat mi leo sit amet lectus. Praesent non odio bibendum magna bibendum accumsan. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam euismod, tortor nec pharetra ultricies, ante erat imperdiet velit, nec laoreet enim lacus a velit. </p>
 
     <div class="vf-tabs">
-      <ul class="vf-tabs__list">
+      <ul class="vf-tabs__list" data-vf-tbas_list>
         <li class="vf-tabs__item">
           <a class="vf-tabs__link" href="#vf-tabs__section-nested--1">Nested tab 1</a>
         </li>
@@ -53,5 +53,26 @@
     </div>
 
 
+  </section>
+</div>
+
+
+<div class="vf-tabs">
+  <ul class="vf-tabs__list" data-vf-tbas_list>
+    <li class="vf-tabs__item">
+      <a class="vf-tabs__link" href="#vf-tabs__section--10">Second tab set</a>
+    </li>
+    <li class="vf-tabs__item">
+      <a class="vf-tabs__link" href="#vf-tabs__section--11">Tab</a>
+    </li>
+  </ul>
+</div>
+
+<div class="vf-tabs-content">
+  <section class="vf-tabs__section" id="vf-tabs__section--10">
+    <h2>Section 10</h2>
+  </section>
+  <section class="vf-tabs__section" id="vf-tabs__section--11">
+    <h2>Section 11</h2>
   </section>
 </div>

--- a/components/vf-tabs/vf-tabs.js
+++ b/components/vf-tabs/vf-tabs.js
@@ -7,12 +7,15 @@
 function vfTabs() {
   // Get relevant elements and collections
   // todo: `document` here should be a scopped passed param like #mydiv or .my-div
-  const tablist = document.querySelectorAll('[data-vf-tabs_list]');
-  const tabsSection = "vf-tabs__section--";
-  const panelsList = document.querySelectorAll('.vf-tabs-content');
-  const panels = document.querySelectorAll('[id^="vf-tabs__section"]');
-  const tabs = document.querySelectorAll('.vf-tabs__link');
+  const tablist = document.querySelectorAll('[data-vf-js-tabs]');
+  const panelsList = document.querySelectorAll('[data-vf-js-tabs-content]');
+  const panels = document.querySelectorAll('[data-vf-js-tabs-content] [id^="vf-tabs__section"]');
+  const tabs = document.querySelectorAll('[data-vf-js-tabs] .vf-tabs__link');
   if (!tablist || !panels || !tabs) {
+    // exit: either tabs or tabbed content not found
+    return;
+  }
+  if (tablist.length == 0 || panels.length == 0 || tabs.length == 0) {
     // exit: either tabs or tabbed content not found
     return;
   }

--- a/components/vf-tabs/vf-tabs.js
+++ b/components/vf-tabs/vf-tabs.js
@@ -1,3 +1,5 @@
+// document.
+
 /**
  * Finds all tabs on a page and activates them
  * @example vfTabs()
@@ -5,7 +7,7 @@
 function vfTabs() {
   // Get relevant elements and collections
   // todo: `document` here should be a scopped passed param like #mydiv or .my-div
-  const tablist = document.querySelectorAll('.vf-tabs__list');
+  const tablist = document.querySelectorAll('[data-vf-tabs_list]');
   const tabsSection = "vf-tabs__section--";
   const panelsList = document.querySelectorAll('.vf-tabs-content');
   const panels = document.querySelectorAll('[id^="vf-tabs__section"]');

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/panel-resources.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/panel-resources.nunj
@@ -4,7 +4,7 @@
 <h3 class="vf-text vf-text--heading-r">Resources and files</h3>
 
 <div class="vf-tabs">
-  <ul class="vf-tabs__list">
+  <ul class="vf-tabs__list" data-vf-js-tabs>
     <!--<li class="vf-tabs__item">Pattern files</li>-->
     {% for resource in collection.items() %}
       {% if resource.base != 'package-lock.json' %}
@@ -16,7 +16,7 @@
   </ul>
 
 </div>
-<div class="vf-tabs-content">
+<div class="vf-tabs-content" data-vf-js-tabs-content>
   {% for resource in collection.items() %}
     {% if resource.base != 'package-lock.json' %}
     <section class="vf-tabs__section" id="vf-tabs__section--{{ resource.id }}">

--- a/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/panel-resources.nunj
+++ b/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/panel-resources.nunj
@@ -4,7 +4,7 @@
 <h3 class="vf-text vf-text--heading-r">Resources and files</h3>
 
 <div class="vf-tabs">
-  <ul class="vf-tabs__list">
+  <ul class="vf-tabs__list" data-vf-js-tabs>
     <!--<li class="vf-tabs__item">Pattern files</li>-->
     {% for resource in collection.items() %}
       {% if resource.base != 'package-lock.json' %}
@@ -16,7 +16,7 @@
   </ul>
 
 </div>
-<div class="vf-tabs-content">
+<div class="vf-tabs-content" data-vf-js-tabs-content>
   {% for resource in collection.items() %}
     {% if resource.base != 'package-lock.json' %}
     <section class="vf-tabs__section" id="vf-tabs__section--{{ resource.id }}">

--- a/tools/frctl-mandelbrot-vf-subtheme/views/partials/scripts.nunj
+++ b/tools/frctl-mandelbrot-vf-subtheme/views/partials/scripts.nunj
@@ -1,5 +1,6 @@
 {% for script in frctl.theme.get('scripts') %}
-<script src="{{ path(script) }}?cachebust={{ frctl.theme.get('version') }}"></script>
+<!--<script src="{{ path(script) }}?cachebust={{ frctl.theme.get('version') }}"></script>-->
+{% endfor %}
 {% if frctl.env.server %}
 <script src="{{ path('/scripts/scripts.js') }}?cachebust={{ frctl.theme.get('version') }}"></script>
 {% else %}
@@ -22,4 +23,3 @@
     }
   }
 </script>
-{% endfor %}


### PR DESCRIPTION
Fixes #129. 

Basically the problem was that when there was more than one tab set on a page and the first tab set wasn't JS tabs, it was throwing off indexes. 

This fix adds in data attributes:
```
<ul class="vf-tabs__list" data-vf-js-tabs>
```
```
<div class="vf-tabs-content" data-vf-js-tabs-content>
```

This means when there are non-JS tabs, data attributes can be left off and all works well. 