### PR TITLE
Fix/lerna version

### DIFF
--- a/components/embl-boilerplate-page/package.json
+++ b/components/embl-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "@visual-framework/embl-boilerplate-page",
   "description": "embl-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/embl-boilerplate-page/package.json
+++ b/components/embl-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@visual-framework/embl-boilerplate-page",
   "description": "embl-boilerplate-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/embl-breadcrumbs-lookup/package.json
+++ b/components/embl-breadcrumbs-lookup/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "embl-breadcrumbs-lookup",
   "description": "embl-breadcrumbs-lookup component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/embl-breadcrumbs-lookup/package.json
+++ b/components/embl-breadcrumbs-lookup/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "embl-breadcrumbs-lookup",
   "description": "embl-breadcrumbs-lookup component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -16,8 +16,6 @@
   "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/embl-breadcrumbs-lookup",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
-  },
-  "dependencies": {
   },
   "keywords": [
     "fractal",

--- a/components/embl-conditional-edit/package.json
+++ b/components/embl-conditional-edit/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "@visual-framework/embl-conditional-edit",
   "description": "embl-conditional-edit component",
   "homepage": "https://visual-framework.github.io/vf-core",

--- a/components/embl-conditional-edit/package.json
+++ b/components/embl-conditional-edit/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "@visual-framework/embl-conditional-edit",
   "description": "embl-conditional-edit component",
   "homepage": "https://visual-framework.github.io/vf-core",
@@ -16,9 +16,9 @@
     "embl-conditional-edit.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/embl-conditional-edit",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"

--- a/components/embl-content-hub-loader/package.json
+++ b/components/embl-content-hub-loader/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "@visual-framework/embl-content-hub-loader",
   "description": "embl-content-hub-loader component",
   "homepage": "https://visual-framework.github.io/vf-core",

--- a/components/embl-content-hub-loader/package.json
+++ b/components/embl-content-hub-loader/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "@visual-framework/embl-content-hub-loader",
   "description": "embl-content-hub-loader component",
   "homepage": "https://visual-framework.github.io/vf-core",
@@ -16,9 +16,9 @@
     "embl-content-hub-loader.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/embl-content-hub-loader",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"

--- a/components/embl-content-meta-properties/package.json
+++ b/components/embl-content-meta-properties/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@visual-framework/embl-content-meta-properties",
   "description": "embl-content-meta-properties component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/embl-content-meta-properties/package.json
+++ b/components/embl-content-meta-properties/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "@visual-framework/embl-content-meta-properties",
   "description": "embl-content-meta-properties component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/embl-grid/package.json
+++ b/components/embl-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/embl-grid",
   "description": "embl-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -21,7 +21,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/embl-grid/package.json
+++ b/components/embl-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/embl-grid",
   "description": "embl-grid component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -21,7 +21,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/embl-group-page/package.json
+++ b/components/embl-group-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@visual-framework/embl-group-page",
   "description": "embl-group-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/embl-group-page/package.json
+++ b/components/embl-group-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "@visual-framework/embl-group-page",
   "description": "embl-group-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/embl-logo/package.json
+++ b/components/embl-logo/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "@visual-framework/embl-logo",
   "description": "embl-logo component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,7 +24,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/embl-logo/package.json
+++ b/components/embl-logo/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "@visual-framework/embl-logo",
   "description": "embl-logo component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -24,7 +24,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/embl-subsite-page/package.json
+++ b/components/embl-subsite-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@visual-framework/embl-subsite-page",
   "description": "embl-subsite-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/embl-subsite-page/package.json
+++ b/components/embl-subsite-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "@visual-framework/embl-subsite-page",
   "description": "embl-subsite-page component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/vf-activity-group/package.json
+++ b/components/vf-activity-group/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-activity-group",
   "description": "vf-activity-group component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,10 +23,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-activity-list": "^0.0.21",
-    "@visual-framework/vf-grid": "^0.0.20",
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-activity-list": "^0.0.22",
+    "@visual-framework/vf-grid": "^0.0.21",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-activity-group/package.json
+++ b/components/vf-activity-group/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-activity-group",
   "description": "vf-activity-group component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,10 +23,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-activity-list": "^0.0.22",
-    "@visual-framework/vf-grid": "^0.0.21",
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-activity-list": "^0.0.23",
+    "@visual-framework/vf-grid": "^0.0.22",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-activity-list/package.json
+++ b/components/vf-activity-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-activity-list",
   "description": "vf-activity-list component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.20",
-    "@visual-framework/vf-list": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-blockquote": "^0.0.21",
+    "@visual-framework/vf-list": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-activity-list/package.json
+++ b/components/vf-activity-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-activity-list",
   "description": "vf-activity-list component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-blockquote": "^0.0.21",
-    "@visual-framework/vf-list": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-blockquote": "^0.0.22",
+    "@visual-framework/vf-list": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-article-meta-information/package.json
+++ b/components/vf-article-meta-information/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "@visual-framework/vf-article-meta-information",
   "description": "vf-article-meta-information component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -22,7 +22,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18"
+    "@visual-framework/vf-sass-config": "^0.0.19"
   },
   "keywords": [
     "fractal",

--- a/components/vf-article-meta-information/package.json
+++ b/components/vf-article-meta-information/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@visual-framework/vf-article-meta-information",
   "description": "vf-article-meta-information component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -22,7 +22,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17"
+    "@visual-framework/vf-sass-config": "^0.0.18"
   },
   "keywords": [
     "fractal",

--- a/components/vf-badge/package.json
+++ b/components/vf-badge/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-badge",
   "description": "vf-badge component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -27,7 +27,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-badge/package.json
+++ b/components/vf-badge/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-badge",
   "description": "vf-badge component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -27,7 +27,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-banner/package.json
+++ b/components/vf-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "@visual-framework/vf-banner",
   "description": "vf-banner component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-badge": "^0.0.12",
-    "@visual-framework/vf-sass-config": "^0.0.18"
+    "@visual-framework/vf-sass-config": "^0.0.19"
   },
   "keywords": [
     "fractal",

--- a/components/vf-banner/package.json
+++ b/components/vf-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@visual-framework/vf-banner",
   "description": "vf-banner component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-badge": "^0.0.12",
-    "@visual-framework/vf-sass-config": "^0.0.17"
+    "@visual-framework/vf-sass-config": "^0.0.18"
   },
   "keywords": [
     "fractal",

--- a/components/vf-blockquote/package.json
+++ b/components/vf-blockquote/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-blockquote",
   "description": "vf-blockquote component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-blockquote/package.json
+++ b/components/vf-blockquote/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-blockquote",
   "description": "vf-blockquote component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-boilerplate-page/package.json
+++ b/components/vf-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "@visual-framework/vf-boilerplate-page",
   "description": "vf-boilerplate-page component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-boilerplate-page/package.json
+++ b/components/vf-boilerplate-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@visual-framework/vf-boilerplate-page",
   "description": "vf-boilerplate-page component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-box/package.json
+++ b/components/vf-box/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-box",
   "description": "vf-box component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-box/package.json
+++ b/components/vf-box/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-box",
   "description": "vf-box component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-breadcrumbs/package.json
+++ b/components/vf-breadcrumbs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.23",
+  "version": "0.0.24",
   "name": "@visual-framework/vf-breadcrumbs",
   "description": "vf-breadcrumbs component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,8 +23,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-list": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-breadcrumbs/package.json
+++ b/components/vf-breadcrumbs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-breadcrumbs",
   "description": "vf-breadcrumbs component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,8 +23,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-list": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-button/package.json
+++ b/components/vf-button/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-button",
   "description": "vf-button component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -27,7 +27,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-button/package.json
+++ b/components/vf-button/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-button",
   "description": "vf-button component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -27,7 +27,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-code-example/package.json
+++ b/components/vf-code-example/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-code-example",
   "description": "vf-code-example component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-code-example/package.json
+++ b/components/vf-code-example/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-code-example",
   "description": "vf-code-example component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-contact/package.json
+++ b/components/vf-contact/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-contact",
   "description": "vf-contact component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-contact/package.json
+++ b/components/vf-contact/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-contact",
   "description": "vf-contact component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-content/package.json
+++ b/components/vf-content/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-content",
   "description": "vf-content component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,18 +23,18 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-badge": "^0.0.20",
-    "@visual-framework/vf-blockquote": "^0.0.20",
-    "@visual-framework/vf-box": "^0.0.20",
-    "@visual-framework/vf-button": "^0.0.20",
-    "@visual-framework/vf-divider": "^0.0.20",
-    "@visual-framework/vf-figure": "^0.0.20",
-    "@visual-framework/vf-form": "^0.0.21",
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-link": "^0.0.20",
-    "@visual-framework/vf-list": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-text": "^0.0.20",
+    "@visual-framework/vf-badge": "^0.0.21",
+    "@visual-framework/vf-blockquote": "^0.0.21",
+    "@visual-framework/vf-box": "^0.0.21",
+    "@visual-framework/vf-button": "^0.0.21",
+    "@visual-framework/vf-divider": "^0.0.21",
+    "@visual-framework/vf-figure": "^0.0.21",
+    "@visual-framework/vf-form": "^0.0.22",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-link": "^0.0.21",
+    "@visual-framework/vf-list": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-text": "^0.0.21",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-content/package.json
+++ b/components/vf-content/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-content",
   "description": "vf-content component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,18 +23,18 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-badge": "^0.0.21",
-    "@visual-framework/vf-blockquote": "^0.0.21",
-    "@visual-framework/vf-box": "^0.0.21",
-    "@visual-framework/vf-button": "^0.0.21",
-    "@visual-framework/vf-divider": "^0.0.21",
-    "@visual-framework/vf-figure": "^0.0.21",
-    "@visual-framework/vf-form": "^0.0.22",
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-link": "^0.0.21",
-    "@visual-framework/vf-list": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-text": "^0.0.21",
+    "@visual-framework/vf-badge": "^0.0.22",
+    "@visual-framework/vf-blockquote": "^0.0.22",
+    "@visual-framework/vf-box": "^0.0.22",
+    "@visual-framework/vf-button": "^0.0.22",
+    "@visual-framework/vf-divider": "^0.0.22",
+    "@visual-framework/vf-figure": "^0.0.22",
+    "@visual-framework/vf-form": "^0.0.23",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-link": "^0.0.22",
+    "@visual-framework/vf-list": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-text": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-core/package.json
+++ b/components/vf-core/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "@visual-framework/vf-core",
   "description": "vf-core component",
   "homepage": "https://visual-framework.github.io/vf-core",

--- a/components/vf-core/package.json
+++ b/components/vf-core/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "@visual-framework/vf-core",
   "description": "vf-core component",
   "homepage": "https://visual-framework.github.io/vf-core",
@@ -16,9 +16,9 @@
     "vf-core.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/vf-core",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"

--- a/components/vf-data-protection-banner/package.json
+++ b/components/vf-data-protection-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-data-protection-banner",
   "description": "vf-data-protection-banner component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -25,10 +25,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.20",
-    "@visual-framework/vf-grid": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-text": "^0.0.20",
+    "@visual-framework/vf-button": "^0.0.21",
+    "@visual-framework/vf-grid": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-text": "^0.0.21",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-data-protection-banner/package.json
+++ b/components/vf-data-protection-banner/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-data-protection-banner",
   "description": "vf-data-protection-banner component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -25,10 +25,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.21",
-    "@visual-framework/vf-grid": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-text": "^0.0.21",
+    "@visual-framework/vf-button": "^0.0.22",
+    "@visual-framework/vf-grid": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-text": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-divider/package.json
+++ b/components/vf-divider/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-divider",
   "description": "vf-divider component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-divider/package.json
+++ b/components/vf-divider/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-divider",
   "description": "vf-divider component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-factoid/package.json
+++ b/components/vf-factoid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-factoid",
   "description": "vf-factoid component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-text": "^0.0.20",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-text": "^0.0.21",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-factoid/package.json
+++ b/components/vf-factoid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-factoid",
   "description": "vf-factoid component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-text": "^0.0.21",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-text": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-favicon/package.json
+++ b/components/vf-favicon/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-favison",
   "description": "vf-favison component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,7 +24,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-favicon/package.json
+++ b/components/vf-favicon/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-favison",
   "description": "vf-favison component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,7 +24,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-figure/package.json
+++ b/components/vf-figure/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-figure",
   "description": "vf-figure component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,7 +24,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-figure/package.json
+++ b/components/vf-figure/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-figure",
   "description": "vf-figure component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,7 +24,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-font-plex-mono/package.json
+++ b/components/vf-font-plex-mono/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-plex-mono-font",
   "description": "vf-plex-mono-font component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-font-plex-mono/package.json
+++ b/components/vf-font-plex-mono/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-plex-mono-font",
   "description": "vf-plex-mono-font component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-font-plex-sans/package.json
+++ b/components/vf-font-plex-sans/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-plex-sans-font",
   "description": "vf-plex-sans-font component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-font-plex-sans/package.json
+++ b/components/vf-font-plex-sans/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-plex-sans-font",
   "description": "vf-plex-sans-font component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-footer/package.json
+++ b/components/vf-footer/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "@visual-framework/vf-footer",
   "description": "vf-footer component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-footer/package.json
+++ b/components/vf-footer/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@visual-framework/vf-footer",
   "description": "vf-footer component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-form",
   "description": "vf-form component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -33,7 +33,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-form",
   "description": "vf-form component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -33,7 +33,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/vf-form__checkbox/package.json
+++ b/components/vf-form/vf-form__checkbox/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-form__checkbox",
   "description": "vf-form__checkbox component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.22",
-    "@visual-framework/vf-form__label": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-form__item": "^0.0.23",
+    "@visual-framework/vf-form__label": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/vf-form__checkbox/package.json
+++ b/components/vf-form/vf-form__checkbox/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-form__checkbox",
   "description": "vf-form__checkbox component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.21",
-    "@visual-framework/vf-form__label": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-form__item": "^0.0.22",
+    "@visual-framework/vf-form__label": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/vf-form__helper/package.json
+++ b/components/vf-form/vf-form__helper/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-form__helper",
   "description": "vf-form__helper component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/vf-form__helper/package.json
+++ b/components/vf-form/vf-form__helper/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-form__helper",
   "description": "vf-form__helper component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/vf-form__input/package.json
+++ b/components/vf-form/vf-form__input/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-form__input",
   "description": "vf-form__input component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.22",
-    "@visual-framework/vf-form__label": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-form__item": "^0.0.23",
+    "@visual-framework/vf-form__label": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/vf-form__input/package.json
+++ b/components/vf-form/vf-form__input/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-form__input",
   "description": "vf-form__input component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__item": "^0.0.21",
-    "@visual-framework/vf-form__label": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-form__item": "^0.0.22",
+    "@visual-framework/vf-form__label": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-form__item",
   "description": "vf-form__item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,11 +23,11 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__helper": "^0.0.21",
-    "@visual-framework/vf-form__input": "^0.0.22",
-    "@visual-framework/vf-form__item": "^0.0.22",
-    "@visual-framework/vf-form__label": "^0.0.18",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-form__helper": "^0.0.22",
+    "@visual-framework/vf-form__input": "^0.0.23",
+    "@visual-framework/vf-form__item": "^0.0.23",
+    "@visual-framework/vf-form__label": "^0.0.19",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-form__item",
   "description": "vf-form__item component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
@@ -23,11 +23,11 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-form__helper": "^0.0.20",
-    "@visual-framework/vf-form__input": "^0.0.21",
-    "@visual-framework/vf-form__item": "^0.0.21",
-    "@visual-framework/vf-form__label": "^0.0.17",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-form__helper": "^0.0.21",
+    "@visual-framework/vf-form__input": "^0.0.22",
+    "@visual-framework/vf-form__item": "^0.0.22",
+    "@visual-framework/vf-form__label": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-form/vf-form__label/package.json
+++ b/components/vf-form/vf-form__label/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-form__label",
   "description": "vf-form__label component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/vf-form/vf-form__label/package.json
+++ b/components/vf-form/vf-form__label/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-form__label",
   "description": "vf-form__label component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/vf-form/vf-form__radio/package.json
+++ b/components/vf-form/vf-form__radio/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-form__radio",
   "description": "vf-form__radio component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/vf-form/vf-form__radio/package.json
+++ b/components/vf-form/vf-form__radio/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-form__radio",
   "description": "vf-form__radio component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/vf-form/vf-form__select/package.json
+++ b/components/vf-form/vf-form__select/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-form__select",
   "description": "vf-form__select component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/vf-form/vf-form__select/package.json
+++ b/components/vf-form/vf-form__select/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-form__select",
   "description": "vf-form__select component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/vf-form/vf-form__textarea/package.json
+++ b/components/vf-form/vf-form__textarea/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-form__textarea",
   "description": "vf-form__textarea component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/vf-form/vf-form__textarea/package.json
+++ b/components/vf-form/vf-form__textarea/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-form__textarea",
   "description": "vf-form__textarea component",
   "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",

--- a/components/vf-global-header/package.json
+++ b/components/vf-global-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-global-header",
   "description": "vf-global-header component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-logo": "^0.0.20",
-    "@visual-framework/vf-navigation": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-logo": "^0.0.21",
+    "@visual-framework/vf-navigation": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-global-header/package.json
+++ b/components/vf-global-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-global-header",
   "description": "vf-global-header component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-logo": "^0.0.21",
-    "@visual-framework/vf-navigation": "^0.0.22",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-logo": "^0.0.22",
+    "@visual-framework/vf-navigation": "^0.0.23",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-grid-page/package.json
+++ b/components/vf-grid-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-grid-page",
   "description": "vf-grid-page component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -22,7 +22,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-grid-page/package.json
+++ b/components/vf-grid-page/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-grid-page",
   "description": "vf-grid-page component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -22,7 +22,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-grid/package.json
+++ b/components/vf-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-grid",
   "description": "vf-grid component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -22,7 +22,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-grid/package.json
+++ b/components/vf-grid/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-grid",
   "description": "vf-grid component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -22,7 +22,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-header/package.json
+++ b/components/vf-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-header",
   "description": "vf-header component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,10 +23,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-global-header": "^0.0.22",
-    "@visual-framework/vf-masthead": "^0.0.22",
-    "@visual-framework/vf-navigation": "^0.0.22",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-global-header": "^0.0.23",
+    "@visual-framework/vf-masthead": "^0.0.23",
+    "@visual-framework/vf-navigation": "^0.0.23",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-header/package.json
+++ b/components/vf-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-header",
   "description": "vf-header component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,10 +23,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-global-header": "^0.0.21",
-    "@visual-framework/vf-masthead": "^0.0.21",
-    "@visual-framework/vf-navigation": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-global-header": "^0.0.22",
+    "@visual-framework/vf-masthead": "^0.0.22",
+    "@visual-framework/vf-navigation": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-heading/package.json
+++ b/components/vf-heading/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-heading",
   "description": "vf-heading component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-heading/package.json
+++ b/components/vf-heading/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-heading",
   "description": "vf-heading component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-inlay/package.json
+++ b/components/vf-inlay/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "@visual-framework/vf-inlay",
   "description": "vf-inlay component",
   "homepage": "https://visual-framework.github.io/vf-core",

--- a/components/vf-inlay/package.json
+++ b/components/vf-inlay/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "@visual-framework/vf-inlay",
   "description": "vf-inlay component",
   "homepage": "https://visual-framework.github.io/vf-core",
@@ -16,9 +16,9 @@
     "vf-inlay.config.yml"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
-"publishConfig": {
-  "access": "public"
-},
+  "publishConfig": {
+    "access": "public"
+  },
   "repo": "https://github.com/visual-framework/vf-core/tree/master/tree/master/components/vf-inlay",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"

--- a/components/vf-intro/package.json
+++ b/components/vf-intro/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-intro",
   "description": "vf-intro component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-text": "^0.0.21",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-text": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-intro/package.json
+++ b/components/vf-intro/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-intro",
   "description": "vf-intro component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-text": "^0.0.20",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-text": "^0.0.21",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-job-description/package.json
+++ b/components/vf-job-description/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-job-description",
   "description": "vf-job-description component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,10 +24,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.20",
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-text": "^0.0.20",
+    "@visual-framework/vf-button": "^0.0.21",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-text": "^0.0.21",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-job-description/package.json
+++ b/components/vf-job-description/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-job-description",
   "description": "vf-job-description component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,10 +24,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-button": "^0.0.21",
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-text": "^0.0.21",
+    "@visual-framework/vf-button": "^0.0.22",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-text": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-link-list/package.json
+++ b/components/vf-link-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-link-list",
   "description": "vf-link-list component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,8 +24,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-link-list/package.json
+++ b/components/vf-link-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-link-list",
   "description": "vf-link-list component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,8 +24,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-link/package.json
+++ b/components/vf-link/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-link",
   "description": "vf-link component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-link/package.json
+++ b/components/vf-link/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-link",
   "description": "vf-link component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-list/package.json
+++ b/components/vf-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-list",
   "description": "vf-list component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -26,7 +26,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-list/package.json
+++ b/components/vf-list/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-list",
   "description": "vf-list component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -26,7 +26,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-logo/package.json
+++ b/components/vf-logo/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-logo",
   "description": "vf-logo component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,7 +24,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-logo/package.json
+++ b/components/vf-logo/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-logo",
   "description": "vf-logo component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,7 +24,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-masthead/package.json
+++ b/components/vf-masthead/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-masthead",
   "description": "vf-masthead component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,8 +24,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-grid": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-masthead/package.json
+++ b/components/vf-masthead/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-masthead",
   "description": "vf-masthead component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,8 +24,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-grid": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-navigation/package.json
+++ b/components/vf-navigation/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-navigation",
   "description": "vf-navigation component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -26,8 +26,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-list": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-navigation/package.json
+++ b/components/vf-navigation/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-navigation",
   "description": "vf-navigation component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -26,8 +26,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-list": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-news-container/package.json
+++ b/components/vf-news-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-news-container",
   "description": "vf-news-container component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,10 +23,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.20",
-    "@visual-framework/vf-news-item": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-section-header": "^0.0.21",
+    "@visual-framework/vf-grid": "^0.0.21",
+    "@visual-framework/vf-news-item": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-section-header": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-news-container/package.json
+++ b/components/vf-news-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-news-container",
   "description": "vf-news-container component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,10 +23,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.21",
-    "@visual-framework/vf-news-item": "^0.0.22",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-section-header": "^0.0.22",
+    "@visual-framework/vf-grid": "^0.0.22",
+    "@visual-framework/vf-news-item": "^0.0.23",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-section-header": "^0.0.23",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-news-item/package.json
+++ b/components/vf-news-item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-news-item",
   "description": "vf-news-item component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -26,10 +26,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-link": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-text": "^0.0.20",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-link": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-text": "^0.0.21",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-news-item/package.json
+++ b/components/vf-news-item/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-news-item",
   "description": "vf-news-item component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -26,10 +26,10 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-link": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-text": "^0.0.21",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-link": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-text": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-no-js/package.json
+++ b/components/vf-no-js/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "@visual-framework/vf-no-js",
   "description": "vf-no-js component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-no-js/package.json
+++ b/components/vf-no-js/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@visual-framework/vf-no-js",
   "description": "vf-no-js component",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-page-header/package.json
+++ b/components/vf-page-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-page-header",
   "description": "vf-page-header component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,8 +23,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-page-header/package.json
+++ b/components/vf-page-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-page-header",
   "description": "vf-page-header component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,8 +23,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-sass-config/package.json
+++ b/components/vf-sass-config/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "@visual-framework/vf-sass-config",
   "description": "vf-sass-config",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-sass-config/package.json
+++ b/components/vf-sass-config/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.17",
+  "version": "0.0.18",
   "name": "@visual-framework/vf-sass-config",
   "description": "vf-sass-config",
   "homepage": "https://visual-framework.github.io/vf-core/",

--- a/components/vf-section-header/package.json
+++ b/components/vf-section-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-section-header",
   "description": "vf-section-header component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,8 +24,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-section-header/package.json
+++ b/components/vf-section-header/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-section-header",
   "description": "vf-section-header component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,8 +24,8 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-snippet/package.json
+++ b/components/vf-snippet/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-snippet",
   "description": "vf-snippet component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-text": "^0.0.21",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-text": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-snippet/package.json
+++ b/components/vf-snippet/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-snippet",
   "description": "vf-snippet component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,9 +23,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-text": "^0.0.20",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-text": "^0.0.21",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-summary-container/package.json
+++ b/components/vf-summary-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-summary-container",
   "description": "vf-summary component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,11 +23,11 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.21",
-    "@visual-framework/vf-grid": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-section-header": "^0.0.22",
-    "@visual-framework/vf-summary": "^0.0.22",
+    "@visual-framework/embl-grid": "^0.0.22",
+    "@visual-framework/vf-grid": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-section-header": "^0.0.23",
+    "@visual-framework/vf-summary": "^0.0.23",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-summary-container/package.json
+++ b/components/vf-summary-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-summary-container",
   "description": "vf-summary component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,11 +23,11 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.20",
-    "@visual-framework/vf-grid": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-section-header": "^0.0.21",
-    "@visual-framework/vf-summary": "^0.0.21",
+    "@visual-framework/embl-grid": "^0.0.21",
+    "@visual-framework/vf-grid": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-section-header": "^0.0.22",
+    "@visual-framework/vf-summary": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-summary",
   "description": "vf-summary component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -26,9 +26,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-text": "^0.0.21",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-text": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-summary",
   "description": "vf-summary component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -26,9 +26,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-text": "^0.0.20",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-text": "^0.0.21",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-tabs/package.json
+++ b/components/vf-tabs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-tabs",
   "description": "vf-tabs component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -25,7 +25,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-tabs/package.json
+++ b/components/vf-tabs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-tabs",
   "description": "vf-tabs component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -25,7 +25,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-tag/package.json
+++ b/components/vf-tag/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-tag",
   "description": "vf-tag component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -27,7 +27,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-tag/package.json
+++ b/components/vf-tag/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-tag",
   "description": "vf-tag component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -27,7 +27,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-text/package.json
+++ b/components/vf-text/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-text",
   "description": "vf-text component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-text/package.json
+++ b/components/vf-text/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-text",
   "description": "vf-text component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-utility-classes/package.json
+++ b/components/vf-utility-classes/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-utility-classes",
   "description": "A set of utility classes to help quickly prototype, and 'tweak' design.",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -21,7 +21,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-utility-classes/package.json
+++ b/components/vf-utility-classes/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-utility-classes",
   "description": "A set of utility classes to help quickly prototype, and 'tweak' design.",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -21,7 +21,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-video-container/package.json
+++ b/components/vf-video-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-video-container",
   "description": "vf-video-container component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,11 +23,11 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
-    "@visual-framework/vf-section-header": "^0.0.21",
-    "@visual-framework/vf-video": "^0.0.20",
-    "@visual-framework/vf-video-teaser": "^0.0.21",
+    "@visual-framework/embl-grid": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-section-header": "^0.0.22",
+    "@visual-framework/vf-video": "^0.0.21",
+    "@visual-framework/vf-video-teaser": "^0.0.22",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-video-container/package.json
+++ b/components/vf-video-container/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-video-container",
   "description": "vf-video-container component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,11 +23,11 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/embl-grid": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
-    "@visual-framework/vf-section-header": "^0.0.22",
-    "@visual-framework/vf-video": "^0.0.21",
-    "@visual-framework/vf-video-teaser": "^0.0.22",
+    "@visual-framework/embl-grid": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
+    "@visual-framework/vf-section-header": "^0.0.23",
+    "@visual-framework/vf-video": "^0.0.22",
+    "@visual-framework/vf-video-teaser": "^0.0.23",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-video-teaser/package.json
+++ b/components/vf-video-teaser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-video-teaser",
   "description": "vf-video-teaser component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,9 +24,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.20",
-    "@visual-framework/vf-link": "^0.0.20",
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-heading": "^0.0.21",
+    "@visual-framework/vf-link": "^0.0.21",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-video-teaser/package.json
+++ b/components/vf-video-teaser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23",
   "name": "@visual-framework/vf-video-teaser",
   "description": "vf-video-teaser component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -24,9 +24,9 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.21",
-    "@visual-framework/vf-link": "^0.0.21",
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-heading": "^0.0.22",
+    "@visual-framework/vf-link": "^0.0.22",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-video/package.json
+++ b/components/vf-video/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.20",
+  "version": "0.0.21",
   "name": "@visual-framework/vf-video",
   "description": "vf-video component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.17",
+    "@visual-framework/vf-sass-config": "^0.0.18",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [

--- a/components/vf-video/package.json
+++ b/components/vf-video/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.21",
+  "version": "0.0.22",
   "name": "@visual-framework/vf-video",
   "description": "vf-video component",
   "homepage": "https://visual-framework.github.io/vf-core/",
@@ -23,7 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.18",
+    "@visual-framework/vf-sass-config": "^0.0.19",
     "node-normalize-scss": "^8.0.0"
   },
   "keywords": [


### PR DESCRIPTION
As we're out of sync in the repo with npmjs.com

`lerna version patch --no-git-tag-version`

Had a quick scan and this looks right with what's on https://www.npmjs.com/org/visual-framework

In the future when we publish it looks like we can:
- `lerna publish --no-git-tag-version`

https://github.com/lerna/lerna/tree/master/commands/version#--no-git-tag-version