### PR TITLE
removes bottomg margin for the vf-code-example

### DIFF
--- a/components/vf-code-example/vf-code-example.scss
+++ b/components/vf-code-example/vf-code-example.scss
@@ -8,12 +8,11 @@ $vf-code-example-enable-hljs: true !default;
 .vf-code-example__pre,
 .vf-code-example {
   // pre and code should always be monospace
-  @include set-type(body--s,$vf-font-family-monospace);
+  @include set-type(body--s,$vf-font-family-monospace, $custom-margin-bottom: 0);
 }
 
 .vf-code-example {
   display: grid;
-  margin-bottom: map-get($vf-spacing-map, vf-spacing-xxl) * 2;
 }
 
 .vf-content pre,


### PR DESCRIPTION
as this is mainly, for now, used in the component library and not within the actual visual framework being used (except, for now, the fixed banner on some example pages). I have removed the bottom margin.

For use in the component library we could rely on the parent `vf-tabs__section` for vertical spacing. 

I don't think the jury's out on this one yet - but it at least makes it's used 'in real content terms' look more appealing. 