### PR TITLE
Docs/further seperate embl from vf core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # CHANGELOG
 
-See http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/changelog
+See https://visual-framework.github.io/vf-core/changelog

--- a/README.md
+++ b/README.md
@@ -1,25 +1,33 @@
 # Visual Framework 2.0
 
+---
+
+**👋 Downloading or cloning this repo? 🛑**
+
+Usually you don't need this whole repo. Only clone this repo if you wish to further develop the Visual Framework core or contribute a global pattern, otherwise: [see the "Get Started" section](#get-started).
+
+---
+
 ## What is this?
 
-This framework is designed with the needs of life science websites and services. It goes beyond guidance for tables, graphs, data-heavy typography and focuses on being sane defaults and implements its CSS in a way that won't interfere with your existing patterns that use Bootstrap, Angular, or something else.
+The Visual Framework (VF) is designed with the needs of life science websites and services. It goes beyond guidance for tables, graphs, data-heavy typography and focuses on being sane defaults and implements its CSS in a way that won't interfere with your existing patterns that use Bootstrap, Angular, or something else.
 
-The VF 2.0 is extensible, modular and overridable; it's there to help and not get in the way.
+The VF 2.0 enables consistency and portability, it is extensible, modular and overridable; here to help and not get in the way.
 
-- Demo:
-  - [Online pattern library](https://dev.beta.embl.org/guidelines/visual-framework/dev-docs)
-  - [Changelog](https://github.com/visual-framework/vf-core/blob/develop/docs/changelog/index.md)
-- Philosophy:
-  - [Aims of the VF 2.0](https://blogs.embl.org/communications/2018/09/12/faster-scientific-websites-through-reusability/)
-  - [Principles and Methods](https://dev.beta.embl.org/guidelines/visual-framework/principles-methods/)
-- Help out:
-  - [Contributing guide](https://github.com/visual-framework/vf-core/blob/develop/CONTRIBUTING.md)
-  - [Request a pattern](https://github.com/visual-framework/vf-core/issues/new?template=new-pattern-request.md)
-  - [Make a new pattern](https://dev.beta.embl.org/guidelines/visual-framework/dev-docs/docs/guidelines.html)
-- Make it your own:
-  - [Clone the child theme template](https://github.com/khawkins98/vf-child-playground)
+- **Demo:** &nbsp;
+[Online pattern library](https://visual-framework.github.io/vf-core)
+&nbsp; § &nbsp; [Changelog](https://github.com/visual-framework/vf-core/blob/develop/docs/changelog/index.md)
+- **Philosophy:** &nbsp;
+[Aims of the VF 2.0](https://blogs.embl.org/communications/2018/09/12/faster-scientific-websites-through-reusability/)
+&nbsp; § &nbsp; [Principles and Methods](https://dev.beta.embl.org/guidelines/visual-framework/principles-methods/)
+- **Help out:** &nbsp;
+[Contributing guide](https://github.com/visual-framework/vf-core/blob/develop/CONTRIBUTING.md)
+&nbsp; § &nbsp; [Request a pattern](https://github.com/visual-framework/vf-core/issues/new?template=new-pattern-request.md)
+&nbsp; § &nbsp; [Make a new pattern](https://visual-framework.github.io/vf-core/docs/guidelines.html)
+- **Make it your own:** &nbsp;
+[Clone the child theme template](https://github.com/khawkins98/vf-child-playground)
 
-### Why use this?
+### Why a VF?
 
 The Visual Framework address three major needs:
 
@@ -39,22 +47,23 @@ The Visual Framework address three major needs:
 
 ### Get started
 
-Here's three ways you can make use of the Visual Framework.
+Here are ways to utilise the Visual Framework:
 
-1. 🏎 Utilise the whole, unaltered Framework: include the [CSS, JS and copy a boilerplate](https://dev.beta.embl.org/guidelines/visual-framework/dev-docs/components/render/vf-boilerplate-page)
+1. 🛍 [Browse the online patterns](https://visual-framework.github.io/vf-core)
+1. 🏎 Utilise the whole, unaltered Framework: include the [CSS, JS and copy a boilerplate](https://visual-framework.github.io/vf-core/components/render/vf-boilerplate-page)
 1. 🚰 [Install a specific pattern from npm](https://www.npmjs.com/org/visual-framework) and include the Sass/JS
-1. 🏗 Or customise the framework with [your own Visual Framework child theme](https://github.com/khawkins98/vf-child-playground)
+1. 🏗 Get a custom look and patterns with [your own Visual Framework child theme](https://github.com/khawkins98/vf-child-playground)
 
-**Should you install/clone this repo?**
+---
 
-Usually: no. Only clone this repo if you wish to further develop the Visual Framework core or contribute a global pattern, otherwise follow one of the bullets above.
+## 🚧 ✍ Developing, contributing
 
 ### How do I make my own theme or customise patterns?
 
 <a id="childtheme"></a>Unless you want to tweak the core patterns or the build process, there's really little reason to customise this repo. If your desire is to make your own theme or patterns, you should follow a guide on:
 
-1. 🚧 [Set up your own child theme](https://github.com/khawkins98/vf-child-playground), and then:
-2. 🎨 [Add your own patterns to the new child theme](https://github.com/khawkins98/vf-child-playground#make-and-edit-patterns; finally:
+1. 🏗  [Set up your own child theme](https://github.com/khawkins98/vf-child-playground), and then:
+2. 🎨 [Add your own patterns to the new child theme](https://github.com/khawkins98/vf-child-playground#make-and-edit-patterns); finally:
 3. 🍻 Bonus! [Contribute patterns this core Visual Framework](https://github.com/khawkins98/vf-child-playground#contribute-new-patterns-back-to-the-global-vf-core)
 
 ### I have an idea or concern!
@@ -131,20 +140,34 @@ This codebase includes a folder and file creation tool. It allows you to quickly
 1. Install Yeoman
    - If you've come this far and you don't have `yo`, you should be able to install it with `npm install -g yo@latest`
    - If you get stuck, [see the official install guide](http://yeoman.io/codelab/setup.html)
-2. Create a new component
-   - You will need to use the vf-font-monospace-stack `gulp component` and answer the questions when prompted.
+1. Create a new component
+   - Run `gulp component` and answer the questions when prompted.
        - **Type of component:** We use a variation of the atomic design methodology, [read about the differences here](http://bradfrost.com/blog/post/atomic-web-design/#atoms). We use: elements, blocks, and containers.
            - an element would be a heading, or a button
            - a block would be a teaser, or a search form
            - a container would be a group of teasers
        - **Name of component:** Go for something simple and obvious (todo: we need a guide/documentation on how we name things). Don't worry about namespacing and prefixing, the tooling will take care of this.
        - **NPM package:** If you're making something interesting (probably not an 'element'), then saying 'yes' will allow the component to be shared as an optional part of the framework on NPM.
-3. Developing your component
-   - Detailed guide to come, but for now edit the new files and develop with `gulp dev`
-4. Sharing you component back
-   - If you didn't make it an NPM package: Make a pull request?
-   - If it is an NPM package: Submit guide here?
+    - You customised template pattern will have been added to your `/components` directory.
+1. Add the `@import 'vfc-your-pattern.scss';` to `/assets/scss/styles.scss`.
+1. Developing your component
+   - Edit your template files in the `/components/your-pattern-name` folder
+   - Run `gulp dev` to compile and preview the pattern
+1. Sharing you component back
+   - Publish it to npm; or
+   - If you think your pattern is of use to the wider `vf-core` community, [make a Pull Request](https://github.com/visual-framework/vf-core/pulls).
 
-## Design Tokens
+## Global colour, typography and spacing.
 
-The [Design Token concept](https://medium.com/eightshapes-llc/tokens-in-design-systems-25dd82d58421) specifies design (colour, spacing, type) as reusable JSON or YAML that are translated from `.yml` data into `.scss` using [Theo](https://github.com/salesforce-ux/theo#-theo).
+The Visual Framework uses the [Design Token concept](https://medium.com/eightshapes-llc/tokens-in-design-systems-25dd82d58421) to specify design (colour, spacing, type) as reusable JSON or YAML that are translated from `.yml` data into `.scss` using [Theo](https://github.com/salesforce-ux/theo#-theo).
+
+This Design Token abstraction [helps portability and integration](https://uxdesign.cc/design-tokens-for-dummies-8acebf010d71) with other technical systems.
+
+You can find the Design Tokens in `components/vf-design-tokens`.
+
+## Language and spelling of documentation, code
+
+The `vf-core` project is being led by EMBL where British English and we're aware that most code is American English (`colour` vs `color`); so:
+
+- 📚🇬🇧 Documentation is written in British English 💂‍ `I like the centred text and colours`
+- ⌨️🇺🇸 Code is written in American english 🧢 `$vf-main-color: green;`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usually you don't need this whole repo. Only clone this repo if you wish to furt
 
 ---
 
-## What is this?
+## 🎫 What is this?
 
 The Visual Framework (VF) is designed with the needs of life science websites and services. It goes beyond guidance for tables, graphs, data-heavy typography and focuses on being sane defaults and implements its CSS in a way that won't interfere with your existing patterns that use Bootstrap, Angular, or something else.
 
@@ -27,12 +27,20 @@ The VF 2.0 enables consistency and portability, it is extensible, modular and ov
 - **Make it your own:** &nbsp;
 [Clone the child theme template](https://github.com/khawkins98/vf-child-playground)
 
-### Why a VF?
+### ⏰ When will this be ready?
+
+- This is a v2.0 that was imagined in 2017 and development began in the summer of 2018.
+- As of January 2019 we're in early alpha.
+- We're hopeful a beta could be ready before summer 2018.
+
+Watch the [releases](https://github.com/visual-framework/vf-core/releases) and let us know your feedback: [issues](https://github.com/visual-framework/vf-core/issues) or [email](mailto:ken.hawkins@embl.de).
+
+### 🤔 Why a VF?
 
 The Visual Framework address three major needs:
 
-1. ⚗️🌳 Life Sciences: We address common needs for the Life Science websites. The Visual Framework can be easily tailored to niche needs, but out of the box it's pleasant looking, but dry and serious to support focus, clarity and data.
-1. 🏚 Compatibility: the Visual Framework is designed to work with other frameworks (both CSS, like Bootstrap, and JS, like React or Angular). We mainly achieve this by:
+1. ⚗️🌳 Life sciences: We address common needs for [life science websites](https://www.ebi.ac.uk/services). The Visual Framework can be easily tailored to niche needs, but out of the box it's pleasant looking, but dry and serious to support focus, clarity and data.
+1. 🏰 Share only what you need to: the Visual Framework is designed to work with other frameworks (both CSS, like Bootstrap, and JS, like React or Angular). This allows common patterns (and brand design) to be shared between sites without cross-contaminating into another framework. We mainly achieve this by:
    - Name spacing all selectors for CSS or JS (`vf-*`)
    - No CSS styling on HTML elements. We only attached to name spaced classes, that is:
       - ✅ `.vf-button {}`
@@ -40,14 +48,14 @@ The Visual Framework address three major needs:
       - 🚫 `button {}`
       - 🚫🙊🙉 `div.button {}`
    - 🖕 This necessarily requires a bit more class writing, but it ensures the Visual Framework won't break existing code.
+   - BYOJS: Bring your own JavaScript. We've included only a minimal amount of JS in patterns and it's fully optional (just remove the JavaScript selectors). So if you'd rather use Angular or Bootstrap for your tabs, the Visual Framework won't get in the way.
 1. 🌕🌜 Use a little or a lot:
    - A lot: The framework (and [child theme template](https://github.com/khawkins98/vf-child-playground)) will generate a monolithic `styles.css` and `script.js` that can be easily included, a la Bootstrap.
    - A little: Instead you can include `.scss` partials or per-pattern `.css` and `.js` files. You can do this through making a [child theme](https://github.com/khawkins98/vf-child-playground) or [npm installs](https://www.npmjs.com/org/visual-framework).
-1. ☕️ BYOJS: Bring your own JavaScript. We've included only a minimal amount of JS in patterns and it's fully optional (just remove the JavaScript selectors). So if you'd rather use Angular or Bootstrap for your tabs, the Visual Framework won't get in the way.
 
-### Get started
+### 🚼 Get started
 
-Here are ways to utilise the Visual Framework:
+<a id="get-started"></a>Here are ways to utilise the Visual Framework:
 
 1. 🛍 [Browse the online patterns](https://visual-framework.github.io/vf-core)
 1. 🏎 Utilise the whole, unaltered Framework: include the [CSS, JS and copy a boilerplate](https://visual-framework.github.io/vf-core/components/render/vf-boilerplate-page)
@@ -169,5 +177,5 @@ You can find the Design Tokens in `components/vf-design-tokens`.
 
 The `vf-core` project is being led by EMBL where British English and we're aware that most code is American English (`colour` vs `color`); so:
 
-- 📚🇬🇧 Documentation is written in British English 💂‍ `I like the centred text and colours`
+- 📚🇬🇧 Documentation is written in British English 💂‍ `Rarely use centred text, always use colours`
 - ⌨️🇺🇸 Code is written in American english 🧢 `$vf-main-color: green;`

--- a/components/vf-activity-group/package.json
+++ b/components/vf-activity-group/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-activity-group",
   "description": "vf-activity-group component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-activity-group.css",

--- a/components/vf-activity-list/package.json
+++ b/components/vf-activity-list/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-activity-list",
   "description": "vf-activity-list component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-activity-list.css",

--- a/components/vf-article-meta-information/package.json
+++ b/components/vf-article-meta-information/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.6",
   "name": "@visual-framework/vf-article-meta-information",
   "description": "vf-article-meta-information component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-article-meta-information.css",

--- a/components/vf-badge/package.json
+++ b/components/vf-badge/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-badge",
   "description": "vf-badge component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-badge.css",

--- a/components/vf-banner/package.json
+++ b/components/vf-banner/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.6",
   "name": "@visual-framework/vf-banner",
   "description": "vf-banner component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-banner.css",

--- a/components/vf-blockquote/package.json
+++ b/components/vf-blockquote/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-blockquote",
   "description": "vf-blockquote component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-blockquote.css",

--- a/components/vf-boilerplate-page/package.json
+++ b/components/vf-boilerplate-page/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.6",
   "name": "@visual-framework/vf-boilerplate-page",
   "description": "vf-boilerplate-page component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "main": "build/index.js",

--- a/components/vf-box/package.json
+++ b/components/vf-box/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-box",
   "description": "vf-box component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-box.css",

--- a/components/vf-breadcrumbs/package.json
+++ b/components/vf-breadcrumbs/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.22",
   "name": "@visual-framework/vf-breadcrumbs",
   "description": "vf-breadcrumbs component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-breadcrumbs.css",

--- a/components/vf-button/package.json
+++ b/components/vf-button/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-button",
   "description": "vf-button component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-button.css",

--- a/components/vf-code-example/package.json
+++ b/components/vf-code-example/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-code-example",
   "description": "vf-code-example component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-code-example.css",

--- a/components/vf-contact/package.json
+++ b/components/vf-contact/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.17",
   "name": "@visual-framework/vf-contact",
   "description": "vf-contact component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-contact.css",

--- a/components/vf-content/package.json
+++ b/components/vf-content/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-content",
   "description": "vf-content component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-content.css",

--- a/components/vf-data-protection-banner/package.json
+++ b/components/vf-data-protection-banner/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-data-protection-banner",
   "description": "vf-data-protection-banner component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-data-protection-banner.css",

--- a/components/vf-divider/package.json
+++ b/components/vf-divider/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-divider",
   "description": "vf-divider component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-divider.css",

--- a/components/vf-factoid/package.json
+++ b/components/vf-factoid/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-factoid",
   "description": "vf-factoid component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-factoid.css",

--- a/components/vf-favicon/package.json
+++ b/components/vf-favicon/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-favison",
   "description": "vf-favison component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-favison.css",

--- a/components/vf-figure/package.json
+++ b/components/vf-figure/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-figure",
   "description": "vf-figure component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-figure.css",

--- a/components/vf-font-plex-mono/package.json
+++ b/components/vf-font-plex-mono/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.17",
   "name": "@visual-framework/vf-plex-mono-font",
   "description": "vf-plex-mono-font component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-plex-mono-font.css",

--- a/components/vf-font-plex-sans/package.json
+++ b/components/vf-font-plex-sans/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.17",
   "name": "@visual-framework/vf-plex-sans-font",
   "description": "vf-plex-sans-font component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-plex-sans-font.css",

--- a/components/vf-footer/package.json
+++ b/components/vf-footer/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.6",
   "name": "@visual-framework/vf-footer",
   "description": "vf-footer component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "build/vf-footer.css",

--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-form",
   "description": "vf-form component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-form.css",

--- a/components/vf-global-header/package.json
+++ b/components/vf-global-header/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-global-header",
   "description": "vf-global-header component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-global-header.css",

--- a/components/vf-grid-page/package.json
+++ b/components/vf-grid-page/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-grid-page",
   "description": "vf-grid-page component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-grid-page.css",

--- a/components/vf-grid/package.json
+++ b/components/vf-grid/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-grid",
   "description": "vf-grid component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-grid.css",

--- a/components/vf-header/package.json
+++ b/components/vf-header/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-header",
   "description": "vf-header component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-header.css",

--- a/components/vf-heading/package.json
+++ b/components/vf-heading/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-heading",
   "description": "vf-heading component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-heading.css",

--- a/components/vf-intro/package.json
+++ b/components/vf-intro/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-intro",
   "description": "vf-intro component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-intro.css",

--- a/components/vf-job-description/package.json
+++ b/components/vf-job-description/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-job-description",
   "description": "vf-job-description component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-job-description.css",

--- a/components/vf-link-list/package.json
+++ b/components/vf-link-list/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-link-list",
   "description": "vf-link-list component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-link-list.css",

--- a/components/vf-link/package.json
+++ b/components/vf-link/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-link",
   "description": "vf-link component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-link.css",

--- a/components/vf-list/package.json
+++ b/components/vf-list/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-list",
   "description": "vf-list component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-list.css",

--- a/components/vf-logo/package.json
+++ b/components/vf-logo/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-logo",
   "description": "vf-logo component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-logo.css",

--- a/components/vf-masthead/package.json
+++ b/components/vf-masthead/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-masthead",
   "description": "vf-masthead component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-masthead.css",

--- a/components/vf-navigation/package.json
+++ b/components/vf-navigation/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-navigation",
   "description": "vf-navigation component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-navigation.css",

--- a/components/vf-news-container/package.json
+++ b/components/vf-news-container/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-news-container",
   "description": "vf-news-container component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-news-container.css",

--- a/components/vf-news-item/package.json
+++ b/components/vf-news-item/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-news-item",
   "description": "vf-news-item component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-news-item.css",

--- a/components/vf-no-js/package.json
+++ b/components/vf-no-js/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.6",
   "name": "@visual-framework/vf-no-js",
   "description": "vf-no-js component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "build/vf-no-js.css",

--- a/components/vf-page-header/package.json
+++ b/components/vf-page-header/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-page-header",
   "description": "vf-page-header component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-page-header.css",

--- a/components/vf-sass-config/package.json
+++ b/components/vf-sass-config/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.17",
   "name": "@visual-framework/vf-sass-config",
   "description": "vf-sass-config",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "files": [

--- a/components/vf-section-header/package.json
+++ b/components/vf-section-header/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-section-header",
   "description": "vf-section-header component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-section-header.css",

--- a/components/vf-snippet/package.json
+++ b/components/vf-snippet/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-snippet",
   "description": "vf-snippet component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-snippet.css",

--- a/components/vf-summary-container/package.json
+++ b/components/vf-summary-container/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-summary-container",
   "description": "vf-summary component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-summary.css",

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-summary",
   "description": "vf-summary component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-summary.css",

--- a/components/vf-tabs/package.json
+++ b/components/vf-tabs/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-tabs",
   "description": "vf-tabs component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-tabs.css",

--- a/components/vf-tag/package.json
+++ b/components/vf-tag/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-tag",
   "description": "vf-tag component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-tag.css",

--- a/components/vf-text/package.json
+++ b/components/vf-text/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-text",
   "description": "vf-text component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-text.css",

--- a/components/vf-utility-classes/package.json
+++ b/components/vf-utility-classes/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-utility-classes",
   "description": "A set of utility classes to help quickly prototype, and 'tweak' design.",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-utility-classes.css",

--- a/components/vf-video-container/package.json
+++ b/components/vf-video-container/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-video-container",
   "description": "vf-video-container component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-video-container.css",

--- a/components/vf-video-teaser/package.json
+++ b/components/vf-video-teaser/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.21",
   "name": "@visual-framework/vf-video-teaser",
   "description": "vf-video-teaser component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-video-teaser.css",

--- a/components/vf-video/package.json
+++ b/components/vf-video/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.20",
   "name": "@visual-framework/vf-video",
   "description": "vf-video component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-video.css",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "vfConfig": {
     "vfNamespace": "vf-",
-    "vfName": "Visual Framework 2.0"
+    "vfName": "Visual Framework 2.0",
+    "vfHomepage": "https://visual-framework.github.io/vf-core"
   },
   "dependencies": {
     "@frctl/fractal": "^1.2.0-beta.1",

--- a/tools/component-generator/index.js
+++ b/tools/component-generator/index.js
@@ -26,7 +26,7 @@ module.exports = class extends Generator {
     this.log((
       chalk.white("This tool helps you develop new components for the Visual Framework \n") +
       chalk.white("Not sure which options to pick? See the guide at: \n") +
-      chalk.white("https://git.VF.de/grp-stratcom/visual-framework-tooling-prototype/blob/setup/initial-installs/README.md#creating-a-new-component")
+      chalk.white("https://github.com/visual-framework/vf-core#creating-a-new-component")
     ));
 
     var componentType = ['element', 'block', 'container', 'grid', 'boilerplate'];
@@ -157,6 +157,7 @@ module.exports = class extends Generator {
         this.destinationPath(totalPath + 'package.json'),
         {
           componentName: fileName,
+          componentHomepage: config.vfConfig.vfHomepage,
           componentStylesheet: fileName + '.scss'
         }
       );

--- a/tools/component-generator/templates/_package.json
+++ b/tools/component-generator/templates/_package.json
@@ -2,7 +2,7 @@
   "version": "0.0.1",
   "name": "@visual-framework/<%= componentName %>",
   "description": "<%= componentName %> component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "<%= componentHomepage %>",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "<%= componentName %>.css",


### PR DESCRIPTION
This does two things:
- More refinements to the onboarding
- Sets pattern package.json to point to the vf-core by default (child themes will point to brand specific pages)