### PR TITLE
Feature/update embl ontology client

### DIFF
--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.hbs
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.hbs
@@ -1,4 +1,4 @@
-{{> @embl-content-meta-properties }}
+{{> @embl-content-meta-properties meta-who="James Sharpe" meta-what="Sharpe Group" meta-where="EMBL Barcelona"}}
 
 <nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
   <div class="vf-text embl-breadcrumbs-lookup--loading-text"></div>

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -131,29 +131,45 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
    */
   function getBreadcrumbParentTerm(parents,facet) {
     var parentTodos = {
-      1: 'what is the parent term context? who/what/where',
+      1: 'what is the parent term context? who/what/where'
       // 2: 'scan the taxonomy and get any parent IDs',
       // 3: 'if there are parent IDs, add breadcrumb and set URL',
-      4: 'if parent was found, does the parent have a parent?'
+      // 4: 'if parent was found, does the parent have a parent?'
     };
     console.log('Todos for getBreadcrumbParentTerm():',parentTodos);
-
-    // what = 98831673-5bc8-4348-8f42-17b09c1d5462
-    // where = ce40f8b4-c7c3-40fe-911e-8d248654fe7e
-    // who = 8c9899b9-b197-4750-b955-894cda8bf9d5
-
 
     // Get each parent by UUID
     // todo: this lookup is, perhaps, flawed as it gives us each ancestor, irregardless
     //       of it's who/what/where path, but maybe this will provide an interesting
     //       "odeur d'information"
-    var activeParent = emblTaxonomy.terms[parents[facet]];
-    console.log(activeParent)
-    if (activeParent == undefined || activeParent == null) {
-      console.warn('embl-js-breadcumbs-lookup: No matching parent found; Stopping parent lookup.');
-      return;
+
+    function insertParent(activeParent) {
+      if (activeParent == undefined || activeParent == null) {
+        console.warn('embl-js-breadcumbs-lookup: No matching parent found; Stopping parent lookup.');
+        return;
+      }
+      emblBreadcrumbPrimary.innerHTML = formatBreadcrumb(activeParent.name_display,activeParent.url) + emblBreadcrumbPrimary.innerHTML;
+
+      // get parents of parent
+      if (activeParent.parents) {
+        getBreadcrumbParentTerm(activeParent.parents,facet);
+      }
+
     }
-    emblBreadcrumbPrimary.innerHTML = formatBreadcrumb(activeParent.name_display,activeParent.url) + emblBreadcrumbPrimary.innerHTML;
+
+    var activeParent;
+
+    if (parents[facet]) {
+      // if a parent has structured who/what/where parents
+      activeParent = emblTaxonomy.terms[parents[facet]];
+      insertParent(activeParent);
+    } else {
+      // otherwise lookup each parent
+      parents.forEach(function (parentId) {
+        activeParent = emblTaxonomy.terms[parentId];
+        insertParent(activeParent);
+      });
+    }
 
     return;
   }

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -104,14 +104,22 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
 
     Array.prototype.forEach.call(Object.keys(emblTaxonomy.terms), (termId) => {
       let term = emblTaxonomy.terms[termId];
-      console.log(term);
       if (term.name === termName) {
         termObject = term;
         return; //exit
       }
     });
 
-    console.log(termObject);
+    // we never want to return undefined
+    if (termObject == undefined || termObject == null) {
+      console.warn('embl-js-breadcumbs-lookup: No matching breadcrumb found for `' + termName + '`; Will use a simple unlinked term.');
+      termObject = {};
+      termObject.name_display = termName;
+      termObject.uuid = 'null';
+      termObject.uuid = [];
+      termObject.url = '#addBreadcrumbPatternForSimpleTerms';
+    }
+
     return termObject;
   }
 
@@ -134,18 +142,18 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
     // where = ce40f8b4-c7c3-40fe-911e-8d248654fe7e
     // who = 8c9899b9-b197-4750-b955-894cda8bf9d5
 
-    // look up each parent UUID
+
+    // Get each parent by UUID
     // todo: this lookup is, perhaps, flawed as it gives us each ancestor, irregardless
     //       of it's who/what/where path, but maybe this will provide an interesting
     //       "odeur d'information"
-    Array.prototype.forEach.call(parents, (parentId, i) => {
-      Array.prototype.forEach.call(emblTaxonomy.terms, (term, i) => {
-        if (parentId === term.uuid) {
-          emblBreadcrumbPrimary.innerHTML = formatBreadcrumb(term.name_display,term.url) + emblBreadcrumbPrimary.innerHTML;
-          return; //exit
-        }
-      });
-    });
+    var activeParent = emblTaxonomy.terms[parents[facet]];
+    console.log(activeParent)
+    if (activeParent == undefined || activeParent == null) {
+      console.warn('embl-js-breadcumbs-lookup: No matching parent found; Stopping parent lookup.');
+      return;
+    }
+    emblBreadcrumbPrimary.innerHTML = formatBreadcrumb(activeParent.name_display,activeParent.url) + emblBreadcrumbPrimary.innerHTML;
 
     return;
   }
@@ -169,15 +177,6 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
   }
 
   var currentTerm = getCurrentTerm(termName);
