### PR TITLE
Fixes/vf ui color

### DIFF
--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -56,6 +56,7 @@
         <div class="vf-masthead__inner">
           <div class="vf-masthead__title">
             <h1 class="vf-masthead__heading">Häring Group</h1>
+            <p class="vf-masthead__sub-heading">Chromosome structure and dynamics</p>
           </div>
         </div>
       </div>

--- a/components/vf-article-meta-information/vf-article-meta-information.scss
+++ b/components/vf-article-meta-information/vf-article-meta-information.scss
@@ -38,7 +38,7 @@
 
   .vf-author--avatar,
   .vf-link.vf-author--avatar__link {
-    border: 1px solid set-ui-color(vf-color-ui-black);
+    border: 1px solid set-ui-color(vf-ui-color-black);
     border-radius: 500px;
     height: 48px;
     order: -1;

--- a/components/vf-article-meta-information/vf-article-meta-information.scss
+++ b/components/vf-article-meta-information/vf-article-meta-information.scss
@@ -38,7 +38,7 @@
 
   .vf-author--avatar,
   .vf-link.vf-author--avatar__link {
-    border: 1px solid set-ui-color(color-ui-black);
+    border: 1px solid set-ui-color(vf-color-ui-black);
     border-radius: 500px;
     height: 48px;
     order: -1;

--- a/components/vf-box/vf-box--inlay.scss
+++ b/components/vf-box/vf-box--inlay.scss
@@ -1,5 +1,5 @@
 .vf-box--inlay {
-  background-color: set-ui-color(vf-color-ui-gray);
-  border-color: set-ui-color(vf-color-ui-gray);
+  background-color: set-ui-color(vf-ui-color-gray);
+  border-color: set-ui-color(vf-ui-color-gray);
   color: set-color(vf-color-black);
 }

--- a/components/vf-box/vf-box--inlay.scss
+++ b/components/vf-box/vf-box--inlay.scss
@@ -1,5 +1,5 @@
 .vf-box--inlay {
-  background-color: set-ui-color(color-ui-gray);
-  border-color: set-ui-color(color-ui-gray);
+  background-color: set-ui-color(vf-color-ui-gray);
+  border-color: set-ui-color(vf-color-ui-gray);
   color: set-color(vf-color-black);
 }

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -8,7 +8,7 @@
   cursor: pointer;
   display: inline-block;
   margin: 0;
-  padding: 16px 24px;
+  padding: 12px;
   text-decoration: none;
 }
 
@@ -42,7 +42,7 @@
   @include button-link($vf-link-color: set-color(vf-color-gray-dark), $vf-link-hover-color: set-color(vf-color-gray));
 
   box-shadow: 0px 6px 0px 0px set-color(vf-color-gray);
-  margin-bottom: 6px; // because we're using box-shadow we need to 'create the space' again 
+  margin-bottom: 6px; // because we're using box-shadow we need to 'create the space' again
 
   &:hover {
     box-shadow: 0px 2px 0px 0px set-color(vf-color-gray);
@@ -74,7 +74,7 @@
 .vf-button--s {
   @include set-type(body--s);
 
-  padding: 12px 8px;
+  padding: 8px;
   // @include padding(all, map-get($vf-spacing-map, vf-spacing-s));
 
   &.vf-button--rounded {
@@ -85,8 +85,7 @@
 .vf-button--l {
   @include set-type(button--r);
 
-  padding: 20px 32px;
-  // @include padding(all, map-get($vf-spacing-map, vf-spacing-l));
+  padding: 16px;
 }
 
 

--- a/components/vf-code-example/vf-code-example.scss
+++ b/components/vf-code-example/vf-code-example.scss
@@ -25,7 +25,7 @@ $vf-code-example-enable-hljs: true !default;
 @if $vf-code-example-enable-hljs == true {
   /* github.com style (c) Vasily Polovnyov <vast@whiteants.net> */
   .hljs {
-    background: set-ui-color(vf-color-ui-gray);
+    background: set-ui-color(vf-ui-color-gray);
     color: set-color(vf-color-black);
     display: block;
     overflow-x: auto;

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -33,6 +33,12 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
   color: $vf-masthead__title-text--color;
 }
 
+.vf-masthead__sub-heading {
+  @include set-type(heading--s);
+
+  color: $vf-masthead__title-text--color;
+}
+
 .vf-masthead__heading a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
in a recent commit we had `color-ui-black` to use with calling the Sass maps for colours -- where we actually need `vf-ui-color-` etc. 

This fixes that.