### PR TITLE
pattern/support-vf-link-in-vf-masthead

### DIFF
--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -56,7 +56,7 @@
         <div class="vf-masthead__inner">
           <div class="vf-masthead__title">
             <h1 class="vf-masthead__heading">
-              <a href="#" class="vf-link">Häring Group</a>
+              <a href="#" class="vf-masthead__heading__link">Häring Group</a>
             </h1>
             <p class="vf-masthead__sub-heading">Chromosome structure and dynamics</p>
           </div>

--- a/components/embl-group-page/embl-group-page.hbs
+++ b/components/embl-group-page/embl-group-page.hbs
@@ -55,7 +55,9 @@
       <div class="vf-masthead">
         <div class="vf-masthead__inner">
           <div class="vf-masthead__title">
-            <h1 class="vf-masthead__heading">Häring Group</h1>
+            <h1 class="vf-masthead__heading">
+              <a href="#" class="vf-link">Häring Group</a>
+            </h1>
             <p class="vf-masthead__sub-heading">Chromosome structure and dynamics</p>
           </div>
         </div>

--- a/components/vf-masthead/vf-masthead--inlay.hbs
+++ b/components/vf-masthead/vf-masthead--inlay.hbs
@@ -4,7 +4,7 @@
       <div class="vf-masthead__inner">
         <div class="vf-masthead__title">
           <h1 class="vf-masthead__heading">
-            <a class="vf-link" href="http://dev-vf-theme-prototype.pantheonsite.io">Häring Group</a>
+            <a class="vf-masthead__heading__link" href="http://dev-vf-theme-prototype.pantheonsite.io">Häring Group</a>
           </h1>
         </div>
       </div>

--- a/components/vf-masthead/vf-masthead--inlay.hbs
+++ b/components/vf-masthead/vf-masthead--inlay.hbs
@@ -4,7 +4,7 @@
       <div class="vf-masthead__inner">
         <div class="vf-masthead__title">
           <h1 class="vf-masthead__heading">
-            <a href="http://dev-vf-theme-prototype.pantheonsite.io">Häring Group</a>
+            <a class="vf-link" href="http://dev-vf-theme-prototype.pantheonsite.io">Häring Group</a>
           </h1>
         </div>
       </div>

--- a/components/vf-masthead/vf-masthead--with-title-block.hbs
+++ b/components/vf-masthead/vf-masthead--with-title-block.hbs
@@ -2,7 +2,7 @@
   <div class="vf-masthead__title">
     <div class="vf-masthead__title-inner">
       <h1 class="vf-masthead__heading">
-        <a href="http://dev.beta.embl.org/guidelines/visual-framework" class="Header-title" data-pjax="">Visual Framework 2.0</a>
+        <a href="http://dev.beta.embl.org/guidelines/visual-framework" class="vf-link" data-pjax="">Visual Framework 2.0</a>
       </h1>
       <h2 class="vf-masthead__subheading">
         <span class="vf-masthead__location">EMBL</span>

--- a/components/vf-masthead/vf-masthead--with-title-block.hbs
+++ b/components/vf-masthead/vf-masthead--with-title-block.hbs
@@ -2,7 +2,7 @@
   <div class="vf-masthead__title">
     <div class="vf-masthead__title-inner">
       <h1 class="vf-masthead__heading">
-        <a href="http://dev.beta.embl.org/guidelines/visual-framework" class="vf-link" data-pjax="">Visual Framework 2.0</a>
+        <a href="http://dev.beta.embl.org/guidelines/visual-framework" class="vf-masthead__heading__link" data-pjax="">Visual Framework 2.0</a>
       </h1>
       <h2 class="vf-masthead__subheading">
         <span class="vf-masthead__location">EMBL</span>

--- a/components/vf-masthead/vf-masthead.hbs
+++ b/components/vf-masthead/vf-masthead.hbs
@@ -1,7 +1,9 @@
 <div class="vf-masthead" style="background-image: url('{{ path '/assets/vf-masthead/assets/group-bg.png' }}')">
   <div class="vf-masthead__inner">
     <div class="vf-masthead__title">
-      <h1 class="vf-masthead__heading">Strategy &amp; Communications</h1>
+      <h1 class="vf-masthead__heading">
+        <a href="#" class="vf-link">Strategy &amp; Communications</a>
+      </h1>
       <h2 class="vf-masthead__subheading">
         <span class="vf-masthead__location">VF Hamburg</span>
         <span class="vf-masthead__group">Structural Biology</span>

--- a/components/vf-masthead/vf-masthead.hbs
+++ b/components/vf-masthead/vf-masthead.hbs
@@ -2,7 +2,7 @@
   <div class="vf-masthead__inner">
     <div class="vf-masthead__title">
       <h1 class="vf-masthead__heading">
-        <a href="#" class="vf-link">Strategy &amp; Communications</a>
+        <a href="#" class="vf-masthead__heading__link">Strategy &amp; Communications</a>
       </h1>
       <h2 class="vf-masthead__subheading">
         <span class="vf-masthead__location">VF Hamburg</span>

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -39,7 +39,7 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
   color: $vf-masthead__title-text--color;
 }
 
-.vf-masthead__heading a {
+.vf-masthead__heading .vf-link {
   color: inherit;
   text-decoration: none;
   z-index: 5150;

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -39,7 +39,7 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
   color: $vf-masthead__title-text--color;
 }
 
-.vf-masthead__heading .vf-link {
+.vf-masthead__heading__link {
   color: inherit;
   text-decoration: none;
   z-index: 5150;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17542,7 +17542,7 @@
         },
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         },

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
@@ -5,7 +5,7 @@
     <div class="vf-masthead__title">
       <div class="vf-masthead__title-inner">
         <h1 class="vf-masthead__heading">
-          <a href="http://dev.beta.embl.org/guidelines/visual-framework" class="Header-title" data-pjax>{{ frctl.get('project.title') | default('Component Library') }}</a>
+          <a href="http://dev.beta.embl.org/guidelines/visual-framework" class="vf-link" data-pjax>{{ frctl.get('project.title') | default('Component Library') }}</a>
         </h1>
         <h2 class="vf-masthead__subheading">
           <span class="vf-masthead__location">EMBL</span>

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/header.nunj
@@ -5,7 +5,7 @@
     <div class="vf-masthead__title">
       <div class="vf-masthead__title-inner">
         <h1 class="vf-masthead__heading">
-          <a href="http://dev.beta.embl.org/guidelines/visual-framework" class="vf-link" data-pjax>{{ frctl.get('project.title') | default('Component Library') }}</a>
+          <a href="http://dev.beta.embl.org/guidelines/visual-framework" class="vf-masthead__heading__link" data-pjax>{{ frctl.get('project.title') | default('Component Library') }}</a>
         </h1>
         <h2 class="vf-masthead__subheading">
           <span class="vf-masthead__location">EMBL</span>


### PR DESCRIPTION
This does two useful things:

- Drops styling on an `a` element in the CSS
- Supports usage of `vf-masthead__heading__link`

In practice that means it resolves common styling specificity issues when dealing with `a:visited` in other CSS files (like I'm dealing with when trying to integrate with the EBI VF 1.3 CSS).