### PR TITLE
Idea/improve vf inlay nesting

### DIFF
--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -72,6 +72,8 @@
         <aside class="vf-inlay__content--additional">
           [group leader]
         </aside>
+
+        <hr class="vf-divider" />
       </section>
 
       <section class="vf-inlay__content vf-u-background-color-white">

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -60,6 +60,21 @@
 
       <section class="vf-inlay__content vf-u-background-color-white">
 
+        <div class="vf-grid">
+          {{> '@vf-banner--inline'}}
+        </div>
+
+
+        <main class="vf-inlay__content--main">
+          <h1>The Häring group aims to understand the molecular machinery that organises eukaryotic genomes. <a href="http://vfthemeprototype.lndo.site/about/">Read more about the Häring group</a></h1>  </main>
+        </main>
+
+        <aside class="vf-inlay__content--additional">
+          [group leader]
+        </aside>
+      </section>
+
+      <section class="vf-inlay__content vf-u-background-color-white">
         <main class="vf-inlay__content--main">
           {{> '@vf-content'}}
         </main>

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -38,11 +38,11 @@
       </div>
   </section>
 
-  <div class="vf-body vf-u-background-color-gray-bright">
+  <div class="vf-body ">
 
-    <section class="vf-inlay vf-u-background-color-green">
+    <section class="vf-inlay vf-u-background-color-gray-bright">
 
-      <header class="vf-inlay__header">
+      <header class="vf-inlay__header vf-u-background-color-green">
 
         <div class="vf-masthead">
           <div class="vf-masthead__inner">
@@ -53,31 +53,26 @@
         </div>
 
         <div class="vf-inlay__navigation vf-inlay__navigation--site">
-          {{render '@vf-navigation--site'}}
+          {{render '@vf-navigation--main'}}
         </div>
 
       </header>
 
-      <main class="vf-inlay__content vf-inlay__content--main">
-      </main>
+      <section class="vf-inlay__content vf-u-background-color-white">
 
-      <aside class="vf-inlay__content vf-inlay__content--additional">
-      </aside>
+        <main class="vf-inlay__content--main">
+          {{> '@vf-content'}}
+        </main>
 
-    </section>
+        <aside class="vf-inlay__content--additional">
+          {{> '@vf-box'}}
+        </aside>
 
-
-    <section class="embl-grid embl-grid--has-centered-content vf-u-background-color-white">
-      <div></div>
-      <div>
-        {{> '@vf-content'}}
-      </div>
+      </section>
 
     </section>
 
-  </div>
 
-  <div class="vf-body">
     <section class="vf-news-container | embl-grid embl-grid--has-sidebar">
 
       {{> '@vf-section-header' section-title='Latest Press Releases'}}

--- a/components/vf-inlay/vf-inlay.config.yml
+++ b/components/vf-inlay/vf-inlay.config.yml
@@ -1,4 +1,5 @@
 title: Inlay
 label: Inlay
+preview: '@preview--nogrid'
 context:
   pattern-type: grid

--- a/components/vf-inlay/vf-inlay.hbs
+++ b/components/vf-inlay/vf-inlay.hbs
@@ -1,25 +1,34 @@
-<section class="vf-inlay vf-u-background-color-green">
+<div class="vf-body">
+  <section class="vf-inlay vf-u-background-color-gray-bright">
 
-  <header class="vf-inlay__header">
-    
-    <div class="vf-masthead">
-      <div class="vf-masthead__inner">
-        <div class="vf-masthead__title">
-          <h1 class="vf-masthead__heading">Häring Group</h1>
+    <header class="vf-inlay__header vf-u-background-color-green">
+
+      <div class="vf-masthead">
+        <div class="vf-masthead__inner">
+          <div class="vf-masthead__title">
+            <h1 class="vf-masthead__heading">Häring Group</h1>
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="vf-inlay__navigation vf-inlay__navigation--site">
-      {{render '@vf-navigation--main'}}
-    </div>
+      <div class="vf-inlay__navigation vf-inlay__navigation--site">
+        {{render '@vf-navigation--main'}}
+      </div>
 
-  </header>
+    </header>
 
-  <main class="vf-inlay__content vf-inlay__content--main">
-  </main>
+    <section class="vf-inlay__content vf-u-background-color-white">
+      <main class="vf-inlay__content--main">
+        {{> '@vf-content'}}
+      </main>
 
-  <aside class="vf-inlay__content vf-inlay__content--additional">
-  </aside>
+      <aside class="vf-inlay__content--additional">
+        {{> '@vf-box'}}
+      </aside>
+    </section>
 
-</section>
+  </section>
+
+
+
+</div>

--- a/components/vf-inlay/vf-inlay.hbs
+++ b/components/vf-inlay/vf-inlay.hbs
@@ -29,6 +29,4 @@
 
   </section>
 
-
-
 </div>

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -38,12 +38,12 @@
   grid-column: 2 / -2;
   /* stylelint-disable declaration-colon-space-after, indentation */
   grid-template-columns:
-    minmax(var(--page-grid-gap), auto)
+    minmax(var(--page-grid-gap), 60px)
 
       minmax(auto, 47.5em)
       minmax(18.125em, auto)
 
