### PR TITLE
Feature/update collated previews

### DIFF
--- a/components/vf-badge/vf-badge.scss
+++ b/components/vf-badge/vf-badge.scss
@@ -62,6 +62,8 @@ $vf-badge--tertiary-color--text: set-color(vf-color-white) !default;
   background-color: $vf-badge--primary-color--background;
   border-color: $vf-badge--primary-color--border;
   color: $vf-badge--primary-color--text;
+
+  @include inline-link($vf-badge--primary-color--text,$vf-badge--primary-color--text,$vf-badge--primary-color--text,$vf-badge--primary-color--text);
 }
 
 a.vf-badge--primary:hover {
@@ -73,15 +75,22 @@ a.vf-badge--primary:hover {
   background-color: $vf-badge--secondary-color--background;
   border-color: $vf-badge--secondary-color--border;
   color: $vf-badge--secondary-color--text;
+
+  @include inline-link($vf-badge--secondary-color--text,$vf-badge--secondary-color--text,$vf-badge--secondary-color--text,$vf-badge--secondary-color--text);
 }
 
 .vf-badge--tertiary {
   background-color: $vf-badge--tertiary-color--background;
   border-color: $vf-badge--tertiary-color--border;
   color: $vf-badge--tertiary-color--text;
+
+  @include inline-link($vf-badge--tertiary-color--text,$vf-badge--tertiary-color--text,$vf-badge--tertiary-color--text,$vf-badge--tertiary-color--text);
+
 }
 
 .vf-badge--outline {
   background-color: $vf-badge--outline-color--background;
   color: $vf-badge--outline-color--text;
+
+  @include inline-link($vf-badge--outline-color--text,$vf-badge--outline-color--text);
 }

--- a/components/vf-box/vf-box.config.yml
+++ b/components/vf-box/vf-box.config.yml
@@ -1,6 +1,6 @@
 title: Box
 label: Box
-preview: '@preview--elements'
+preview: '@preview--blocks'
 status: alpha
 context:
   pattern-type: block

--- a/components/vf-button/vf-button--sizes.hbs
+++ b/components/vf-button/vf-button--sizes.hbs
@@ -1,5 +1,5 @@
 <section>
-  <button class="vf-button vf-button--s">A Small Button</button>
-  <button class="vf-button">A Regular Button</button>
-  <button class="vf-button vf-button--l">A Large Button</button>
+  <button class="vf-button vf-button--s vf-button--primary">A Small Button</button>
+  <button class="vf-button vf-button--primary">A Regular Button</button>
+  <button class="vf-button vf-button--l vf-button--primary">A Large Button</button>
 </section>

--- a/components/vf-button/vf-button--variants.hbs
+++ b/components/vf-button/vf-button--variants.hbs
@@ -1,4 +1,4 @@
 <section>
-  <button class="vf-button vf-button--pill">A Pill Button</button>
-  <button class="vf-button vf-button--rounded">A Rounded Button</button>
+  <button class="vf-button vf-button--pill vf-button--primary">A Pill Button</button>
+  <button class="vf-button vf-button--rounded vf-button--primary">A Rounded Button</button>
 </section>

--- a/components/vf-button/vf-button.hbs
+++ b/components/vf-button/vf-button.hbs
@@ -1,1 +1,1 @@
-<button class="vf-button">I am a button</button>
+<button class="vf-button vf-button--primary">I am a button</button>

--- a/components/vf-link/vf-link.hbs
+++ b/components/vf-link/vf-link.hbs
@@ -1,4 +1,15 @@
-<a class="vf-link" href="#">An inline link</a>
-<a class="vf-link vf-link--hover" href="#">An inline link :hover</a>
-<a class="vf-link vf-link--visited" href="#">An inline link :visited</a>
-<a class="vf-link" href="#" disabled>An inline link :disabled</a>
+<p class="vf-text">
+  <a class="vf-link" href="#">An inline link</a>
+</p>
+
+<p class="vf-text">
+  <a class="vf-link vf-link--hover" href="#">An inline link :hover</a>
+</p>
+
+<p class="vf-text">
+  <a class="vf-link vf-link--visited" href="#">An inline link :visited</a>
+</p>
+
+<p class="vf-text">
+  <a class="vf-link" href="#" disabled>An inline link :disabled</a>
+</p>

--- a/components/vf-sass-config/mixins/_links.scss
+++ b/components/vf-sass-config/mixins/_links.scss
@@ -1,4 +1,4 @@
-@mixin inline-link($vf-link-color: $vf-link-color, $vf-link-hover-color: $vf-link-hover-color) {
+@mixin inline-link($vf-link-color: $vf-link-color, $vf-link-hover-color: $vf-link-hover-color, $vf-link-visited-color: $vf-link-visited-color, $vf-link-disabled-color: $vf-link-disabled-color) {
   color: $vf-link-color;
 
 

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/panel-html.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/panel-html.nunj
@@ -12,6 +12,7 @@
   </pre>
   {% else %}
   {% for variant in entity.variants().items() %}
+<a id="{{ variant.handle }}-code" href="#{{ variant.handle }}-code">Anchor (todo: `vf-link--anchor` or such)</a>
 <pre class="vf-code-example__pre">{{ '<span class="hljs-comment">&lt;!-- ' + variant.label + ' --&gt;</span>' }}
 {{ render.entity(variant.render(null, renderEnv, {preview: false, collate: false}) | async(true)) | trim }}
 </pre>

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/pen/preview.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/pen/preview.nunj
@@ -39,7 +39,7 @@
 </div>
 
 
-{% if ((entity.preview == '@preview--blocks') or (entity.isCollated)) -%}
+{% if ((entity.preview == '@preview--blocks') or (entity.preview == '@preview--elements') or (entity.isCollated)) -%}
   <div class="vf-body"><div class="vf-grid">
   <div class="vf-pattern__container">
   <!-- @preview--blocks aren't done in iframes, this allows us a bit more flexibility and to test cross-contamination -->

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/pen/preview.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/pen/preview.nunj
@@ -7,7 +7,7 @@
     {% else %}
     {% set variants = entity.parent.variants() %}
     {% endif %}
-    {% if variants.size > 1 %}
+    {% if variants.size > 1 and entity.isCollated == "false" %}
         <div class="vf-tabs">
           <ul class="vf-tabs__list">
             <li class="vf-tabs__item">
@@ -38,32 +38,50 @@
   </div>
 </div>
 
-<div class="Pen-panel Pen-preview Preview" data-behaviour="preview" id="preview-{{ entity.id }}">
-    <div class="Preview-wrapper" data-role="resizer-disabled">
-      {% if renderError -%}
-          {{ renderError }}
-      {% else %}
-       <iframe
-          class="Preview-iframe"
-          data-role="window"
-          src="{{ previewUrl }}"
-          sandbox="allow-same-origin allow-scripts allow-forms"
 
-          marginwidth="0" marginheight="0" frameborder="1" vspace="0" hspace="0" scrolling="yes"
-          onload="resizeIframe(this)"
-        >
-      </iframe>
-      {%- endif %}
+{% if ((entity.preview == '@preview--blocks') or (entity.isCollated)) -%}
+  <div class="vf-body"><div class="vf-grid">
+  <div class="vf-pattern__container">
+  <!-- @preview--blocks aren't done in iframes, this allows us a bit more flexibility and to test cross-contamination -->
+  {% for item in entity.variants().items() %}
+    {% if item.isHidden == false %}
+      <h3 class="vf-text vf-text--heading-r"><a class="vf-badge vf-badge--tertiary" href="#{{ item.handle }}" id="{{ item.handle }}">Variant {{ item.label }}</a></h3>
+      {% set rendered = item.render(null, renderEnv, { preview: withLayout, collate: withCollation }) | async(true) %}
+      {{ rendered}}
+      <hr class="vf-divider" />
+    {% endif %}
+  {% endfor %}
+  </div>
+  </div></div>
+{% else %}
+  <div class="Pen-panel Pen-preview Preview" data-behaviour="preview" id="preview-{{ entity.id }}">
+      <div class="Preview-wrapper" data-role="resizer-disabled">
+        {% if renderError -%}
+            {{ renderError }}
+        {% else %}
+         <iframe
+            class="Preview-iframe"
+            data-role="window"
+            src="{{ previewUrl }}"
+            sandbox="allow-same-origin allow-scripts allow-forms"
 
-      <div class="vf-body">
-        <div class="vf-grid">
-          <p class="vf-figure__caption">
-            Open the above preview in a new window:
-            <a data-no-pjax href="{{ path(frctl.theme.urlFromRoute('preview', { handle: entity.handle })) }}"><span>With layout</span> {% include "icons/open-in-browser.svg" %}</a>
-            <a data-no-pjax href="{{ path(frctl.theme.urlFromRoute('render', { handle: entity.handle })) }}"><span>Component only</span> {% include "icons/open-in-browser.svg" %}</a>
-          </p>
-        </div>
+            marginwidth="0" marginheight="0" frameborder="1" vspace="0" hspace="0" scrolling="yes"
+            onload="resizeIframe(this)"
+          >
+        </iframe>
+        {%- endif %}
+
       </div>
+  </div>
+{%- endif %}
 
-    </div>
+
+<div class="vf-body">
+  <div class="vf-grid">
+    <p class="vf-figure__caption">
+      Open the above preview in a new window:
+      <a data-no-pjax href="{{ path(frctl.theme.urlFromRoute('preview', { handle: entity.handle })) }}"><span>With layout</span> {% include "icons/open-in-browser.svg" %}</a>
+      <a data-no-pjax href="{{ path(frctl.theme.urlFromRoute('render', { handle: entity.handle })) }}"><span>Component only</span> {% include "icons/open-in-browser.svg" %}</a>
+    </p>
+  </div>
 </div>

--- a/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/panel-html.nunj
+++ b/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/panel-html.nunj
@@ -12,6 +12,7 @@
   </pre>
   {% else %}
   {% for variant in entity.variants().items() %}
+<a id="{{ variant.handle }}-code" href="#{{ variant.handle }}-code">Anchor (todo: `vf-link--anchor` or such)</a>
 <pre class="vf-code-example__pre">{{ '<span class="hljs-comment">&lt;!-- ' + variant.label + ' --&gt;</span>' }}
 {{ render.entity(variant.render(null, renderEnv, {preview: false, collate: false}) | async(true)) | trim }}
 </pre>

--- a/tools/frctl-mandelbrot-vf-subtheme/views/partials/pen/preview.nunj
+++ b/tools/frctl-mandelbrot-vf-subtheme/views/partials/pen/preview.nunj
@@ -39,7 +39,7 @@
 </div>
 
 
-{% if ((entity.preview == '@preview--blocks') or (entity.isCollated)) -%}
+{% if ((entity.preview == '@preview--blocks') or (entity.preview == '@preview--elements') or (entity.isCollated)) -%}
   <div class="vf-body"><div class="vf-grid">
   <div class="vf-pattern__container">
   <!-- @preview--blocks aren't done in iframes, this allows us a bit more flexibility and to test cross-contamination -->

--- a/tools/frctl-mandelbrot-vf-subtheme/views/partials/pen/preview.nunj
+++ b/tools/frctl-mandelbrot-vf-subtheme/views/partials/pen/preview.nunj
@@ -7,7 +7,7 @@
     {% else %}
     {% set variants = entity.parent.variants() %}
     {% endif %}
-    {% if variants.size > 1 %}
+    {% if variants.size > 1 and entity.isCollated == "false" %}
         <div class="vf-tabs">
           <ul class="vf-tabs__list">
             <li class="vf-tabs__item">
@@ -38,32 +38,50 @@
   </div>
 </div>
 
-<div class="Pen-panel Pen-preview Preview" data-behaviour="preview" id="preview-{{ entity.id }}">
-    <div class="Preview-wrapper" data-role="resizer-disabled">
-      {% if renderError -%}
-          {{ renderError }}
-      {% else %}
-       <iframe
-          class="Preview-iframe"
-          data-role="window"
-          src="{{ previewUrl }}"
-          sandbox="allow-same-origin allow-scripts allow-forms"
 
-          marginwidth="0" marginheight="0" frameborder="1" vspace="0" hspace="0" scrolling="yes"
-          onload="resizeIframe(this)"
-        >
-      </iframe>
-      {%- endif %}
+{% if ((entity.preview == '@preview--blocks') or (entity.isCollated)) -%}
+  <div class="vf-body"><div class="vf-grid">
+  <div class="vf-pattern__container">
+  <!-- @preview--blocks aren't done in iframes, this allows us a bit more flexibility and to test cross-contamination -->
+  {% for item in entity.variants().items() %}
+    {% if item.isHidden == false %}
+      <h3 class="vf-text vf-text--heading-r"><a class="vf-badge vf-badge--tertiary" href="#{{ item.handle }}" id="{{ item.handle }}">Variant {{ item.label }}</a></h3>
+      {% set rendered = item.render(null, renderEnv, { preview: withLayout, collate: withCollation }) | async(true) %}
+      {{ rendered}}
+      <hr class="vf-divider" />
+    {% endif %}
+  {% endfor %}
+  </div>
+  </div></div>
+{% else %}
+  <div class="Pen-panel Pen-preview Preview" data-behaviour="preview" id="preview-{{ entity.id }}">
+      <div class="Preview-wrapper" data-role="resizer-disabled">
+        {% if renderError -%}
+            {{ renderError }}
+        {% else %}
+         <iframe
+            class="Preview-iframe"
+            data-role="window"
+            src="{{ previewUrl }}"
+            sandbox="allow-same-origin allow-scripts allow-forms"
 
-      <div class="vf-body">
-        <div class="vf-grid">
-          <p class="vf-figure__caption">
-            Open the above preview in a new window:
-            <a data-no-pjax href="{{ path(frctl.theme.urlFromRoute('preview', { handle: entity.handle })) }}"><span>With layout</span> {% include "icons/open-in-browser.svg" %}</a>
-            <a data-no-pjax href="{{ path(frctl.theme.urlFromRoute('render', { handle: entity.handle })) }}"><span>Component only</span> {% include "icons/open-in-browser.svg" %}</a>
-          </p>
-        </div>
+            marginwidth="0" marginheight="0" frameborder="1" vspace="0" hspace="0" scrolling="yes"
+            onload="resizeIframe(this)"
+          >
+        </iframe>
+        {%- endif %}
+
       </div>
+  </div>
+{%- endif %}
 
-    </div>
+
+<div class="vf-body">
+  <div class="vf-grid">
+    <p class="vf-figure__caption">
+      Open the above preview in a new window:
+      <a data-no-pjax href="{{ path(frctl.theme.urlFromRoute('preview', { handle: entity.handle })) }}"><span>With layout</span> {% include "icons/open-in-browser.svg" %}</a>
+      <a data-no-pjax href="{{ path(frctl.theme.urlFromRoute('render', { handle: entity.handle })) }}"><span>Component only</span> {% include "icons/open-in-browser.svg" %}</a>
+    </p>
+  </div>
 </div>


### PR DESCRIPTION
Addresses ideas in #213 and #6, including:

- hiding tabs for collated patterns
- forcing all blocks to have a collated appearance
- not using iframes for collated/blocks
- adding anchor links (we could use a pattern around those)
- also sneaks in a few things found around links in badges

After (left) / before (right):

![image](https://user-images.githubusercontent.com/928100/52558560-feb32680-2df2-11e9-9da2-3dcdf6907ff3.png)
