### PR TITLE
refactoring the global-header pattern

### DIFF
--- a/components/vf-global-header/vf-global-header.hbs
+++ b/components/vf-global-header/vf-global-header.hbs
@@ -1,4 +1,4 @@
-<div class="vf-global-header">
+<header class="vf-global-header">
 
   <div class="vf-global-header__inner">
 
@@ -10,4 +10,4 @@
 
   </div>
 
-</div>
+</header>

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -11,7 +11,7 @@ $vf-global-header__link-text--color: set-color(vf-color-black);
   grid-column: 1 / -1;
   grid-template-columns: minmax(var(--page-grid-gap), auto) minmax(auto, $global-page-max-width) minmax(var(--page-grid-gap), auto);
   height: auto;
-  margin-bottom: -1px; // this hides the border if it's part of a larger header
+  margin-bottom: 16px;
   padding: .5rem 0;
 }
 


### PR DESCRIPTION
The designs have changed so we've currently got a pattern that is out of date in terms of HTML tags and CSS.

This PR is the first of a few - that makes changes surrounding the 'masthead' pattern.

In this PR we update the global-header pattern to be:

- a `<header>` element in HTML rather than a div
- adds the bottom margin to the component taken from the `vf-masthead` pattern
- in doing so removes the `-1px` bottom margin previously.
