### PR TITLE
bug: make group masthead link styling more robust

### DIFF
--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -40,7 +40,9 @@ $vf-masthead__title-text--color: set-color(vf-color-white);
 }
 
 .vf-masthead__heading__link {
-  color: inherit;
+  @include inline-link($vf-masthead__title-text--color,$vf-masthead__title-text--color,$vf-masthead__title-text--color,$vf-masthead__title-text--color);
+
+  color: $vf-masthead__title-text--color;
   text-decoration: none;
   z-index: 5150;
 }


### PR DESCRIPTION
Follows up on #185 to make things more consistent on link hover, underlines. Prompted by the integration with external styles, but also makes things a bit better generally (like when it has been `:visisted`)