### PR TITLE
bug: stop emblContentHub from running twice

### DIFF
--- a/components/embl-content-hub-loader/embl-content-hub-loader.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.js
@@ -12,6 +12,4 @@ function emblContentHub() {
   emblContentHubFetch();
 }
 
-emblContentHub();
-
 export { emblContentHub };


### PR DESCRIPTION
Accidently left the call to `emblContentHub()` inside the pattern directly, should have only been done in `scripts.js`