### PR TITLE
changes pre-commit to pre-push

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -359,7 +359,7 @@ gulp.task('tokens', gulp.parallel(
   'tokens:variables', 'tokens:typographic-scale', 'tokens:maps'
 ));
 
-gulp.task('precommit-test', gulp.parallel(
+gulp.task('prepush-test', gulp.parallel(
   'scss-lint', 'css'
 ));
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "license": "Apache-2.0",
   "husky": {
     "hooks": {
-      "pre-commit": "gulp precommit-test"
+      "pre-push": "gulp prepush-test"
     }
   }
 }


### PR DESCRIPTION
This PR:

- changes the `pre-commit` to a `pre-push` 
- updates anything written as `pre-commit` or similar to `pre-push` or similar
- works great

trying to get a quick win after failing so badly trying to resolve the `vf-masthead` issue.