### PR TITLE
Pattern/embl group page background

### DIFF
--- a/components/embl-boilerplate-page/embl-boilerplate-page.hbs
+++ b/components/embl-boilerplate-page/embl-boilerplate-page.hbs
@@ -8,7 +8,7 @@
   <meta content="width=device-width, initial-scale=1, minimum-scale=1" name="viewport">
 
   {{> @vf-favicon}}
-  {{> @embl-content-meta-properties meta-who="Group Jane" meta-where="Barcelona" meta-what="research,cancer" }}
+  {{> @embl-content-meta-properties meta-who="Group Jane" meta-where="Barcelona" meta-what="research,cancer" meta-active="what"}}
 
   {{#if _config.project.environment.local }}
   <link rel="stylesheet" href="{{ path '/css/styles.css' }}">

--- a/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
@@ -133,9 +133,10 @@ function emblContentHubFetch() {
     if (typeof(vfTabs) === 'function') {
       vfTabs(targetLocation);
     }
-    if (typeof(emblBreadcrumbs) === 'function') {
-      emblBreadcrumbs(); // no scope for emblBreadcrumbs
-    }
+    // don't run breadcrumbs as part of contenthub, use case is different
+    // if (typeof(emblBreadcrumbs) === 'function') {
+    //   emblBreadcrumbs(); // no scope for emblBreadcrumbs
+    // }
   }
 
   // Enable class injection after loading contents

--- a/components/embl-content-meta-properties/embl-content-meta-properties.hbs
+++ b/components/embl-content-meta-properties/embl-content-meta-properties.hbs
@@ -7,6 +7,7 @@
 <!-- Content role -->
 <meta name="embl:utility" content="-8"> <!-- if content is task and work based or if is meant to inspire -->
 <meta name="embl:reach" content="-5"> <!-- if content is externally (public) or internally focused (those that work at EMBL) -->
+
 <!-- Page infromation -->
 <meta name="embl:maintainer" content="{{ meta-maintainer }}"> <!-- the contact person or group responsible for the page -->
 <meta name="embl:last-review" content="{{ meta-last-review }}"> <!-- the last time the page was reviewed or updated -->

--- a/components/embl-group-page/embl-group-page--contact.hbs
+++ b/components/embl-group-page/embl-group-page--contact.hbs
@@ -8,7 +8,7 @@
   <meta content="width=device-width, initial-scale=1, minimum-scale=1" name="viewport">
 
   {{> @vf-favicon}}
-  {{> @embl-content-meta-properties meta-who="Group Jane" meta-where="Barcelona" meta-what="research,cancer" }}
+  {{> @embl-content-meta-properties meta-who="Group Jane" meta-where="Barcelona" meta-what="research,cancer" meta-active="what"}}
 
   {{#if _config.project.environment.local }}
   <link rel="stylesheet" href="{{ path '/css/styles.css' }}">

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -40,9 +40,9 @@
 
   <div class="vf-body ">
 
-    <section class="vf-inlay vf-u-background-color-ui-gray">
+    <section class="vf-inlay embl-group-page--bg-color">
 
-      <header class="vf-inlay__header vf-u-background-color-green">
+      <header class="vf-inlay__header embl-group-page--vf-header--bg-color">
 
         <div class="vf-masthead">
           <div class="vf-masthead__inner">

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -22,10 +22,6 @@
     <link rel="import" href="https://dev.beta.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=574&pattern=node-body&source=contenthub" data-target="self" data-embl-js-content-hub-loader>
   </header>
 
-  <nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
-    <div class="vf-text embl-breadcrumbs-lookup--loading-text"></div>
-  </nav>
-
   <!-- dismissible banner -->
   <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase" data-vf-js-banner data-vf-js-banner-state="dismissible" data-vf-js-banner-button-text="Close notice">
       <div class="vf-banner__content | " data-vf-js-banner-text>
@@ -42,9 +38,15 @@
       </div>
   </section>
 
-  <div class="vf-body ">
+  <div class="vf-body embl-group-page--bg-color">
 
-    <section class="vf-inlay embl-group-page--bg-color">
+    <section class="embl-grid">
+      <nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
+        <div class="vf-text embl-breadcrumbs-lookup--loading-text"></div>
+      </nav>
+    </section>
+
+    <section class="vf-inlay">
 
       <header class="vf-inlay__header embl-group-page--vf-header--bg-color">
 

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -8,7 +8,7 @@
   <meta content="width=device-width, initial-scale=1, minimum-scale=1" name="viewport">
 
   {{> @vf-favicon}}
-  {{> @embl-content-meta-properties meta-who="Group Jane" meta-where="Barcelona" meta-what="research,cancer" meta-last-review="2019-01-20"}}
+  {{> @embl-content-meta-properties meta-who="Strategy and Communications" meta-where="EMBL" meta-what="Visual Framework" meta-last-review="2019-01-20" meta-active="what"}}
 
   {{#if _config.project.environment.local }}
   <link rel="stylesheet" href="{{ path '/css/styles.css' }}">
@@ -21,6 +21,10 @@
   <header class="vf-header">
     <link rel="import" href="https://dev.beta.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=574&pattern=node-body&source=contenthub" data-target="self" data-embl-js-content-hub-loader>
   </header>
+
+  <nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
+    <div class="vf-text embl-breadcrumbs-lookup--loading-text"></div>
+  </nav>
 
   <!-- dismissible banner -->
   <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase" data-vf-js-banner data-vf-js-banner-state="dismissible" data-vf-js-banner-button-text="Close notice">

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -24,16 +24,16 @@
 
   <!-- dismissible banner -->
   <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase" data-vf-js-banner data-vf-js-banner-state="dismissible" data-vf-js-banner-button-text="Close notice">
-      <div class="vf-banner__content | " data-vf-js-banner-text>
+      <div class="vf-banner__content" data-vf-js-banner-text>
         <div>
           <h3 class="vf-text vf-text--heading-r">
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
-      {{~#codeblockhtml~}}
+{{~#codeblockhtml~}}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/css/styles.css">
 <script src="https://dev.assets.emblstatic.net/vf/scripts/scripts.js"></script>
-      {{/codeblockhtml}}
+{{/codeblockhtml}}
         </div>
       </div>
   </section>

--- a/components/embl-group-page/embl-group-page.scss
+++ b/components/embl-group-page/embl-group-page.scss
@@ -1,0 +1,10 @@
+// embl-group-page
+@import 'embl-group-page.variables.scss';
+
+.embl-group-page--bg-color {
+  background-color: $embl-group-page--background;
+}
+
+.embl-group-page--vf-header--bg-color {
+  background-color: $embl-group-page--vf-header--background;
+}

--- a/components/embl-group-page/embl-group-page.variables.scss
+++ b/components/embl-group-page/embl-group-page.variables.scss
@@ -1,0 +1,4 @@
+// embl-group-page
+
+$embl-group-page--background: set-ui-color(vf-ui-color-gray);
+$embl-group-page--vf-header--background: set-color(vf-color-green);

--- a/components/embl-group-page/index.scss
+++ b/components/embl-group-page/index.scss
@@ -1,1 +1,12 @@
 // setup files required
+
+// sass-lint:disable clean-import-paths
+@import 'vf-global-variables';
+@import 'vf-variables';
+@import 'vf-functions';
+@import 'vf-mixins';
+
+// pattern specific styles
+
+@import 'embl-group-page.variables.scss';
+@import 'embl-group-page.scss';

--- a/components/embl-group-page/package.json
+++ b/components/embl-group-page/package.json
@@ -6,7 +6,14 @@
   "author": "VF",
   "license": "Apache 2.0",
   "main": "build/index.js",
-  "files": [],
+  "files": [
+    "index.scss",
+    "embl-group-page.css",
+    "embl-group-page.scss",
+    "embl-group-page.variables.scss",
+    "embl-group-page.hbs",
+    "embl-group-page.config.yml"
+  ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {
     "access": "public"

--- a/components/embl-subsite-page/embl-subsite-page.hbs
+++ b/components/embl-subsite-page/embl-subsite-page.hbs
@@ -8,7 +8,7 @@
   <meta content="width=device-width, initial-scale=1, minimum-scale=1" name="viewport">
 
   {{> @vf-favicon}}
-  {{> @embl-content-meta-properties meta-who="Group Jane" meta-where="Barcelona" meta-what="research,cancer" }}
+  {{> @embl-content-meta-properties meta-who="Group Jane" meta-where="Barcelona" meta-what="research,cancer" meta-active="what"}}
 
   {{#if _config.project.environment.local }}
   <link rel="stylesheet" href="{{ path '/css/styles.css' }}">

--- a/components/vf-banner/index.scss
+++ b/components/vf-banner/index.scss
@@ -8,7 +8,7 @@
 
 // pattern specific styles
 
-@import "vf-banner.variables.scss";
+@import 'vf-banner.variables.scss';
 @import 'vf-banner.scss';
 
 // positional banners

--- a/components/vf-banner/vf-banner.js
+++ b/components/vf-banner/vf-banner.js
@@ -184,22 +184,21 @@ function vfBannerInsert(banner,bannerId,scope) {
     vfBannerCookieNameAndVersion = banner.vfJsBannerCookieName + '_' + banner.vfJsBannerCookieVersion;
   }
 
-  if (vfBannerCookieNameAndVersion != "null") {
-    // utility to reset cookie when developing
-    // console.warn('vf-banner: vfBannerReset cookie reset override is on.');
-    // vfBannerReset(vfBannerCookieNameAndVersion);
+  // utility to reset cookie when developing
+  // console.warn('vf-banner: vfBannerReset cookie reset override is on.');
+  // vfBannerReset(vfBannerCookieNameAndVersion);
 
-    // if blocking or dismissible, allow the user to close it, store a cookie (if specified)
-    if (banner.vfJsBannerState === 'blocking' || banner.vfJsBannerState === 'dismissible') {
-
-      // On click: close banner, pass any cooke name (or `null`)
-      if (banner.vfJsBannerButtonText) {
-        targetBanner.addEventListener('click', function(){
-          vfBannerConfirm(targetBanner,vfBannerCookieNameAndVersion);
-        }, false);
-      }
+  // if blocking or dismissible, allow the user to close it, store a cookie (if specified)
+  if (banner.vfJsBannerState === 'blocking' || banner.vfJsBannerState === 'dismissible') {
+    // On click: close banner, pass any cooke name (or `null`)
+    if (banner.vfJsBannerButtonText) {
+      targetBanner.addEventListener('click', function(){
+        vfBannerConfirm(targetBanner,vfBannerCookieNameAndVersion);
+      }, false);
     }
+  }
 
+  if (vfBannerCookieNameAndVersion != "null") {
     // if banner has been previously accepted
     if (vfBannerGetCookie(vfBannerCookieNameAndVersion) === 'true') {
       // banner has been accepted, close

--- a/components/vf-boilerplate-page/vf-boilerplate-page.hbs
+++ b/components/vf-boilerplate-page/vf-boilerplate-page.hbs
@@ -24,16 +24,16 @@
 
   <!-- dismissible banner -->
   <section class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase" data-vf-js-banner data-vf-js-banner-state="dismissible" data-vf-js-banner-button-text="Close notice">
-      <div class="vf-banner__content | " data-vf-js-banner-text>
+      <div class="vf-banner__content" data-vf-js-banner-text>
         <div>
           <h3 class="vf-text vf-text--heading-r">
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
-      {{~#codeblockhtml~}}
+{{~#codeblockhtml~}}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/css/styles.css">
 <script src="https://dev.assets.emblstatic.net/vf/scripts/scripts.js"></script>
-      {{/codeblockhtml}}
+{{/codeblockhtml}}
         </div>
       </div>
   </section>

--- a/components/vf-boilerplate-page/vf-boilerplate-page.hbs
+++ b/components/vf-boilerplate-page/vf-boilerplate-page.hbs
@@ -8,7 +8,7 @@
   <meta content="width=device-width, initial-scale=1, minimum-scale=1" name="viewport">
 
   {{> @vf-favicon}}
-  {{> @embl-content-meta-properties meta-who="Group Jane" meta-where="Barcelona" meta-what="research,cancer" }}
+  {{> @embl-content-meta-properties meta-who="Group Jane" meta-where="Barcelona" meta-what="research,cancer" meta-active="what"}}
 
   {{#if _config.project.environment.local }}
   <link rel="stylesheet" href="{{ path '/css/styles.css' }}">

--- a/components/vf-breadcrumbs/vf-breadcrumbs.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.scss
@@ -1,13 +1,16 @@
 // vf-breadcrumbs
 @import 'vf-breadcrumbs.variables.scss';
 
+.embl-grid > .vf-breadcrumbs {
+  margin-top: $vf-breadcrumbs__margin--top;
+}
+
 .embl-grid > .vf-breadcrumbs:first-child {
   grid-column: 1 / -1;
 }
 
 .vf-breadcrumbs {
   display: flex;
-  margin-bottom: $vf-breadcrumbs__margin--bottom;
 }
 
 .vf-breadcrumbs__item {
@@ -29,7 +32,7 @@
 }
 
 .vf-breadcrumbs__heading {
-  @include set-type(body--r);
+  @include set-type(body--r, $custom-margin-bottom: 0);
 
   display: inline;
 

--- a/components/vf-breadcrumbs/vf-breadcrumbs.variables.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.variables.scss
@@ -6,4 +6,4 @@ $vf-breadcrumbs__item-related-text--color: set-color(vf-color-gray);
 $vf-breadcrumbs__item-related-link--color: set-color(vf-color-azure);
 $vf-breadcrumbs__item-related-link--color--hover: set-color(vf-color-gray);
 
-$vf-breadcrumbs__margin--bottom: 24px;
+$vf-breadcrumbs__margin--top: 16px;

--- a/components/vf-core/index.scss
+++ b/components/vf-core/index.scss
@@ -38,13 +38,14 @@ html, button {
 @import 'vf-content/vf-content.scss';
 
 /* All Visual Framework grids */
+
 @import 'vf-grid/vf-grid.scss';
 @import 'vf-inlay/vf-inlay.scss';
 @import 'vf-grid-page/vf-grid-page.scss';
 @import 'embl-grid/embl-grid.scss';
 
-
 /* All Visual Framework Elements */
+
 @import 'vf-badge/vf-badge.scss';
 @import 'vf-link/vf-link.scss';
 @import 'vf-logo/vf-logo.scss';
@@ -56,9 +57,6 @@ html, button {
 @import 'vf-blockquote/vf-blockquote.scss';
 @import 'vf-divider/vf-divider.scss';
 @import 'embl-conditional-edit/embl-conditional-edit.scss';
-
-
-
 
 /* All Visual Framework Blocks */
 
@@ -121,6 +119,7 @@ html, button {
 @import 'embl-group-page/embl-group-page.scss';
 
 /* All Visual Framework Deprecated Patterns */
+
 @import 'vf-tag/vf-tag.scss';
 @import 'vf-job-description/vf-job-description.scss';
 @import 'vf-news-item/vf-news-item.scss';
@@ -129,6 +128,7 @@ html, button {
 @import 'vf-factoid/vf-factoid.scss';
 
 /* All Visual Framework Utility and high-specificity patterns */
+
 @import 'vf-utility-classes/vf-utility-classes.scss';
 @import 'vf-heading/vf-heading.scss';
 @import 'vf-text/vf-text.scss';

--- a/components/vf-core/index.scss
+++ b/components/vf-core/index.scss
@@ -116,6 +116,10 @@ html, button {
 @import 'vf-video-container/vf-video-container.scss';
 @import 'vf-footer/vf-footer.scss';
 
+/* All Visual Framework Boilerplates */
+
+@import 'embl-group-page/embl-group-page.scss';
+
 /* All Visual Framework Deprecated Patterns */
 @import 'vf-tag/vf-tag.scss';
 @import 'vf-job-description/vf-job-description.scss';

--- a/components/vf-header/vf-header.scss
+++ b/components/vf-header/vf-header.scss
@@ -7,7 +7,6 @@
   display: grid;
   grid-column: 1 / -1;
   grid-template-columns: minmax(var(--page-grid-gap), auto) minmax(auto, $global-page-max-width) minmax(var(--page-grid-gap), auto);
-  margin-bottom: 1rem;
 }
 
 .vf-header > .vf-global-header {

--- a/components/vf-header/vf-header.scss
+++ b/components/vf-header/vf-header.scss
@@ -7,9 +7,7 @@
   display: grid;
   grid-column: 1 / -1;
   grid-template-columns: minmax(var(--page-grid-gap), auto) minmax(auto, $global-page-max-width) minmax(var(--page-grid-gap), auto);
-  height: 100%;
   margin-bottom: 1rem;
-  max-height: 320px;
 }
 
 .vf-header > .vf-global-header {

--- a/components/vf-inlay/vf-inlay.hbs
+++ b/components/vf-inlay/vf-inlay.hbs
@@ -1,32 +1,26 @@
 <div class="vf-body">
-  <section class="vf-inlay vf-u-background-color-ui-gray">
+  <div class="vf-grid">
+    <div class="vf-box">
 
-    <header class="vf-inlay__header vf-u-background-color-green">
+      <p class="vf-text vf-text--r">
+        Use this for content that should be set within other content.
+        The design on this page is not stylisitic, but structural.
+      </p>
 
-      <div class="vf-masthead">
-        <div class="vf-masthead__inner">
-          <div class="vf-masthead__title">
-            <h1 class="vf-masthead__heading">Häring Group</h1>
-          </div>
-        </div>
-      </div>
+      <section class="vf-inlay vf-u-background-color-off-white vf-u-text-color-gray-dark">
+        <section class="vf-inlay__content">
+          <main class="vf-inlay__content--full-width">
+            {{> '@vf-summary--article'}}
+          </main>
+          <main class="vf-inlay__content--main">
+            {{> '@vf-content'}}
+          </main>
+          <main class="vf-inlay__content--additional">
+            {{> '@vf-box'}}
+          </main>
+        </section>
+      </section>
 
-      <div class="vf-inlay__navigation vf-inlay__navigation--main">
-        {{render '@vf-navigation--main'}}
-      </div>
-
-    </header>
-
-    <section class="vf-inlay__content vf-u-background-color-white">
-      <main class="vf-inlay__content--main">
-        {{> '@vf-content'}}
-      </main>
-
-      <aside class="vf-inlay__content--additional">
-        {{> '@vf-box'}}
-      </aside>
-    </section>
-
-  </section>
-
+    </div>
+  </div>
 </div>

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -81,6 +81,12 @@
   padding-top: 36px;
 }
 
+.vf-inlay__content--full-width {
+  grid-column: 2 / -2;
+  @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
+}
+
+
 .vf-inlay__content--main {
   grid-column: 2 / -2;
   padding-right: var(--page-grid-gap);
@@ -88,6 +94,7 @@
   @media (min-width: 1100px) {
     grid-column: 2 / 3;
   }
+  @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
 }
 
 .vf-inlay__content--additional {


### PR DESCRIPTION
Does a bunch of little things to:

- get the EMBL group pages looking more like Mark's design
- suggests setting the background on the parent container (so the background also goes behind the breadcrumb)
  - adds `.embl-group-page--bg-color` `.embl-group-page--vf-header--bg-color` (see comment at https://github.com/visual-framework/vf-core/commit/0fd03a67313af09df999eb38f75cbd5eb910fd10)
- the default `vf-inlay.hbs` is more generic and less like the `embl-group-page.hbs`
  - adds `.vf-inlay__content--full-width`
- fix some minor issues, linting

Screenshot of Mark's design, after, before:

![image](https://user-images.githubusercontent.com/928100/52476697-b94aeb00-2b9f-11e9-8a9f-8763904c032f.png)
