### PR TITLE
Make `set-type` margins optional

### DIFF
--- a/components/vf-badge/vf-badge.scss
+++ b/components/vf-badge/vf-badge.scss
@@ -22,7 +22,7 @@ $vf-badge--tertiary-color--text: set-color(vf-color-white) !default;
 
 
 .vf-badge {
-  @include set-type(button--r,$set-margins: false);
+  @include set-type(button--r);
 
   border: 1px solid currentColor;
   color: inherit;

--- a/components/vf-badge/vf-badge.scss
+++ b/components/vf-badge/vf-badge.scss
@@ -22,7 +22,7 @@ $vf-badge--tertiary-color--text: set-color(vf-color-white) !default;
 
 
 .vf-badge {
-  @include set-type(button--r);
+  @include set-type(button--r, $set-margins: false);
 
   border: 1px solid currentColor;
   color: inherit;

--- a/components/vf-badge/vf-badge.scss
+++ b/components/vf-badge/vf-badge.scss
@@ -22,7 +22,7 @@ $vf-badge--tertiary-color--text: set-color(vf-color-white) !default;
 
 
 .vf-badge {
-  @include set-type(button--r, $set-margins: false);
+  @include set-type(button--r, $custom-margin-bottom: disable);
 
   border: 1px solid currentColor;
   color: inherit;

--- a/components/vf-badge/vf-badge.scss
+++ b/components/vf-badge/vf-badge.scss
@@ -22,7 +22,7 @@ $vf-badge--tertiary-color--text: set-color(vf-color-white) !default;
 
 
 .vf-badge {
-  @include set-type(button--r);
+  @include set-type(button--r,$set-margins: false);
 
   border: 1px solid currentColor;
   color: inherit;

--- a/components/vf-sass-config/mixins/_typography.scss
+++ b/components/vf-sass-config/mixins/_typography.scss
@@ -1,6 +1,6 @@
 // mixin to generate correct font information when included into an element
 
-@mixin set-type($font-size, $global-font-family: $global-font-family) {
+@mixin set-type($font-size, $global-font-family: $global-font-family, $set-margins: true) {
   // @if $global-font-family != $vf-typography--monospace {
 
     font-family: $global-font-family;
@@ -15,16 +15,19 @@
     }
     line-height: map-deep-get($map-font-family, $font-size, line-height);
 
-    @if (str-index($name, 'body--')) {
-      margin: 0 0 $vf-text-margin--bottom 0;
-      margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+    @if $set-margins {
+      @if (str-index($name, 'body--')) {
+        margin: 0 0 $vf-text-margin--bottom 0;
+        margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+      }
+
+      @if (str-index($name, 'heading--')) {
+        // This approach would work if  we want a $vf-heading-margin--bottom, or something
+        margin: 0 0 $vf-text-margin--bottom 0;
+        margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+      }
     }
 
-    @if (str-index($name, 'heading--')) {
-      // This approach would work if  we want a $vf-heading-margin--bottom, or something
-      margin: 0 0 $vf-text-margin--bottom 0;
-      margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-    }
   // }
   // @else {
   //

--- a/components/vf-sass-config/mixins/_typography.scss
+++ b/components/vf-sass-config/mixins/_typography.scss
@@ -1,6 +1,6 @@
 // mixin to generate correct font information when included into an element
 
-@mixin set-type($font-size, $global-font-family: $global-font-family, $set-margins: true) {
+@mixin set-type($font-size, $global-font-family: $global-font-family) {
   // @if $global-font-family != $vf-typography--monospace {
 
     font-family: $global-font-family;
@@ -14,7 +14,14 @@
       font-weight: map-deep-get($map-font-family, $font-size, font-weight);
     }
     line-height: map-deep-get($map-font-family, $font-size, line-height);
-    @if $set-margins {
+
+    @if (str-index($name, 'body--')) {
+      margin: 0 0 $vf-text-margin--bottom 0;
+      margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+    }
+
+    @if (str-index($name, 'heading--')) {
+      // This approach would work if  we want a $vf-heading-margin--bottom, or something
       margin: 0 0 $vf-text-margin--bottom 0;
       margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
     }

--- a/components/vf-sass-config/mixins/_typography.scss
+++ b/components/vf-sass-config/mixins/_typography.scss
@@ -1,6 +1,6 @@
 // mixin to generate correct font information when included into an element
 
-@mixin set-type($font-size, $global-font-family: $global-font-family) {
+@mixin set-type($font-size, $global-font-family: $global-font-family, $set-margins: true) {
   // @if $global-font-family != $vf-typography--monospace {
 
     font-family: $global-font-family;
@@ -14,8 +14,10 @@
       font-weight: map-deep-get($map-font-family, $font-size, font-weight);
     }
     line-height: map-deep-get($map-font-family, $font-size, line-height);
-    margin: 0 0 $vf-text-margin--bottom 0;
-    margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+    @if $set-margins {
+      margin: 0 0 $vf-text-margin--bottom 0;
+      margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+    }
   // }
   // @else {
   //

--- a/components/vf-sass-config/mixins/_typography.scss
+++ b/components/vf-sass-config/mixins/_typography.scss
@@ -1,6 +1,6 @@
 // mixin to generate correct font information when included into an element
-
-@mixin set-type($font-size, $global-font-family: $global-font-family, $set-margins: true) {
+// $custom-margin-bottom: variable, auto, disable
+@mixin set-type($font-size, $global-font-family: $global-font-family, $custom-margin-bottom: auto) {
   // @if $global-font-family != $vf-typography--monospace {
 
     font-family: $global-font-family;
@@ -15,13 +15,18 @@
     }
     line-height: map-deep-get($map-font-family, $font-size, line-height);
 
-    @if $set-margins {
-      @if (str-index($name, 'body--')) {
+    @if $custom-margin-bottom == 'disable' {
+    }
+    @else if $custom-margin-bottom != 'auto' {
+      margin: 0 0 $custom-margin-bottom 0;
+      // margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+    }
+    @else {
+      @if (str-index($font-size, 'body--')) {
         margin: 0 0 $vf-text-margin--bottom 0;
         margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
       }
-
-      @if (str-index($name, 'heading--')) {
+      @else if (str-index($font-size, 'heading--')) {
         // This approach would work if  we want a $vf-heading-margin--bottom, or something
         margin: 0 0 $vf-text-margin--bottom 0;
         margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;


### PR DESCRIPTION
There are cases where we want to use the default typography, but not have margins.

[`vf-badge`](https://dev.beta.embl.org/guidelines/visual-framework/dev-docs/components/detail/vf-badge.html) is a good example of this: 

![image](https://user-images.githubusercontent.com/928100/51027629-abe71480-1591-11e9-8dac-86345f39b548.png)

The fix here is one approach, a few other options:

1. As I've done but with different variable names/logic (not sure if I've done a good approach)"
  - `mixin set-type($font-size, $global-font-family: $global-font-family, $set-margins: true) {`
2. Just let the `margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;` and then unset/add `margin-bottom: 0` (feels messy)
3. Update the token YAML with a new prop:
```
  - name: button--r
    value:
      font-size: 16px
      font-weight: 700
      line-height: 1
      margin: 0 0 var(--vf-text-margin--bottom, 16px) 0
```

The way I've gone in this PR feels like the most balanced approach, I think. 