### PR TITLE
vf-banner--fixed margin issue

### DIFF
--- a/components/vf-banner/vf-banner--fixed.scss
+++ b/components/vf-banner/vf-banner--fixed.scss
@@ -3,6 +3,7 @@
   grid-column: 1 / -1;
   grid-template-columns: minmax(var(--page-grid-gap), auto) [main-start] minmax(288px, 76.5em) [main-end] minmax(var(--page-grid-gap), auto);
   left: 0;
+  margin: 0;
   padding: 0;
   position: fixed;
   width: 100%;

--- a/components/vf-core/index.scss
+++ b/components/vf-core/index.scss
@@ -108,9 +108,10 @@ html, button {
 @import 'vf-intro/vf-intro.scss';
 
 @import 'vf-banner/vf-banner.scss';
+  @import 'vf-banner/vf-banner--phase.scss';
   @import 'vf-banner/vf-banner--fixed.scss';
   @import 'vf-banner/vf-banner--gdpr.scss';
-  @import 'vf-banner/vf-banner--phase.scss';
+
 
 @import 'vf-news-container/vf-news-container.scss';
 @import 'vf-video-container/vf-video-container.scss';


### PR DESCRIPTION
I've added `margin: 0` to override the `vf-banner--phase` bottom margin so that, if required, the banner will stick, fixed to the bottom of the page with no margin. Had to switch the imports around too with 'theme' before 'positioning' - not sure if this is some precedent we want to look at.

imports:

pattern.scss
pattern--theme-options.scss
pattern--positioning-options.scss


It might be just needed for `vf-banner` for now.
