### PR TITLE
updates article summary

### DIFF
--- a/components/vf-summary/vf-summary--article.scss
+++ b/components/vf-summary/vf-summary--article.scss
@@ -4,24 +4,6 @@
     margin-left: $vf-summary--article__date-margin-left;
     margin-right: $vf-summary--article__date-margin-right;
     position: relative;
-
-    &::before {
-      color: inherit;
-      content: ',';
-      font-family: inherit;
-      font-size: inherit;
-      left: -8px;
-      position: absolute;
-    }
-
-    &::after {
-      color: inherit;
-      content: ' — ';
-      font-family: inherit;
-      font-size: inherit;
-      position: absolute;
-      right: -18px;
-    }
   }
 
   .vf-summary__meta {

--- a/components/vf-summary/vf-summary.variables.scss
+++ b/components/vf-summary/vf-summary.variables.scss
@@ -44,7 +44,7 @@ $vf-summary__button__color--background: green;
 // ------------------------------------------------------------
 
 $vf-summary--article__date-margin-left: .75rem;
-$vf-summary--article__date-margin-right: 1.5rem;
+$vf-summary--article__date-margin-right: .75rem;
 
 
 $vf-summary--news__category-margin-right: 1rem;


### PR DESCRIPTION
as the design has been updated since moving from Plex mono to Plex sans the comma and em dash in the vf-summary article meta information has been removed and spacing adjusted. 

This PR reflects that by:

- removing the `:before` containing a comma
- removing the `:after` containing an em dash
- adjusts the meta margin variables for consistency