### PR TITLE
refactors component list UI to separate EMBL specific patterns

### DIFF
--- a/components/embl-boilerplate-page/embl-boilerplate-page.config.yml
+++ b/components/embl-boilerplate-page/embl-boilerplate-page.config.yml
@@ -2,4 +2,4 @@ title: EMBL Boilerplate page
 label: EMBL Boilerplate
 preview: '@preview--nogrid'
 context:
-  pattern-type: boilerplate
+  pattern-type: embl-boilerplate

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.config.yml
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.config.yml
@@ -3,7 +3,7 @@ label: EMBL Breadcrumbs
 preview: '@preview--blocks'
 status: alpha
 context:
-  pattern-type: block
+  pattern-type: embl-block
   meta-who: Strategy and Communications
   meta-what: Visual Framework
   meta-where: EMBL

--- a/components/embl-conditional-edit/embl-conditional-edit.config.yml
+++ b/components/embl-conditional-edit/embl-conditional-edit.config.yml
@@ -1,4 +1,4 @@
 title: EMBL Conditional Edit Links pattern
 label: EMBL Conditional Edit
 context:
-  pattern-type: element
+  pattern-type: embl-element

--- a/components/embl-content-hub-loader/embl-content-hub-loader.config.yml
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.config.yml
@@ -2,4 +2,4 @@ title: EMBL ContentHub Loader pattern
 label: EMBL ContentHub Loader
 status: beta
 context:
-  pattern-type: container
+  pattern-type: embl-container

--- a/components/embl-content-meta-properties/embl-content-meta-properties.config.yml
+++ b/components/embl-content-meta-properties/embl-content-meta-properties.config.yml
@@ -3,7 +3,7 @@ label: EMBL Content meta properties
 preview: '@preview--blocks'
 status: alpha
 context:
-  pattern-type: block
+  pattern-type: embl-block
   meta-who: all
   meta-what: services, websites
   meta-where: EMBL

--- a/components/embl-grid/embl-grid.config.yml
+++ b/components/embl-grid/embl-grid.config.yml
@@ -3,4 +3,4 @@ label: EMBL Grid
 preview: '@preview--grids'
 status: live
 context:
-  pattern-type: grid
+  pattern-type: embl-grid

--- a/components/embl-group-page/embl-group-page.config.yml
+++ b/components/embl-group-page/embl-group-page.config.yml
@@ -2,4 +2,4 @@ title: EMBL Group page
 label: EMBL Group
 preview: '@preview--fullhtml'
 context:
-  pattern-type: boilerplate
+  pattern-type: embl-boilerplate

--- a/components/embl-logo/embl-logo.config.yml
+++ b/components/embl-logo/embl-logo.config.yml
@@ -2,4 +2,4 @@ title: EMBL Logo
 label: EMBL Logo
 preview: '@preview--elements'
 context:
-  pattern-type: element
+  pattern-type: embl-element

--- a/components/embl-subsite-page/embl-subsite-page.config.yml
+++ b/components/embl-subsite-page/embl-subsite-page.config.yml
@@ -2,4 +2,4 @@ title: EMBL Subsite page
 label: EMBL Subsite
 preview: '@preview--nogrid'
 context:
-  pattern-type: boilerplate
+  pattern-type: embl-boilerplate

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/pattern-list.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/pattern-list.nunj
@@ -39,4 +39,15 @@
 
 {{ patternByType('Boilerplates', type='boilerplate', description='Whole-page templates that are a collection of many patterns.') }}
 
+{{ patternByType('EMBL Grids', type='embl-grid', description='EMBLs way to put stuff in columns.') }}
+
+{{ patternByType('EMBL Elements', type='embl-element', description='EMBLs micro elements of the pattern library.') }}
+
+{{ patternByType('EMBL Blocks', type='embl-block', description='Simple patterns from EMBL like sections headers, galleries and so on.') }}
+
+{{ patternByType('EMBL Containers', type='embl-container', description='More complex EMBL patterns that sometimes have specific layout, like page intros, mastheads, news sections and so on.') }}
+
+{{ patternByType('EMBL Boilerplates', type='embl-boilerplate', description='Whole-page templates that are a collection of many patterns.') }}
+
+
 {{ patternByType('Deprecated', type='deprecated', description='These patterns are no longer maintained.') }}

--- a/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/pattern-list.nunj
+++ b/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/pattern-list.nunj
@@ -39,4 +39,15 @@
 
 {{ patternByType('Boilerplates', type='boilerplate', description='Whole-page templates that are a collection of many patterns.') }}
 
+{{ patternByType('EMBL Grids', type='embl-grid', description='EMBLs way to put stuff in columns.') }}
+
+{{ patternByType('EMBL Elements', type='embl-element', description='EMBLs micro elements of the pattern library.') }}
+
+{{ patternByType('EMBL Blocks', type='embl-block', description='Simple patterns from EMBL like sections headers, galleries and so on.') }}
+
+{{ patternByType('EMBL Containers', type='embl-container', description='More complex EMBL patterns that sometimes have specific layout, like page intros, mastheads, news sections and so on.') }}
+
+{{ patternByType('EMBL Boilerplates', type='embl-boilerplate', description='Whole-page templates that are a collection of many patterns.') }}
+
+
 {{ patternByType('Deprecated', type='deprecated', description='These patterns are no longer maintained.') }}


### PR DESCRIPTION
This PR:

- updates the nunjucks files to separate the EMBL patterns from VF Core patterns
- prefixes existing `pattern-type` with `embl-` so they get picked up 