### PR TITLE
Refactor/vf links list

### DIFF
--- a/components/vf-link-list/vf-link-list--tight.hbs
+++ b/components/vf-link-list/vf-link-list--tight.hbs
@@ -1,26 +1,33 @@
-<div class="vf-links vf-links--tight">
-  <h3 class="vf-links__heading | vf-text vf-text--heading-xs">Latest Posts</h3>
-  <ul class="vf-links__list vf-links__list--s vf-links__list--secondary">
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">All<span class="vf-link__quantity">39</span></a>
+<div class="vf-links vf-links--tight vf-links__list--s">
+  <h3 class="vf-links__heading">Latest Posts</h3>
+  <ul class="vf-links__list vf-links__list--secondary | vf-list">
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="">All</a>
+      <span class="vf-link__quantity">39</span>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">Administration<span class="vf-link__quantity">39</span></a>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="">Administration</a>
+      <span class="vf-link__quantity">39</span>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">Bioninformatics<span class="vf-link__quantity">39</span></a>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="">Bioninformatics</a>
+      <span class="vf-link__quantity">39</span>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">Communication<span class="vf-link__quantity">39</span></a>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="">Communication</a>
+      <span class="vf-link__quantity">39</span>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">Data Curation<span class="vf-link__quantity">39</span></a>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="">Data Curation</a>
+      <span class="vf-link__quantity">39</span>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">General Support Services<span class="vf-link__quantity">39</span></a>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="">General Support Services</a>
+      <span class="vf-link__quantity">39</span>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">IT and Infrastructure<span class="vf-link__quantity">39</span></a>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="">IT and Infrastructure</a>
+      <span class="vf-link__quantity">39</span>
     </li>
   </ul>
 </div>

--- a/components/vf-link-list/vf-link-list--tight.hbs
+++ b/components/vf-link-list/vf-link-list--tight.hbs
@@ -3,31 +3,31 @@
   <ul class="vf-links__list vf-links__list--secondary | vf-list">
     <li class="vf-list__item">
       <a class="vf-list__link" href="">All</a>
-      <span class="vf-link__quantity">39</span>
+      <span class="vf-list__meta">39</span>
     </li>
     <li class="vf-list__item">
       <a class="vf-list__link" href="">Administration</a>
-      <span class="vf-link__quantity">39</span>
+      <span class="vf-list__meta">39</span>
     </li>
     <li class="vf-list__item">
       <a class="vf-list__link" href="">Bioninformatics</a>
-      <span class="vf-link__quantity">39</span>
+      <span class="vf-list__meta">39</span>
     </li>
     <li class="vf-list__item">
       <a class="vf-list__link" href="">Communication</a>
-      <span class="vf-link__quantity">39</span>
+      <span class="vf-list__meta">39</span>
     </li>
     <li class="vf-list__item">
       <a class="vf-list__link" href="">Data Curation</a>
-      <span class="vf-link__quantity">39</span>
+      <span class="vf-list__meta">39</span>
     </li>
     <li class="vf-list__item">
       <a class="vf-list__link" href="">General Support Services</a>
-      <span class="vf-link__quantity">39</span>
+      <span class="vf-list__meta">39</span>
     </li>
     <li class="vf-list__item">
       <a class="vf-list__link" href="">IT and Infrastructure</a>
-      <span class="vf-link__quantity">39</span>
+      <span class="vf-list__meta">39</span>
     </li>
   </ul>
 </div>

--- a/components/vf-link-list/vf-link-list.hbs
+++ b/components/vf-link-list/vf-link-list.hbs
@@ -1,20 +1,20 @@
-<div class="vf-links vf-u-background-color-gray-bright">
-  <h3 class="vf-links__heading | vf-text vf-text--heading-r">Latest Posts</h3>
-  <ul class="vf-links__list">
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">VF’s top social media posts of 2017 and what we learned from them</a>
+<div class="vf-links">
+  <h3 class="vf-links__heading">Latest Posts</h3>
+  <ul class="vf-links__list | vf-list">
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#">VF’s top social media posts of 2017 and what we learned from them</a>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">The VF Imaging Centre: all about visibility</a>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#">The VF Imaging Centre: all about visibility</a>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">Press office sprint 1: journalist personas</a>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#">Press office sprint 1: journalist personas</a>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">A colour scheme for VF</a>{{render '@vf-badge'}}<p class="vf-links__meta">Updated 14th February 2018</p>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#">A colour scheme for VF</a>{{render '@vf-badge'}}<p class="vf-links__meta">Updated 14th February 2018</p>
     </li>
