### PR TITLE
updates visual framework pattern page layout

### DIFF
--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/browser.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/browser.nunj
@@ -7,12 +7,12 @@
   {% endall %}
   #}
 
-  <hr class="vf-divider vf-u-margin__bottom-xl vf-u-margin__top-xl">
+  <hr class="vf-divider vf-u-margin__bottom-r vf-u-margin__top-r">
 
   {% include 'partials/browser/panel-html.nunj' %}
 
 
-  <hr class="vf-divider vf-u-margin__bottom-xl vf-u-margin__top-xl">
+  <hr class="vf-divider vf-u-margin__bottom-r vf-u-margin__top-r">
 
   <div class="vf-grid vf-grid__col-3">
     <div class="vf-grid__col--span-3">

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/panel-notes.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/panel-notes.nunj
@@ -1,4 +1,4 @@
-<hr class="vf-divider vf-u-margin__bottom-xl vf-u-margin__top-xl">
+<hr class="vf-divider vf-u-margin__bottom-r vf-u-margin__top-r">
 <h3 class="vf-text vf-text--heading-r">Notes</h3>
 <div class="vf-content">
   <div class="pattern-library-notes pattern-library-notes--condensed">

--- a/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/pattern-list.nunj
+++ b/tools/frctl-mandelbrot-embl-subtheme/views/partials/browser/pattern-list.nunj
@@ -26,7 +26,7 @@
     </div>
   </section>
 </section>
-<hr class="vf-divider vf-u-margin__bottom-xl vf-u-margin__top-xl">
+<hr class="vf-divider vf-u-margin__bottom-r vf-u-margin__top-r">
 {% endmacro %}
 
 {{ patternByType('Grids', type='grid', description='Put stuff in columns.') }}

--- a/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/browser.nunj
+++ b/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/browser.nunj
@@ -7,12 +7,12 @@
   {% endall %}
   #}
 
-  <hr class="vf-divider vf-u-margin__bottom-xl vf-u-margin__top-xl">
+  <hr class="vf-divider vf-u-margin__bottom-r vf-u-margin__top-r">
 
   {% include 'partials/browser/panel-html.nunj' %}
 
 
-  <hr class="vf-divider vf-u-margin__bottom-xl vf-u-margin__top-xl">
+  <hr class="vf-divider vf-u-margin__bottom-r vf-u-margin__top-r">
 
   <div class="vf-grid vf-grid__col-3">
     <div class="vf-grid__col--span-3">

--- a/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/panel-notes.nunj
+++ b/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/panel-notes.nunj
@@ -1,4 +1,4 @@
-<hr class="vf-divider vf-u-margin__bottom-xl vf-u-margin__top-xl">
+<hr class="vf-divider vf-u-margin__bottom-r vf-u-margin__top-r">
 <h3 class="vf-text vf-text--heading-r">Notes</h3>
 <div class="vf-content">
   <div class="pattern-library-notes pattern-library-notes--condensed">

--- a/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/pattern-list.nunj
+++ b/tools/frctl-mandelbrot-vf-subtheme/views/partials/browser/pattern-list.nunj
@@ -4,8 +4,8 @@
 
 
 {% macro patternByType(displayName='Grids', type='grid', description='') %}
-<section class="embl-grid embl-grid--with-label">
-  <section data-description="label area">
+<section class="vf-grid">
+  <section data-description="label area" style="grid-column: 1 / -1;">
     <h4 class="vf-text vf-text--heading-s">
       {{ displayName }}
       <a id="{{ type }}"></a>
@@ -14,8 +14,7 @@
       {{ description }}
     </p>
   </section>
-  <section data-description="pattern list">
-    <div class="vf-grid vf-grid__col-3">
+  <section data-description="pattern list" class="vf-grid vf-grid__col-4" style="grid-column: 1 / -1;">
       {% asyncEach component in frctl.components %}
 
         {# handle component collections, aka "subpatterns" #}
@@ -23,8 +22,7 @@
           {% for subcomponent in component %}
             {% if subcomponent.context['pattern-type'] == type and subcomponent.isHidden != true %}
               <p class="vf-text">
-                <a class="vf-link" href="{{ path(frctl.theme.urlFromRoute('component', { handle: subcomponent.handle })) }}">{{ subcomponent.label }}</a>
-                {% if subcomponent.status %}{{ status.unlabelled(subcomponent.status) }}{% endif %}
+                <a class="vf-link--secondary" href="{{ path(frctl.theme.urlFromRoute('component', { handle: subcomponent.handle })) }}">{{ subcomponent.label }}</a>
               </p>
             {% endif %}
           {% endfor %}
@@ -32,15 +30,13 @@
 
         {% if component.context['pattern-type'] == type %}
         <p class="vf-text">
-          <a class="vf-link" href="{{ path(frctl.theme.urlFromRoute('component', { handle: component.handle })) }}">{{ component.label }}</a>
-          {% if component.status %}{{ status.unlabelled(component.status) }}{% endif %}
+          <a class="vf-link--secondary" href="{{ path(frctl.theme.urlFromRoute('component', { handle: component.handle })) }}">{{ component.label }}</a>
         </p>
         {% endif %}
       {% endeach %}
-    </div>
   </section>
 </section>
-<hr class="vf-divider vf-u-margin__bottom-xl vf-u-margin__top-xl">
+<hr class="vf-divider vf-u-margin__bottom-r vf-u-margin__top-r">
 {% endmacro %}
 
 {{ patternByType('Grids', type='grid', description='Put stuff in columns.') }}


### PR DESCRIPTION
puts the `link--secondary` onto the patterns home page, removes some divs, changes up the grid, removes some vertical spacing

<img width="1255" alt="Screenshot 2019-03-14 at 15 21 32" src="https://user-images.githubusercontent.com/925197/54364322-f443b100-466c-11e9-99d8-8fbd8fcb6118.png">