-    minmax(var(--page-grid-gap), auto)
+    minmax(var(--page-grid-gap), 60px)
   ;
   /* stylelint-enable */
 }
@@ -70,12 +70,12 @@
   display: grid;
   /* stylelint-disable declaration-colon-space-after, indentation */
   grid-template-columns:
-    minmax(var(--page-grid-gap), auto)
+    minmax(var(--page-grid-gap), 60px)
     [main-start]
       minmax(auto, 100%)
       minmax(18.125em, auto)
     [main-end]
-    minmax(var(--page-grid-gap), auto)
+    minmax(var(--page-grid-gap), 60px)
   ;
   /* stylelint-enable */
   grid-column: 2 / 3;

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -38,12 +38,12 @@
   grid-column: 2 / -2;
   /* stylelint-disable declaration-colon-space-after, indentation */
   grid-template-columns:
-    minmax(var(--page-grid-gap), 60px)
+    minmax(var(--page-grid-gap), auto)
 
       minmax(auto, 47.5em)
       minmax(18.125em, auto)
 
-    minmax(var(--page-grid-gap), 60px)
+    minmax(var(--page-grid-gap), auto)
   ;
   /* stylelint-enable */
 }
@@ -70,27 +70,24 @@
   display: grid;
   /* stylelint-disable declaration-colon-space-after, indentation */
   grid-template-columns:
-    minmax(var(--page-grid-gap), 60px)
+    minmax(var(--page-grid-gap), auto)
     [main-start]
       minmax(auto, 100%)
       minmax(18.125em, auto)
     [main-end]
-    minmax(var(--page-grid-gap), 60px)
+    minmax(var(--page-grid-gap), auto)
   ;
   /* stylelint-enable */
   grid-column: 2 / 3;
-  padding-right: minmax(var(--page-grid-gap), 60px);
-  padding-left: minmax(var(--page-grid-gap), 60px);
-
 }
 .vf-inlay__content--main {
   grid-column: 2 / -2;
 
   @media (min-width: 1100px) {
     grid-column: 2 / 3;
-    // padding-right: minmax(var(--page-grid-gap), 60px);
-    // padding-left: minmax(var(--page-grid-gap), 60px);
   }
+
+  padding-right: var(--page-grid-gap);
 }
 
 .vf-inlay__content--additional {

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -5,14 +5,11 @@
   grid-column: 1 / -1;
   /* stylelint-disable  declaration-colon-space-after, indentation */
   grid-template-columns:
-    minmax(var(--page-grid-gap), 60px)
+    minmax(var(--page-grid-gap), auto)
 
-    [main-start]
-      minmax(auto, 47.5em)
-      minmax(18.125em, auto)
-    [main-end]
+    minmax(auto, 76.5em)
 
-    minmax(var(--page-grid-gap), 60px)
+    minmax(var(--page-grid-gap), auto)
   ;
   /* stylelint-enable */
 
@@ -28,7 +25,7 @@
   }
 
   @media (min-width: 480px) {
-    grid-column: 2 / -2;
+    // grid-column: 2 / -2;
   }
 
   @media (min-width: 1024px) {
@@ -38,7 +35,7 @@
 
 .vf-inlay__header {
   display: grid;
-  grid-column: 1 / -1;
+  grid-column: 2 / -2;
   /* stylelint-disable declaration-colon-space-after, indentation */
   grid-template-columns:
     minmax(var(--page-grid-gap), 60px)
@@ -68,12 +65,31 @@
   }
 }
 
+.vf-inlay__content {
+  padding-top: 36px;
+  display: grid;
+  /* stylelint-disable declaration-colon-space-after, indentation */
+  grid-template-columns:
+    minmax(var(--page-grid-gap), 60px)
+    [main-start]
+      minmax(auto, 100%)
+      minmax(18.125em, auto)
+    [main-end]
+    minmax(var(--page-grid-gap), 60px)
+  ;
+  /* stylelint-enable */
+  grid-column: 2 / 3;
+  padding-right: minmax(var(--page-grid-gap), 60px);
+  padding-left: minmax(var(--page-grid-gap), 60px);
+
+}
 .vf-inlay__content--main {
   grid-column: 2 / -2;
 
   @media (min-width: 1100px) {
     grid-column: 2 / 3;
-    margin-right: var(--page-grid-gap);
+    // padding-right: minmax(var(--page-grid-gap), 60px);
+    // padding-left: minmax(var(--page-grid-gap), 60px);
   }
 }
 
@@ -82,6 +98,5 @@
 
   @media (min-width: 1100px) {
     grid-column: 3 / 4;
-    max-width: 350px;
   }
 }


### PR DESCRIPTION
So basically this does a couple things that I think will make `vf-inlay` more workable, particularly allowing the background colour to be set directly as `vf-inlay vf-u-background-color-gray-bright`, which feels more natural to me. 

I think it also sorts a couple inconsistencies on how the grid inside of vf-inlay was working. 

I might be missing something though...

## quick visual comparison

### Currently

![image](https://user-images.githubusercontent.com/928100/52337242-70602e80-2a07-11e9-881e-6ddcd65ed037.png)

### Proposed

![image](https://user-images.githubusercontent.com/928100/52337291-8e2d9380-2a07-11e9-97b1-9b442888cd7a.png)
