### PR TITLE
normalise: underline links

### DIFF
--- a/components/vf-sass-config/mixins/_links.scss
+++ b/components/vf-sass-config/mixins/_links.scss
@@ -8,6 +8,7 @@
   /// @todo Add documentation about how/when/where to expect, use $vf-include-normalisations
   @if $vf-include-normalisations == true {
     border-bottom: none;
+    text-decoration: underline;
   }
 
   color: $vf-link-color;
@@ -17,6 +18,7 @@
 
     @if $vf-include-normalisations == true {
       border-bottom: none;
+      text-decoration: underline;
     }
   }
 
@@ -25,6 +27,7 @@
 
     @if $vf-include-normalisations == true {
       border-bottom: none;
+      text-decoration: underline;
     }
   }
 
@@ -34,6 +37,7 @@
 
     @if $vf-include-normalisations == true {
       border-bottom: none;
+      text-decoration: underline;
     }
   }
 }


### PR DESCRIPTION
This follows up on #283, and normalises the `@mixin inline-link` to underline links.

Background:

1. We're relying on normalise+default browser behaviour to underline links (that is, we never explicitily say `a { text-decoration: underline}`
2. Many other frameworks reset `a, a:vistited { text-decoration: prop }`
3. It's reasonable that we expect where a `vf-link` type of class has been used that we want to not use a global `a:visited` style

