### PR TITLE
Pattern/embl group page grid

### DIFF
--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -47,6 +47,9 @@
     </section>
 
     <section class="vf-inlay">
+    <div class="vf-grid">
+      <link rel="import" href="https://dev.beta.embl.org/api/v1/pattern.html?pattern=node-body&filter-content-type=article&filter-id=580&source=contenthub" data-target="self" data-embl-js-content-hub-loader="">
+    </div>
 
       <header class="vf-inlay__header embl-group-page--vf-header--bg-color">
 
@@ -66,9 +69,6 @@
 
       <section class="vf-inlay__content vf-u-background-color-white">
 
-        <div class="vf-grid">
-          {{> '@vf-banner--inline'}}
-        </div>
 
 
         <main class="vf-inlay__content--main">

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -46,30 +46,31 @@
       </nav>
     </section>
 
-    <section class="vf-inlay">
     <div class="vf-grid">
       <link rel="import" href="https://dev.beta.embl.org/api/v1/pattern.html?pattern=node-body&filter-content-type=article&filter-id=580&source=contenthub" data-target="self" data-embl-js-content-hub-loader="">
     </div>
 
-      <header class="vf-inlay__header embl-group-page--vf-header--bg-color">
+    <header class="embl-group-header__header embl-group-page--vf-header--bg-color">
 
-        <div class="vf-masthead">
-          <div class="vf-masthead__inner">
-            <div class="vf-masthead__title">
-              <h1 class="vf-masthead__heading">Häring Group</h1>
-            </div>
+      <div class="vf-masthead">
+        <div class="vf-masthead__inner">
+          <div class="vf-masthead__title">
+            <h1 class="vf-masthead__heading">Häring Group</h1>
           </div>
         </div>
+      </div>
 
-        <div class="vf-inlay__navigation vf-inlay__navigation--main">
-          {{render '@vf-navigation--main'}}
-        </div>
+      <div class="embl-group-header__navigation embl-group-header__navigation--main">
+        {{render '@vf-navigation--main'}}
+      </div>
 
-      </header>
+    </header>
+
+    <section class="vf-inlay">
+
+
 
       <section class="vf-inlay__content vf-u-background-color-white">
-
-
 
         <main class="vf-inlay__content--main">
           <h1>The Häring group aims to understand the molecular machinery that organises eukaryotic genomes. <a href="http://vfthemeprototype.lndo.site/about/">Read more about the Häring group</a></h1>  </main>
@@ -94,9 +95,10 @@
       </section>
 
     </section>
+  </div>
 
-
-    <section class="vf-news-container | embl-grid embl-grid--has-sidebar">
+  <div class="vf-body">
+    <section class="vf-news-container | embl-grid embl-grid--has-sidebar vf-u-margin__top-xl">
 
       {{> '@vf-section-header' section-title='Latest Press Releases'}}
 

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -38,7 +38,7 @@
       </div>
   </section>
 
-  <div class="vf-body embl-group-page--bg-color">
+  <div class="vf-body vf-body__main-content embl-group-page--bg-color">
 
     <section class="embl-grid">
       <nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
@@ -97,7 +97,7 @@
     </section>
   </div>
 
-  <div class="vf-body">
+  <div class="vf-body vf-body__additional-content">
     <section class="vf-news-container | embl-grid embl-grid--has-sidebar vf-u-margin__top-xl">
 
       {{> '@vf-section-header' section-title='Latest Press Releases'}}

--- a/components/embl-group-page/embl-group-page.scss
+++ b/components/embl-group-page/embl-group-page.scss
@@ -8,3 +8,35 @@
 .embl-group-page--vf-header--bg-color {
   background-color: $embl-group-page--vf-header--background;
 }
+
+.embl-group-header__header {
+  display: grid;
+  grid-column: 2 / -2;
+  /* stylelint-disable declaration-colon-space-after, indentation */
+  grid-template-columns:
+    minmax(var(--page-grid-gap), 60px)
+    [main-start]
+      auto
+      minmax(auto, 18.125em)
+    [main-end]
+    minmax(var(--page-grid-gap), 60px)
+  ;
+  /* stylelint-enable */
+}
+
+.embl-group-header__navigation {
+  background-color: set-color(vf-color-gray-dark);
+  display: grid;
+  grid-column: 1 / -1;
+  /* stylelint-disable declaration-colon-space-after, indentation */
+  grid-template-columns:
+    minmax(var(--page-grid-gap), 60px)
+    auto
+    minmax(var(--page-grid-gap), 60px)
+  ;
+  /* stylelint-enable */
+  > * {
+    grid-column: 2 / -2;
+    margin-left: -18px;
+  }
+}

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -6,9 +6,9 @@
   /* stylelint-disable  declaration-colon-space-after, indentation */
   grid-template-columns:
     minmax(var(--page-grid-gap), auto)
-
-    minmax(auto, 76.5em)
-
+    [main-start]
+      minmax(auto, 76.5em)
+    [main-end]
     minmax(var(--page-grid-gap), auto)
   ;
   /* stylelint-enable */
@@ -33,38 +33,6 @@
   }
 }
 
-.vf-inlay__header {
-  display: grid;
-  grid-column: 2 / -2;
-  /* stylelint-disable declaration-colon-space-after, indentation */
-  grid-template-columns:
-    minmax(var(--page-grid-gap), 60px)
-    [main-start]
-      auto
-      minmax(auto, 18.125em)
-    [main-end]
-    minmax(var(--page-grid-gap), 60px)
-  ;
-  /* stylelint-enable */
-}
-
-.vf-inlay__navigation {
-  background-color: set-color(vf-color-gray-dark);
-  display: grid;
-  grid-column: 1 / -1;
-  /* stylelint-disable declaration-colon-space-after, indentation */
-  grid-template-columns:
-    minmax(var(--page-grid-gap), 60px)
-    auto
-    minmax(var(--page-grid-gap), 60px)
-  ;
-  /* stylelint-enable */
-  > * {
-    grid-column: 2 / -2;
-    margin-left: -18px;
-  }
-}
-
 .vf-inlay__content {
   display: grid;
   grid-column: 2 / 3;
@@ -85,7 +53,6 @@
   grid-column: 2 / -2;
   @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
 }
-
 
 .vf-inlay__content--main {
   grid-column: 2 / -2;

--- a/components/vf-masthead/vf-masthead--supports.scss
+++ b/components/vf-masthead/vf-masthead--supports.scss
@@ -2,6 +2,6 @@
   grid-column: 1 / -1;
 }
 
-.vf-inlay .vf-masthead {
+.embl-group-header__header .vf-masthead {
   grid-column: 2 / -2;
 }


### PR DESCRIPTION
So here's a new approach following on #221, basically this reasons a few things:

- the navigation header has more to do with `embl-group-page` than `vf-inaly`, the css for that has been moved
- there are two `vf-body`s on this, the frist cover the "group page" and has a bg colour, the second is for the embl content below and has no colour
- the background colour is not part of the inlay structure but a stylistic designation, perhaps that could eventually be set by metadata
- a descriptive approach on vf-body: `vf-body__main-content` and `vf-body__additional-content`

At any rate, brain is sapped. stashing this for the weekend