### PR TITLE
Feature/variant modifiers

### DIFF
--- a/components/vf-box/vf-box.hbs
+++ b/components/vf-box/vf-box.hbs
@@ -1,4 +1,4 @@
 <div class="vf-box">
-  <h2 class="vf-text vf-text--heading-l">Hello World</h2>
+  {{> @vf-heading--template large="true" title="Hello World"}}
   <p class="vf-text vf-text--body-r">This is some more content that would be in the box.</p>
 </div>

--- a/components/vf-heading/vf-heading--template.hbs
+++ b/components/vf-heading/vf-heading--template.hbs
@@ -1,0 +1,19 @@
+{{!--
+  Pass in your display type and title:
+  {{> @vf-heading--template small="true" title="I'm a small headline"}}
+--}}
+
+{{#if display}}
+  <h1 class="vf-text vf-text--heading-xl vf-text--invert">{{{title}}}</h1>
+{{else if extra-large}}
+  <h2 class="vf-text vf-text--heading-xl">{{{title}}}</h2>
+{{else if large}}
+  <h3 class="vf-text vf-text--heading-l">{{{title}}}</h3>
+{{else if regular}}
+  <h4 class="vf-text vf-text--heading-r">{{{title}}}</h4>
+{{else if small}}
+  <h5 class="vf-text vf-text--heading-s">{{{title}}}</h5>
+{{else}}
+  {{!-- catch all for if the heading type doesn't match --}}
+  <h6 class="vf-text vf-text--heading-s">{{{title}}}</h6>
+{{/if}}

--- a/components/vf-heading/vf-heading.config.yml
+++ b/components/vf-heading/vf-heading.config.yml
@@ -2,26 +2,19 @@ title: Visual Framework Headings
 label: Headings
 preview: '@preview--elements'
 status: beta
+variants:
+  - name: template
+    hidden: true
 context:
   pattern-type: element
   vf-heading-modifiers:
-    display:
+    - display: true
       title: This heading size is display and inverted
-      element: h1
-      modifiers: -xl vf-text--invert
-    extra-large:
+    - extra-large: true
       title: This heading size is extra large
-      element: h2
-      modifiers:  -xl
-    large:
+    - large: true
       title: This heading size is large
-      element: h3
-      modifiers:  -l
-    regular:
+    - regular: true
       title: This heading size is regular
-      element: h4
-      modifiers:  -r
-    small:
+    - small: true
       title: This heading size is small
-      element: h5
-      modifiers:  -s

--- a/components/vf-heading/vf-heading.config.yml
+++ b/components/vf-heading/vf-heading.config.yml
@@ -1,6 +1,27 @@
 title: Visual Framework Headings
 label: Headings
 preview: '@preview--elements'
-status: alpha
+status: beta
 context:
   pattern-type: element
+  vf-heading-modifiers:
+    display:
+      title: This heading size is display and inverted
+      element: h1
+      modifiers: -xl vf-text--invert
+    extra-large:
+      title: This heading size is extra large
+      element: h2
+      modifiers:  -xl
+    large:
+      title: This heading size is large
+      element: h3
+      modifiers:  -l
+    regular:
+      title: This heading size is regular
+      element: h4
+      modifiers:  -r
+    small:
+      title: This heading size is small
+      element: h5
+      modifiers:  -s

--- a/components/vf-heading/vf-heading.hbs
+++ b/components/vf-heading/vf-heading.hbs
@@ -1,20 +1,8 @@
-<!-- Display -->
-<h1 class="vf-text vf-text--heading-xl">This heading size is display </h1>
+{{#with vf-heading-modifiers as |modifier|}}
+{{ log modifier }}
+  {{#each modifier as |modifier key|}}
+    <!-- {{ key }} -->
+    <{{this.element}} class="vf-text vf-text--heading{{this.modifiers}}">{{this.title}}</{{this.element}}>
 
-<h1 class="vf-text vf-text--heading-xl vf-text--invert">This heading size is display </h1>
-
-<!-- Xl -->
-<h1 class="vf-text vf-text--heading-xl">This heading size is extra large </h1>
-
-<!-- L -->
-<h2 class="vf-text vf-text--heading-l">This heading size is large </h2>
-
-<!-- R -->
-<h3 class="vf-text vf-text--heading-r">This heading size is regular </h3>
-
-<!-- S -->
-<h4 class="vf-text vf-text--heading-s">This heading size is small </h4>
-
-<!-- Xs -->
-<h5 class="vf-text vf-text--heading-xs">This heading size is extra small </h5>
-<h6 class="vf-text vf-text--heading-xs">This heading size is extra small </h6>
+  {{/each}}
+{{/with}}

--- a/components/vf-heading/vf-heading.hbs
+++ b/components/vf-heading/vf-heading.hbs
@@ -1,8 +1,7 @@
-{{#with vf-heading-modifiers as |modifier|}}
-{{ log modifier }}
-  {{#each modifier as |modifier key|}}
-    <!-- {{ key }} -->
-    <{{this.element}} class="vf-text vf-text--heading{{this.modifiers}}">{{this.title}}</{{this.element}}>
+<!-- Variant modifiers from the pattern Yaml -->
+{{#each vf-heading-modifiers as |modifier type|}}
+  {{> @vf-heading--template modifier title=modifier.title }}
+{{/each}}
 
-  {{/each}}
-{{/with}}
+<!-- Variant modifier directly from vf-heading--template.hbs  -->
+{{> @vf-heading--template large="true" title="I'm a large headline" }}


### PR DESCRIPTION
I think this is a good balance between templating and usability for both those needing templates and to skim docs.

Idea is to introduce an approach of having a (where required) `vf-pattern--template.hbs`; so that:

Devs using `npm`'d templates:
`{{> @vf-heading--template large="true" title="Hello World"}}`

Devs needing html docs:
![image](https://user-images.githubusercontent.com/928100/54534733-4c402780-498d-11e9-9350-a87795a07d33.png)

And then building the patterns:
```hbs
<!-- Variant modifiers from the pattern Yaml -->
{{#each vf-heading-modifiers as |modifier type|}}
  {{> @vf-heading--template modifier title=modifier.title }}
{{/each}}
```

```yml
  vf-heading-modifiers:
    - display: true
      title: This heading size is display and inverted
    - extra-large: true
      title: This heading size is extra large
    - large: true
      title: This heading size is large
    - regular: true
      title: This heading size is regular
    - small: true
      title: This heading size is small
```
