### PR TITLE
enhancement: Block border bottom colours on links

### DIFF
--- a/components/vf-sass-config/mixins/_links.scss
+++ b/components/vf-sass-config/mixins/_links.scss
@@ -2,23 +2,39 @@
   $vf-link-color: $vf-link-color,
   $vf-link-hover-color: $vf-link-hover-color,
   $vf-link-visited-color: $vf-link-visited-color,
-  $vf-link-disabled-color: $vf-link-disabled-color) {
+  $vf-link-disabled-color: $vf-link-disabled-color,
+  $vf-include-normalisations: $vf-include-normalisations) {
+
+  /// @todo Add documentation about how/when/where to expect, use $vf-include-normalisations
+  @if $vf-include-normalisations == true {
+    border-bottom: none;
+  }
 
   color: $vf-link-color;
 
-  border-bottom: none;
-
   &:visited {
     color: $vf-link-visited-color;
+
+    @if $vf-include-normalisations == true {
+      border-bottom: none;
+    }
   }
 
   &:hover {
     color: $vf-link-hover-color;
+
+    @if $vf-include-normalisations == true {
+      border-bottom: none;
+    }
   }
 
   &[disabled] {
     color: $vf-link-disabled-color;
     cursor: not-allowed;
+
+    @if $vf-include-normalisations == true {
+      border-bottom: none;
+    }
   }
 }
 

--- a/components/vf-sass-config/mixins/_links.scss
+++ b/components/vf-sass-config/mixins/_links.scss
@@ -6,6 +6,8 @@
 
   color: $vf-link-color;
 
+  border-bottom: none;
+
   &:visited {
     color: $vf-link-visited-color;
   }
@@ -30,7 +32,6 @@
   border: 2px solid $vf-link-color;
   color: map-get($vf-colors-map, vf-color-white);
 
-
   &:visited {
     background-color: $vf-link-visited-color;
     border-color: $vf-link-visited-color;
@@ -52,7 +53,7 @@
   $vf-link-color: $vf-link-color,
   $vf-link-hover-color: $vf-link-hover-color,
   $vf-link-visited-color: $vf-link-visited-color) {
-    
+
   background-color: map-get($vf-colors-map, vf-color-white);
   border: 2px solid $vf-link-color;
   color: $vf-link-color;

--- a/components/vf-sass-config/variables/vf-global-variables.scss
+++ b/components/vf-sass-config/variables/vf-global-variables.scss
@@ -1,14 +1,22 @@
+// typography variables
+
 @import 'vf-font-families.scss';
 $use-global-typography: true !default;
 $global-font-family: $vf-font-family-sans-serif;
-$vf-include-normalisations: true !default;
+$vf-text-margin--bottom: 16px;
 
 // grid variables
 
 $global-grid-column-gap: 1em;
-$vf-text-margin--bottom: 16px;
-
 $global-page-max-width: 76.5em;
 
-// deprecation
+// deprecation variables
+
 $vf-deprecation-warning: 'This pattern has been deprecated. Consult the pattern\'s README.md for migration tips.';
+
+// normalisation variables
+//
+// This is set to true to remove styling that is added to the VF 2.0 codebase from older VF 1.0 code that 
+// could also be included on the same page.
+
+$vf-include-normalisations: true !default;

--- a/components/vf-sass-config/variables/vf-global-variables.scss
+++ b/components/vf-sass-config/variables/vf-global-variables.scss
@@ -1,7 +1,7 @@
 @import 'vf-font-families.scss';
 $use-global-typography: true !default;
 $global-font-family: $vf-font-family-sans-serif;
-
+$vf-include-normalisations: true !default;
 
 // grid variables
 


### PR DESCRIPTION
A common clash with external css will be `a {border-bottom: 1px dotted; }` we can prevent this on on many links with `vf-*` classes by adding `border-bottom: 0` to the inline-link mixin.

It  seems a reasonable assumption?