### PR TITLE
refactors vf-breadcrumbs - breaking change

### DIFF
--- a/components/vf-breadcrumbs/vf-breadcrumbs--with-related.hbs
+++ b/components/vf-breadcrumbs/vf-breadcrumbs--with-related.hbs
@@ -14,24 +14,21 @@
       Gouda
     </li>
 
-    <ul class="vf-breadcrumbs__list vf-breadcrumbs__list--related | vf-list vf-list--inline">
+  </ul>
 
-      <li class="vf-breadcrumbs__item">
-        Related:
-      </li>
+  <span class="vf-breadcrumbs__heading">Related:</span>
+  <ul class="vf-breadcrumbs__list vf-breadcrumbs__list--related | vf-list vf-list--inline">
 
-      <li class="vf-breadcrumbs__item">
-        <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Biscuits</a>
-      </li>
+    <li class="vf-breadcrumbs__item">
+      <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Biscuits</a>
+    </li>
 
-      <li class="vf-breadcrumbs__item">
-        <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">
-          Fruits For Cheese
-        </a>
-      </li>
-
-    </ul>
-
+    <li class="vf-breadcrumbs__item">
+      <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">
+        Fruits For Cheese
+      </a>
+    </li>
 
   </ul>
+
 </nav>

--- a/components/vf-breadcrumbs/vf-breadcrumbs--with-related.hbs
+++ b/components/vf-breadcrumbs/vf-breadcrumbs--with-related.hbs
@@ -1,27 +1,37 @@
-<ul class="vf-breadcrumbs | vf-list vf-list--inline">
-  <li class="vf-breadcrumbs__item">
-    <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Dairy</a>
-  </li>
-  <li class="vf-breadcrumbs__item">
-    <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Cheese</a>
-  </li>
-  <li class="vf-breadcrumbs__item">
-    Gouda
-  </li>
+<nav class="vf-breadcrumbs" aria-label="Breadcrumb">
 
-  <ul class="vf-breadcrumbs vf-breadcrumbs--related | vf-list vf-list--inline">
+  <ul class="vf-breadcrumbs__list | vf-list vf-list--inline">
+
     <li class="vf-breadcrumbs__item">
-      Related
+      <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Dairy</a>
     </li>
 
     <li class="vf-breadcrumbs__item">
-      <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Biscuits</a>
+      <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Cheese</a>
     </li>
-    <li class="vf-breadcrumbs__item">
-      <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">
-        Fruits For Cheese
-      </a>
+
+    <li class="vf-breadcrumbs__item" aria-current="page">
+      Gouda
     </li>
+
+    <ul class="vf-breadcrumbs__list vf-breadcrumbs__list--related | vf-list vf-list--inline">
+
+      <li class="vf-breadcrumbs__item">
+        Related:
+      </li>
+
+      <li class="vf-breadcrumbs__item">
+        <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Biscuits</a>
+      </li>
+
+      <li class="vf-breadcrumbs__item">
+        <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">
+          Fruits For Cheese
+        </a>
+      </li>
+
+    </ul>
+
+
   </ul>
-
-</ul>
+</nav>

