### PR TITLE
Updates/vf masthead 

### DIFF
--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -52,14 +52,7 @@
 
     <header class="embl-group-header__header embl-group-page--vf-header--bg-color">
 
-      <div class="vf-masthead">
-        <div class="vf-masthead__inner">
-          <div class="vf-masthead__title">
-            <h1 class="vf-masthead__heading">Häring Group</h1>
-            <p class="vf-masthead__sub-heading">Chromosome structure and dynamics</p>
-          </div>
-        </div>
-      </div>
+      {{> '@vf-masthead--groups'}}
 
       <div class="embl-group-header__navigation embl-group-header__navigation--main">
         {{render '@vf-navigation--main'}}

--- a/components/vf-masthead/vf-masthead--groups.hbs
+++ b/components/vf-masthead/vf-masthead--groups.hbs
@@ -1,0 +1,7 @@
+<div class="vf-masthead">
+  <div class="vf-masthead__inner">
+    <div class="vf-masthead__title">
+      <h1 class="vf-masthead__heading">Häring Group<span class="vf-sr-only">:</span> <span class="vf-masthead__heading--additional">Chromosome structure and dynamics</span></h1>
+    </div>
+  </div>
+</div>

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -13,7 +13,8 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
   @media (min-width: $vf-breakpoint-l) {
     display: grid;
     grid-template-columns: calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser)) repeat(auto-fit, minmax(288px, 1fr));
-    grid-template-rows: 48px 1fr;
+    grid-template-rows: max-content 1fr;
+    padding: 16px 0;
   }
 }
 
@@ -28,9 +29,17 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
 
 
 .vf-masthead__heading {
-  @include set-type(heading--xl);
+  @include set-type(heading--xl, $custom-margin-bottom: 0);
 
   color: $vf-masthead__title-text--color;
+  display: flex;
+  flex-direction: column;
+}
+
+.vf-masthead__heading--additional {
+  @include set-type(body--l, $custom-margin-bottom: 0);
+  font-weight: 400;
+  transform: translateY(-8px);
 }
 
 .vf-masthead__sub-heading {


### PR DESCRIPTION
ref: #258 

This component update

- reduces the HTML
- makes the group or team description part of the `H1`

This update does not

- check if `with-title-block` works correctly (I've also not seen this in recent designs)