### PR TITLE
this should catch most design tweaks required 

### DIFF
--- a/components/vf-badge/vf-badge.scss
+++ b/components/vf-badge/vf-badge.scss
@@ -22,7 +22,7 @@ $vf-badge--tertiary-color--text: set-color(vf-color-white) !default;
 
 
 .vf-badge {
-  @include set-type(button--r, $custom-margin-bottom: disable);
+  @include set-type(button--s, $custom-margin-bottom: disable);
 
   border: 1px solid currentColor;
   color: inherit;

--- a/components/vf-breadcrumbs/vf-breadcrumbs.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.scss
@@ -1,16 +1,10 @@
 // vf-breadcrumbs
 @import 'vf-breadcrumbs.variables.scss';
 
-.embl-grid > .vf-breadcrumbs {
-  margin-top: $vf-breadcrumbs__margin--top;
-}
-
-.embl-grid > .vf-breadcrumbs:first-child {
-  grid-column: 1 / -1;
-}
-
 .vf-breadcrumbs {
   display: flex;
+  grid-column: main;
+  margin-top: $vf-breadcrumbs__margin--top;
 }
 
 .vf-breadcrumbs__item {

--- a/components/vf-design-tokens/typographic-scales/vf-font--sans.yml
+++ b/components/vf-design-tokens/typographic-scales/vf-font--sans.yml
@@ -1,7 +1,12 @@
 props:
-  - name: button--r
+  - name: button--s
     value:
       font-size: 16px
+      font-weight: 700
+      line-height: 1
+  - name: button--r
+    value:
+      font-size: 24px
       font-weight: 700
       line-height: 1
   - name: body--xs

--- a/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
+++ b/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
@@ -13,7 +13,7 @@
   // Box.
   + .vf-form__label::before {
     background: set-color(vf-color-white);
-    border: 3px solid set-color(vf-color-gray);
+    border: 3px solid set-ui-color(vf-ui-color-gray);
     content: '';
     display: inline-block;
     height: 16px;

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -3,7 +3,7 @@
 .vf-form__input:not([type='file']) {
   @include set-type(body--r);
 
-  border-color: set-color(vf-color-gray);
+  border-color: set-ui-color(vf-ui-color-gray);
   border-style: solid;
   border-width: 3px;
   box-sizing: border-box;

--- a/components/vf-form/vf-form__radio/vf-form__radio.scss
+++ b/components/vf-form/vf-form__radio/vf-form__radio.scss
@@ -14,7 +14,7 @@
   // Box.
   & + .vf-form__label::before {
     background: set-color(vf-color-white);
-    border: 3px solid set-color(vf-color-gray);
+    border-color: set-ui-color(vf-ui-color-gray);
     border-radius: 50%;
     content: '';
     display: inline-block;

--- a/components/vf-form/vf-form__select/vf-form__select.scss
+++ b/components/vf-form/vf-form__select/vf-form__select.scss
@@ -7,7 +7,7 @@
   background-position: right .7em top 50%, 0 0;
   background-repeat: no-repeat, repeat;
   background-size: .65em auto, 100%;
-  border-color: set-color(vf-color-gray);
+  border-color: set-ui-color(vf-ui-color-gray);
   border-radius: 0;
   border-style: solid;
   border-width: 3px;

--- a/components/vf-form/vf-form__textarea/vf-form__textarea.scss
+++ b/components/vf-form/vf-form__textarea/vf-form__textarea.scss
@@ -1,7 +1,7 @@
 // vf-form__textarea
 
 .vf-form__textarea {
-  border: 3px solid set-color(vf-color-gray);
+  border: 3px solid set-ui-color(vf-ui-color-gray);
   box-sizing: border-box;
   display: block;
   padding: 16px 8px;

--- a/components/vf-navigation/vf-navigation--main.scss
+++ b/components/vf-navigation/vf-navigation--main.scss
@@ -14,7 +14,7 @@
   }
 
   .vf-navigation__item {
-    @include set-type(heading--l);
+    @include set-type(heading--s);
 
     display: block;
     margin: 0;

--- a/components/vf-sass-config/variables/vf-font--sans.scss
+++ b/components/vf-sass-config/variables/vf-font--sans.scss
@@ -37,6 +37,12 @@ $vf-typography--sans-serif: (
   ),
 
   'button--r': (
+    'font-size': 24px,
+    'font-weight': 700,
+    'line-height': 1
+  ),
+
+  'button--s': (
     'font-size': 16px,
     'font-weight': 700,
     'line-height': 1


### PR DESCRIPTION
this should fix

- buttons sizes (the sketch is 24px/bold/sans - the site was 16px/bold/sans)
- navigation font size the sketch file had a smaller font size than site
- form borders - these were using the grey from the vf-color - now uses the vf-ui-colors gray
- removes the need for breadcrumbs to have to be within `embl-grid` as this was adding unnecessary vertical spacing.