-    <li class="vf-links__item">
-      <a class="vf-links__link" href="JavaScript:Void(0);">New team members</a>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#">New team members</a>
     </li>
   </ul>
 </div>

--- a/components/vf-link-list/vf-link-list.scss
+++ b/components/vf-link-list/vf-link-list.scss
@@ -39,7 +39,7 @@
     text-decoration: none;
   }
 
-  .vf-link__quantity {
+  .vf-list__meta {
     color: set-color(vf-color-gray-dark);
     position: relative;
 

--- a/components/vf-link-list/vf-link-list.scss
+++ b/components/vf-link-list/vf-link-list.scss
@@ -9,6 +9,7 @@
 }
 
 .vf-links__list {
+
   .vf-list__item {
     @include set-type(body--l);
     @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
@@ -28,6 +29,7 @@
 }
 
 .vf-links__list--secondary {
+
   .vf-list__link {
     @include inline-link(
       $vf-link-color: set-color(vf-color-gray),
@@ -36,6 +38,7 @@
 
     text-decoration: none;
   }
+
   .vf-link__quantity {
     color: set-color(vf-color-gray-dark);
     position: relative;
@@ -52,14 +55,18 @@
 
 
 .vf-links--tight {
-.vf-links__heading {
+
+  .vf-links__heading {
     @include set-type(heading--s);
   }
+
   .vf-links__item {
     margin-bottom: map-get($vf-spacing-map, vf-spacing-s);
   }
 }
+
 .vf-links__list--s {
+
   .vf-list__item {
     @include set-type(body--s, $custom-margin-bottom: 8px);
   }

--- a/components/vf-link-list/vf-link-list.scss
+++ b/components/vf-link-list/vf-link-list.scss
@@ -2,31 +2,21 @@
 
 .vf-links {
   margin-bottom: map-get($vf-spacing-map, vf-spacing-xxl);
-  padding: map-get($vf-spacing-map, vf-spacing-xxl)
-    map-get($vf-spacing-map, vf-spacing-r);
 }
-.vf-links--tight {
-  .vf-links__item {
-    margin-bottom: map-get($vf-spacing-map, vf-spacing-s);
-  }
+
+.vf-llnks__heading {
+  @include set-type(heading--r);
 }
-.vf-links__list--s {
-  .vf-links__item {
-    @include set-type(body--s);
-  }
-}
+
 .vf-links__list {
-  @include list(vf-links__list);
+  .vf-list__item {
+    @include set-type(body--l);
+    @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
+  }
 
-  padding: 0;
-}
-
-.vf-links__item {
-  @include set-type(body--l);
-  @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
-}
-.vf-links__link {
-  @include inline-link;
+  .vf-badge {
+    margin-left: 8px;
+  }
 }
 
 .vf-links__meta {
@@ -34,10 +24,11 @@
 
   color: set-color(vf-color-gray-dark);
   display: inline;
+  margin-left: 4px;
 }
 
 .vf-links__list--secondary {
-  .vf-links__link {
+  .vf-list__link {
     @include inline-link(
       $vf-link-color: set-color(vf-color-gray),
       $vf-link-hover-color: set-color(vf-color-gray-dark)
@@ -47,13 +38,29 @@
   }
   .vf-link__quantity {
     color: set-color(vf-color-gray-dark);
-    margin-left: 4px;
     position: relative;
+
     &::before {
       content: '(';
     }
+
     &::after {
       content: ')';
     }
+  }
+}
+
+
+.vf-links--tight {
+.vf-links__heading {
+    @include set-type(heading--s);
+  }
+  .vf-links__item {
+    margin-bottom: map-get($vf-spacing-map, vf-spacing-s);
+  }
+}
+.vf-links__list--s {
+  .vf-list__item {
+    @include set-type(body--s, $custom-margin-bottom: 8px);
   }
 }


### PR DESCRIPTION
This PR:

- updates the `vf-links-list` to remove any background colour or padding as that should be left to `vf-box`.
- changes the HTML so that it's more a case of 'using` `vf-list` rather than duplicating the code.
- moves the 'vf-link__quantity` to `vf-list__meta`.
- tidies up the whitespace in the `.sass` file.


note: we need to see where this is implemented in the WP theme as that will need updating. 

another note: there could probably be a few things here that could move to make `vf-list` the overriding thing that changes 'stuff' like `font-size`,  text `colour` etc.
