### PR TITLE
Use one dsahd in place of two

### DIFF
--- a/components/vf-link-list/vf-link-list.hbs
+++ b/components/vf-link-list/vf-link-list.hbs
@@ -1,4 +1,4 @@
-<div class="vf-links vf-u-background-color--gray-bright">
+<div class="vf-links vf-u-background-color-gray-bright">
   <h3 class="vf-links__heading | vf-text vf-text--heading-r">Latest Posts</h3>
   <ul class="vf-links__list">
     <li class="vf-links__item">

--- a/components/vf-sass-config/mixins/_utility--color.scss
+++ b/components/vf-sass-config/mixins/_utility--color.scss
@@ -12,7 +12,7 @@
 @mixin ui-color-modifiers($attribute: 'color', $prefix: '-') {
 
   @each $name, $hex in $vf-ui-colors-map {
-    $name: str-replace($name, 13);
+    $name: str-replace($name, 14);
     &#{$prefix}#{$name} {
       #{$attribute}: $hex;
     }


### PR DESCRIPTION
also sorts a background colour typo

In the name of consistency:

- drops `.vf-u-border-color--ui-yellow`
- does `.vf-u-border-color-ui-yellow`
- so it's like `.vf-u-border-color-azure-dark`

follow up to #215 
