### PR TITLE
Add missing pattern index.scss import

### DIFF
--- a/components/vf-banner/index.scss
+++ b/components/vf-banner/index.scss
@@ -9,3 +9,11 @@
 // pattern specific styles
 
 @import 'vf-banner.scss';
+
+// positional banners
+@import 'vf-banner--fixed.scss';
+@import 'vf-banner--inline.scss';
+@import 'vf-banner--top.scss';
+
+// color/style banners
+@import 'vf-banner--phase.scss';

--- a/components/vf-breadcrumbs/index.scss
+++ b/components/vf-breadcrumbs/index.scss
@@ -13,3 +13,4 @@
 // pattern specific styles
 
 @import 'vf-breadcrumbs.scss';
+@import 'vf-breadcrumbs--with-related.scss';

--- a/components/vf-summary/index.scss
+++ b/components/vf-summary/index.scss
@@ -16,4 +16,4 @@
 @import 'vf-summary--article.scss';
 @import 'vf-summary--job.scss';
 @import 'vf-summary--news.scss';
-@import 'vf-summary--news-has-image.scss';
+@import 'vf-summary--profile.scss';


### PR DESCRIPTION
Where some patterns have mutliple .scss files, not all of them were being imported in index.scss.

We might need a better approach here, this is pretty easy to miss and hard to see if broken. Visual regression testing might help.