### PR TITLE
Update boilerplate tempalte, banner

### DIFF
--- a/components/embl-boilerplate-page/embl-boilerplate-page.config.yml
+++ b/components/embl-boilerplate-page/embl-boilerplate-page.config.yml
@@ -1,5 +1,5 @@
 title: EMBL Boilerplate page
 label: EMBL Boilerplate
-preview: '@preview--nogrid'
+preview: '@preview--fullhtml'
 context:
   pattern-type: embl-boilerplate

--- a/components/embl-boilerplate-page/embl-boilerplate-page.hbs
+++ b/components/embl-boilerplate-page/embl-boilerplate-page.hbs
@@ -22,19 +22,20 @@
     <link rel="import" href="https://dev.beta.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=574&pattern=node-body&source=contenthub" data-target="self" data-embl-js-content-hub-loader>
   </header>
 
-  <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase">
-      <div class="vf-banner__content">
-        <div class="vf-grid vf-grid__col-1">
+  <!-- dismissible banner -->
+  <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase" data-vf-js-banner data-vf-js-banner-state="dismissible" data-vf-js-banner-button-text="Close notice">
+      <div class="vf-banner__content | " data-vf-js-banner-text>
+        <div>
           <h3 class="vf-text vf-text--heading-r">
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
       {{~#codeblockhtml~}}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/css/styles.css">
-<script src="{{ path '/scripts/scripts.js' }}"></script>
+<script src="https://dev.assets.emblstatic.net/vf/scripts/scripts.js"></script>
       {{/codeblockhtml}}
+        </div>
       </div>
-    </div>
   </section>
 
   <div class="vf-body">

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -22,19 +22,20 @@
     <link rel="import" href="https://dev.beta.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=574&pattern=node-body&source=contenthub" data-target="self" data-embl-js-content-hub-loader>
   </header>
 
-  <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase">
-      <div class="vf-banner__content">
-        <div class="vf-grid vf-grid__col-1">
+  <!-- dismissible banner -->
+  <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase" data-vf-js-banner data-vf-js-banner-state="dismissible" data-vf-js-banner-button-text="Close notice">
+      <div class="vf-banner__content | " data-vf-js-banner-text>
+        <div>
           <h3 class="vf-text vf-text--heading-r">
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
       {{~#codeblockhtml~}}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/css/styles.css">
-<script src="{{ path '/scripts/scripts.js' }}"></script>
+<script src="https://dev.assets.emblstatic.net/vf/scripts/scripts.js"></script>
       {{/codeblockhtml}}
+        </div>
       </div>
-    </div>
   </section>
 
   <div class="vf-body">

--- a/components/embl-subsite-page/embl-subsite-page.config.yml
+++ b/components/embl-subsite-page/embl-subsite-page.config.yml
@@ -1,5 +1,5 @@
 title: EMBL Subsite page
 label: EMBL Subsite
-preview: '@preview--nogrid'
+preview: '@preview--fullhtml'
 context:
   pattern-type: embl-boilerplate

--- a/components/embl-subsite-page/embl-subsite-page.hbs
+++ b/components/embl-subsite-page/embl-subsite-page.hbs
@@ -28,19 +28,20 @@
     {{render '@vf-navigation--secondary'}}
   </header>
 
-  <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase">
-      <div class="vf-banner__content">
-        <div class="vf-grid vf-grid__col-1">
+  <!-- dismissible banner -->
+  <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase" data-vf-js-banner data-vf-js-banner-state="dismissible" data-vf-js-banner-button-text="Close notice">
+      <div class="vf-banner__content | " data-vf-js-banner-text>
+        <div>
           <h3 class="vf-text vf-text--heading-r">
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
       {{~#codeblockhtml~}}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/css/styles.css">
-<script src="{{ path '/scripts/scripts.js' }}"></script>
+<script src="https://dev.assets.emblstatic.net/vf/scripts/scripts.js"></script>
       {{/codeblockhtml}}
+        </div>
       </div>
-    </div>
   </section>
 
   <div class="vf-body">

--- a/components/vf-boilerplate-page/vf-boilerplate-page.config.yml
+++ b/components/vf-boilerplate-page/vf-boilerplate-page.config.yml
@@ -1,5 +1,5 @@
 title: VF Boilerplate page
 label: VF Boilerplate
-preview: '@preview--nogrid'
+preview: '@preview--fullhtml'
 context:
   pattern-type: boilerplate

--- a/components/vf-boilerplate-page/vf-boilerplate-page.hbs
+++ b/components/vf-boilerplate-page/vf-boilerplate-page.hbs
@@ -22,19 +22,20 @@
     {{> @vf-global-header}}
   </header>
 
-  <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase">
-      <div class="vf-banner__content">
-        <div class="vf-grid vf-grid__col-1">
+  <!-- dismissible banner -->
+  <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase" data-vf-js-banner data-vf-js-banner-state="dismissible" data-vf-js-banner-button-text="Close notice">
+      <div class="vf-banner__content | " data-vf-js-banner-text>
+        <div>
           <h3 class="vf-text vf-text--heading-r">
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
       {{~#codeblockhtml~}}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/css/styles.css">
-<script src="{{ path '/scripts/scripts.js' }}"></script>
+<script src="https://dev.assets.emblstatic.net/vf/scripts/scripts.js"></script>
       {{/codeblockhtml}}
+        </div>
       </div>
-    </div>
   </section>
 
 


### PR DESCRIPTION
Some boilerplate templates were using the wrong preview:
```
- preview: '@preview--nogrid'
+ preview: '@preview--fullhtml'
```

Also updates boilerplates to use new dismissable banner. 🎆