--- a/components/vf-breadcrumbs/vf-breadcrumbs--with-related.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs--with-related.scss
@@ -1,18 +1,9 @@
 .vf-breadcrumbs__list--related {
-  margin-left: 32px;
 
   .vf-breadcrumbs__item {
-    margin-right: 8px;
     color: $vf-breadcrumbs__item-related-text--color;
+    margin-left: 8px;
     position: relative;
-
-    &:first-of-type {
-      margin-right: 0;
-    }
-
-    &:last-of-type {
-      margin-right: 0;
-    }
 
     &:not(:last-of-type) {
       &::after {

--- a/components/vf-breadcrumbs/vf-breadcrumbs--with-related.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs--with-related.scss
@@ -1,0 +1,31 @@
+.vf-breadcrumbs__list--related {
+  margin-left: 32px;
+
+  .vf-breadcrumbs__item {
+    margin-right: 8px;
+    color: $vf-breadcrumbs__item-related-text--color;
+    position: relative;
+
+    &:first-of-type {
+      margin-right: 0;
+    }
+
+    &:last-of-type {
+      margin-right: 0;
+    }
+
+    &:not(:last-of-type) {
+      &::after {
+        content: '';
+      }
+    }
+  }
+
+  .vf-breadcrumbs__link {
+    color: $vf-breadcrumbs__item-related-link--color;
+
+    &:hover {
+      color: $vf-breadcrumbs__item-related-link--color--hover;
+    }
+  }
+}

--- a/components/vf-breadcrumbs/vf-breadcrumbs.hbs
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.hbs
@@ -1,11 +1,13 @@
-<ul class="vf-breadcrumbs | vf-list vf-list--inline">
-  <li class="vf-breadcrumbs__item">
-    <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Explore</a>
-  </li>
-  <li class="vf-breadcrumbs__item">
-    <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Topics</a>
-  </li>
-  <li class="vf-breadcrumbs__item">
-    Center
-  </li>
-</ul>
+<nav class="vf-breadcrumbs" aria-label="Breadcrumb">
+  <ul class="vf-breadcrumbs__list | vf-list vf-list--inline">
+    <li class="vf-breadcrumbs__item">
+      <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Explore</a>
+    </li>
+    <li class="vf-breadcrumbs__item">
+      <a href="JavaScript:Void(0);" class="vf-breadcrumbs__link">Topics</a>
+    </li>
+    <li class="vf-breadcrumbs__item" aria-current="page">
+      Center
+    </li>
+  </ul>
+</nav>

--- a/components/vf-breadcrumbs/vf-breadcrumbs.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.scss
@@ -6,6 +6,7 @@
 }
 
 .vf-breadcrumbs {
+  display: flex;
   margin-bottom: $vf-breadcrumbs__margin--bottom;
 }
 
@@ -15,6 +16,7 @@
   color: $vf-breadcrumbs__item-text--color;
   margin-right: 3px;
   position: relative;
+
 
   &:not(:last-of-type) {
     &::after {
@@ -28,24 +30,4 @@
 
 .vf-breadcrumbs__link {
   color: currentColor;
-}
-
-.vf-breadcrumbs--related {
-
-  .vf-breadcrumbs__item {
-    margin-left: 16px;
-    color: $vf-breadcrumbs__item-related-text--color;
-    position: relative;
-
-    &:not(:last-of-type) {
-      &::after {
-        content: '';
-      }
-    }
-  }
-
-  .vf-breadcrumbs__link {
-    color: $vf-breadcrumbs__item-related-link--color;
-  }
-
 }

--- a/components/vf-breadcrumbs/vf-breadcrumbs.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.scss
@@ -28,6 +28,16 @@
   }
 }
 
+.vf-breadcrumbs__heading {
+  @include set-type(body--r);
+  
+  display: inline;
+
+  .vf-breadcrumbs__list + & {
+    margin-left: 32px;
+  }
+}
+
 .vf-breadcrumbs__link {
   color: currentColor;
 }

--- a/components/vf-breadcrumbs/vf-breadcrumbs.variables.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.variables.scss
@@ -3,6 +3,7 @@
 $vf-breadcrumbs__item-text--color: set-color(vf-color-black);
 $vf-breadcrumbs__item-chevron--color: set-color(vf-color-gray);
 $vf-breadcrumbs__item-related-text--color: set-color(vf-color-gray);
-$vf-breadcrumbs__item-related-link--color: set-color(vf-color-gray);
+$vf-breadcrumbs__item-related-link--color: set-color(vf-color-azure);
+$vf-breadcrumbs__item-related-link--color--hover: set-color(vf-color-gray);
 
-$vf-breadcrumbs__margin--bottom: 24px; 
+$vf-breadcrumbs__margin--bottom: 24px;

--- a/components/vf-core/index.scss
+++ b/components/vf-core/index.scss
@@ -67,6 +67,7 @@ html, button {
   @import 'vf-box/vf-box--factoid.scss';
 
 @import 'vf-breadcrumbs/vf-breadcrumbs.scss';
+  @import 'vf-breadcrumbs/vf-breadcrumbs--with-related.scss';
 
 @import 'vf-code-example/vf-code-example.scss';
 @import 'vf-page-header/vf-page-header.scss';


### PR DESCRIPTION
This patter moves the lists for breadcrumbs inside a nav element with added aria where appropriate for a11y.

It also splits out the `--with-related` Sass to a separate partial and updates the styles to be more like the Sketch file.

Sketch file: 
![screenshot 2019-01-22 at 09 42 44](https://user-images.githubusercontent.com/925197/51526381-1e75b100-1e2a-11e9-92a2-04e56f2684f2.png)


Before:
![screenshot 2019-01-22 at 09 21 34](https://user-images.githubusercontent.com/925197/51526343-0a31b400-1e2a-11e9-9c48-72088e12da18.png)

After:
![screenshot 2019-01-22 at 09 35 19](https://user-images.githubusercontent.com/925197/51526328-02720f80-1e2a-11e9-8d57-1957e860e757.png)
