### PR TITLE
Update vf-inlay.scss

### DIFF
--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -73,7 +73,7 @@
     minmax(var(--page-grid-gap), 60px)
     [main-start]
       minmax(auto, 100%)
-      minmax(18.125em, auto)
+      minmax(auto, 22.125em)
     [main-end]
     minmax(var(--page-grid-gap), 60px)
   ;


### PR DESCRIPTION
Gets the width of the sidebar to not default to wide, sets a min-width closer to Mark's designs.

Relates to #208