### PR TITLE
updates pagination patterns

### DIFF
--- a/components/vf-pagination/vf-pagination--expanded.hbs
+++ b/components/vf-pagination/vf-pagination--expanded.hbs
@@ -10,7 +10,7 @@
         First <span class="vf-sr-only"> page</span>
       </a>
     </li>
-    <li class="vf-pagination__item" disabled>
+    <li class="vf-pagination__item">
       <span class="vf-pagination__label">
         ...
       </span>

--- a/components/vf-pagination/vf-pagination--expanded.hbs
+++ b/components/vf-pagination/vf-pagination--expanded.hbs
@@ -10,9 +10,8 @@
         First <span class="vf-sr-only"> page</span>
       </a>
     </li>
-    <li class="vf-pagination__item">
+    <li class="vf-pagination__item" disabled>
       <span class="vf-pagination__label">
-        <span class="vf-sr-only">Previous pages</span>
         ...
       </span>
     </li>
@@ -43,7 +42,6 @@
     </li>
     <li class="vf-pagination__item">
       <span class="vf-pagination__label">
-        <span class="vf-sr-only">Next pages</span>
         ...
       </span>
     </li>

--- a/components/vf-pagination/vf-pagination--full.scss
+++ b/components/vf-pagination/vf-pagination--full.scss
@@ -1,6 +1,7 @@
 .vf-pagination__item--pages-per {
   flex: 2 1 0;
-
+  margin-left: 16px;
+  
   &:hover {
     background: unset;
   }

--- a/components/vf-pagination/vf-pagination.scss
+++ b/components/vf-pagination/vf-pagination.scss
@@ -19,27 +19,14 @@
   align-self: flex-end;
   flex: 1 1 0;
   text-align: center;
-
-  &:hover {
-    background-color: set-color(vf-color-gray);
-
-    .vf-pagination__label,
-    .vf-pagination__link {
-      color: set-color(vf-color-white);
-    }
-  }
 }
+
 
 .vf-pagination__item--is-active {
   background-color: set-color(vf-color-gray);
 
-  .vf-pagination__label,
-  .vf-pagination__link {
+  .vf-pagination__label {
     color: set-color(vf-color-white);
-  }
-
-  &:hover {
-    background-color: set-color(vf-color-gray-dark);
   }
 }
 
@@ -51,6 +38,11 @@
   display: block;
   padding: 4px 8px;
   text-decoration: none;
+}
+
+.vf-pagination__link:hover {
+  background-color: set-color(vf-color-gray);
+  color: set-color(vf-color-white);
 }
 
 .vf-pagination__item--jump-back {

--- a/components/vf-pagination/vf-pagination.scss
+++ b/components/vf-pagination/vf-pagination.scss
@@ -16,16 +16,20 @@
   padding-left: 0;
 }
 .vf-pagination__item {
+  align-self: flex-end;
   flex: 1 1 0;
   text-align: center;
 
   &:hover {
     background-color: set-color(vf-color-gray);
+
+    .vf-pagination__label,
     .vf-pagination__link {
       color: set-color(vf-color-white);
     }
   }
 }
+
 .vf-pagination__item--is-active {
   background-color: set-color(vf-color-gray);
 


### PR DESCRIPTION
This PR:

- updates so the hover effect on `vf-pagination__label` has correct text color
- adds `align-self: flex-end` on `.vf-pagination__item` to allow for the items to take up the same size and align with the bottom of the select box in `vf-pagination--full`
- adds some mergin for the `select` so it's not directly next to the `next` link.