-  if (currentTerm == undefined || currentTerm == null) {
-    console.warn('embl-js-breadcumbs-lookup: No matching breadcrumb found for `' + termName + '`; Will use a simple unlinked term.');
-    var currentTerm = {};
-    currentTerm.name_display = termName;
-    currentTerm.uuid = 'null';
-    currentTerm.uuid = [];
-    currentTerm.url = '#addBreadcrumbPatternForSimpleTerms'
-  }
-  console.log(currentTerm)
   var breadcrumbId = currentTerm.uuid,
       breadcrumbUrl = currentTerm.url || '#addFunctionForBreadcrumbPatternForSimpleTerms',
       breadcrumbParents = currentTerm.parents;

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -54,7 +54,7 @@ function emblBreadcrumbsLookup(metaProperties) {
  * @param {string} [url] - URL to pull the taxonomy from
  */
 function emblGetTaxonomy(url) {
-  var url = url || 'https://dev.beta.embl.org/api/v1/pattern.json?pattern=embl-taxonomy&source=contenthub';
+  var url = url || 'https://dev.beta.embl.org/api/v1/pattern.json?pattern=embl-ontology&source=contenthub';
 
   // from https://developers.google.com/web/fundamentals/primers/promises
   // Return a new promise.
@@ -102,13 +102,16 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
 
     var termObject;
 
-    Array.prototype.forEach.call(emblTaxonomy.terms, (term, i) => {
+    Array.prototype.forEach.call(Object.keys(emblTaxonomy.terms), (termId) => {
+      let term = emblTaxonomy.terms[termId];
+      console.log(term);
       if (term.name === termName) {
         termObject = term;
         return; //exit
       }
     });
 
+    console.log(termObject);
     return termObject;
   }
 
@@ -167,10 +170,16 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
 
   var currentTerm = getCurrentTerm(termName);
   if (currentTerm == undefined || currentTerm == null) {
-    console.warn('embl-js-breadcumbs-lookup: No matching breadcrumb found for `' + termName + '`; Exiting.');
+    console.warn('embl-js-breadcumbs-lookup: No matching breadcrumb found for `' + termName + '`; Will use a simple unlinked term.');
+    var currentTerm = {};
+    currentTerm.name_display = termName;
+    currentTerm.uuid = 'null';
+    currentTerm.uuid = [];
+    currentTerm.url = '#addBreadcrumbPatternForSimpleTerms'
   }
+  console.log(currentTerm)
   var breadcrumbId = currentTerm.uuid,
-      breadcrumbUrl = currentTerm.url || 'null',
+      breadcrumbUrl = currentTerm.url || '#addFunctionForBreadcrumbPatternForSimpleTerms',
       breadcrumbParents = currentTerm.parents;
 
   // narrow down to the first matching element
@@ -200,7 +209,8 @@ function emblBreadcrumbs() {
     emblTaxonomy = JSON.parse(response);
 
     // Preprocess the emblTaxonomy for some cleanup tasks
-    Array.prototype.forEach.call(emblTaxonomy.terms, (term, i) => {
+    Array.prototype.forEach.call(Object.keys(emblTaxonomy.terms), (termId) => {
+      let term = emblTaxonomy.terms[termId];
       // If `name_display` is not set, use the internal name
       if (term.name_display === '') term.name_display = term.name;
       // handle null URL

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -124,24 +124,23 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
   }
 
   /**
-   * Take a term and get its parent term
+   * Take a term and get its parent term UUID
+   * todo: this lookup is, perhaps, flawed as it gives us each ancestor, irregardless
+   *       of it's who/what/where path, but maybe this will provide an interesting
+   *       "odeur d'information"
    * @example getBreadcrumbParentTerm(parents,context)
    * @param {array} [parents]  - array of UUIDs
    * @param {string} [facet] - who, what, where
    */
   function getBreadcrumbParentTerm(parents,facet) {
     var parentTodos = {
-      1: 'what is the parent term context? who/what/where'
+      1: 'Respect the parent term context: who/what/where'
       // 2: 'scan the taxonomy and get any parent IDs',
       // 3: 'if there are parent IDs, add breadcrumb and set URL',
       // 4: 'if parent was found, does the parent have a parent?'
     };
     console.log('Todos for getBreadcrumbParentTerm():',parentTodos);
 
-    // Get each parent by UUID
-    // todo: this lookup is, perhaps, flawed as it gives us each ancestor, irregardless
-    //       of it's who/what/where path, but maybe this will provide an interesting
-    //       "odeur d'information"
 
     function insertParent(activeParent) {
       if (activeParent == undefined || activeParent == null) {

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -147,6 +147,7 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
         console.warn('embl-js-breadcumbs-lookup: No matching parent found; Stopping parent lookup.');
         return;
       }
+      activeParent.url = activeParent.url || '#addPatternForTermsWithNoUrl';
       emblBreadcrumbPrimary.innerHTML = formatBreadcrumb(activeParent.name_display,activeParent.url) + emblBreadcrumbPrimary.innerHTML;
 
       // get parents of parent


### PR DESCRIPTION
This revises the `embl-breadcrumbs-lookup` pattern for [the ontology approach](https://gitlab.ebi.ac.uk/emblorg/backlog/issues/124).

Also included is that it looks up the parent-parents  of the active term ... there's more work to be done there.