### PR TITLE
Reference vf-core-patterns in sass build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,7 +69,8 @@ gulp.task('css', function() {
       path.resolve(__dirname, 'components/vf-sass-config/functions'),
       path.resolve(__dirname, 'components/vf-sass-config/mixins'),
       path.resolve(__dirname, 'assets/scss'),
-      path.resolve(__dirname, 'components')
+      path.resolve(__dirname, 'components'),
+      path.resolve(__dirname, 'components/vf-core-patterns')
     ]
   };
   return gulp


### PR DESCRIPTION
For `vf-core` this won't mean anything, but it brings the gulpfile into fuller alignment with the forthcoming `vf-child` theme template.