### PR TITLE
Pattern/vf-summary--has-image

### DIFF
--- a/components/vf-core/index.scss
+++ b/components/vf-core/index.scss
@@ -97,6 +97,7 @@ html, button {
   @import 'vf-summary/vf-summary--job.scss';
   @import 'vf-summary/vf-summary--profile.scss';
   @import 'vf-summary/vf-summary--news.scss';
+  @import 'vf-summary/vf-summary--has-image.scss';
 
 @import 'vf-video/vf-video.scss';
 @import 'vf-video-teaser/vf-video-teaser.scss';

--- a/components/vf-summary/index.scss
+++ b/components/vf-summary/index.scss
@@ -17,3 +17,4 @@
 @import 'vf-summary--job.scss';
 @import 'vf-summary--news.scss';
 @import 'vf-summary--profile.scss';
+@import 'vf-summary--has-image.scss';

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -15,11 +15,13 @@
     "vf-summary--job.scss",
     "vf-summary--news.scss",
     "vf-summary--profiles.scss",
+    "vf-summary--has-image.scss",
     "vf-summary.css",
     "vf-summary.hbs",
     "vf-summary--article.hbs",
     "vf-summary--job.hbs",
-    "vf-summary--mews-has-image.hbs",
+    "vf-summary--news-has-image.hbs",
+    "vf-summary--has-image.hbs"
     "vf-summary--news.hbs",
     "vf-summary--profiles.hbs",
     "vf-summary.config.yml"

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -21,7 +21,7 @@
     "vf-summary--article.hbs",
     "vf-summary--job.hbs",
     "vf-summary--news-has-image.hbs",
-    "vf-summary--has-image.hbs"
+    "vf-summary--has-image.hbs",
     "vf-summary--news.hbs",
     "vf-summary--profiles.hbs",
     "vf-summary.config.yml"

--- a/components/vf-summary/vf-summary--has-image.hbs
+++ b/components/vf-summary/vf-summary--has-image.hbs
@@ -1,0 +1,13 @@
+<article class="vf-summary vf-summary--has-image">
+  <a href="//www.ebi.ac.uk/biosamples/" class="vf-summary__link">
+    <img class="vf-summary__image vf-summary__image--thumbnail" src="https://www.ebi.ac.uk/biosamples/images/logo_biosamples.png" alt="BioSamples">
+  </a>
+  <h3 class="vf-summary__title">
+    <a href="//www.ebi.ac.uk/biosamples/" class="vf-summary__link">
+      BioSamples
+    </a>
+  </h3>
+  <p class="vf-summary__text">
+    A database describing biological samples and providing links to associated experimental data.
+  </p>
+</article>

--- a/components/vf-summary/vf-summary--has-image.scss
+++ b/components/vf-summary/vf-summary--has-image.scss
@@ -1,0 +1,28 @@
+.vf-summary--has-image {
+
+  grid-column-gap: 18px;
+  grid-template-columns: minmax(0, auto) 1fr;
+  grid-template-rows: auto;
+  @include margin--block(bottom, 48px);
+
+  .vf-summary__image {
+    grid-column: 1 / span 1;
+    grid-row: 1 / span 4;
+    width: 180px;
+  }
+
+  .vf-summary__image--thumbnail {
+    width: 50px;
+  }
+
+  .vf-summary__title {
+    grid-column: 2 / -1;
+  }
+
+  .vf-summary__text {
+    align-items: center;
+    display: block;
+    grid-column: 2 / -1;
+  }
+
+}


### PR DESCRIPTION
A placeholder for use in the data resources pages. 

Briefly chatted with Mark on this and like the linked image list, the idea was to make something generic-ish.

![image](https://user-images.githubusercontent.com/928100/54427843-edc04280-471b-11e9-869d-af89c9a11103.png)
