### PR TITLE
Feature/nunjucks extensions

### DIFF
--- a/components/embl-boilerplate-page/embl-boilerplate-page.njk
+++ b/components/embl-boilerplate-page/embl-boilerplate-page.njk
@@ -30,10 +30,10 @@
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
-      {{~#codeblockhtml~}}
+          {% codeblock 'html' -%}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
 <script src="https://dev.assets.emblstatic.net/vf/develop/scripts/scripts.js"></script>
-      {{/codeblockhtml}}
+          {% endcodeblock %}
         </div>
       </div>
   </section>
@@ -62,7 +62,7 @@
 
     <section class="vf-news-container | embl-grid embl-grid--alt">
 
-      {% render '@vf-section-header', {'section-title'='Latest Press Releases'} %}
+      {% render '@vf-section-header', {'section-title': 'Latest Press Releases'} %}
 
       {% render '@vf-figure' %}
 

--- a/components/embl-group-page/embl-group-page.njk
+++ b/components/embl-group-page/embl-group-page.njk
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html lang="en" class="vf-no-js">
 <head>
-  {{> @vf-no-js }}
+  {% render '@vf-no-js' %}
   <title>{{ _target.title }} | {{ _config.project.title }}</title>
 
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1, minimum-scale=1" name="viewport">
 
-  {{> @vf-favicon}}
-  {{> @embl-content-meta-properties meta-who="Strategy and Communications" meta-where="EMBL" meta-what="Visual Framework" meta-last-review="2019-01-20" meta-active="what"}}
+  {% render "@vf-favicon" %}
+  {% render "@embl-content-meta-properties", {"meta_who": "Group Jane", "meta_where": "Barcelona", "meta_what": "Research", "meta_active": "what"} %}
 
-  {{#if _config.project.environment.local }}
+  {% if _config.project.environment.local %}
   <link rel="stylesheet" href="{{ '/css/styles.css' | path }}">
-  {{/if}}
-  {{#if _config.project.environment.production }}
-  <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
-  {{/if}}
+  {% endif %}
+  {% if _config.project.environment.production %}
+  <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/css/styles.css">
+  {% endif %}
 </head>
 <body>
   <header class="vf-header">
@@ -30,10 +30,10 @@
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
-{{~#codeblockhtml~}}
+{% codeblock 'html' -%}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
 <script src="https://dev.assets.emblstatic.net/vf/develop/scripts/scripts.js"></script>
-{{/codeblockhtml}}
+{% endcodeblock %}
         </div>
       </div>
   </section>
@@ -64,7 +64,7 @@
       </div>
 
       <div class="embl-group-header__navigation embl-group-header__navigation--main">
-        {{render '@vf-navigation--main'}}
+        {% render '@vf-navigation--main' %}
       </div>
 
     </header>
@@ -93,11 +93,11 @@
 
       <section class="vf-inlay__content vf-u-background-color-white">
         <main class="vf-inlay__content--main">
-          {{> '@vf-content'}}
+          {% render '@vf-content' %}
         </main>
 
         <aside class="vf-inlay__content--additional">
-          {{> '@vf-box'}}
+          {% render '@vf-box' %}
         </aside>
 
       </section>
@@ -108,19 +108,19 @@
   <div class="vf-body vf-body__additional-content">
     <section class="vf-news-container | embl-grid embl-grid--has-sidebar vf-u-margin__top-xl">
 
-      {{> '@vf-section-header' section-title='Latest Press Releases'}}
+      {% render '@vf-section-header', {'section-title': 'Latest Press Releases'} %}
 
       <div class="vf-news-container__content">
-        {{ render '@vf-news-item' }}
-        {{ render '@vf-news-item' }}
-        {{ render '@vf-news-item' }}
-        {{ render '@vf-news-item' }}
+        {% render '@vf-news-item' %}
+        {% render '@vf-news-item' %}
+        {% render '@vf-news-item' %}
+        {% render '@vf-news-item' %}
       </div>
 
       <div class="vf-news-container__sidebar">
-        {{ render '@vf-news-item--snippet' }}
-        {{ render '@vf-news-item--snippet' }}
-        {{ render '@vf-news-item--snippet' }}
+        {% render '@vf-news-item--snippet' %}
+        {% render '@vf-news-item--snippet' %}
+        {% render '@vf-news-item--snippet' %}
       </div>
 
     </section>

--- a/components/embl-subsite-page/embl-subsite-page.njk
+++ b/components/embl-subsite-page/embl-subsite-page.njk
@@ -33,10 +33,10 @@
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
-      {{~#codeblockhtml~}}
+{% codeblock 'html' -%}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
 <script src="https://dev.assets.emblstatic.net/vf/develop/scripts/scripts.js"></script>
-      {{/codeblockhtml}}
+{% endcodeblock %}
         </div>
       </div>
   </section>

--- a/components/vf-boilerplate-page/vf-boilerplate-page.njk
+++ b/components/vf-boilerplate-page/vf-boilerplate-page.njk
@@ -30,10 +30,10 @@
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
           <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the pattern library</a>.</p>
-{{~#codeblockhtml~}}
+          {% codeblock 'html' -%}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
 <script src="https://dev.assets.emblstatic.net/vf/develop/scripts/scripts.js"></script>
-{{/codeblockhtml}}
+          {% endcodeblock %}
         </div>
       </div>
   </section>

--- a/components/vf-heading/README.md
+++ b/components/vf-heading/README.md
@@ -2,6 +2,14 @@
 
 ## About
 
+## Demo
+
+{% set context = '@vf-heading' | patternContexts %}
+
+{% for modifier in context.vf_heading_modifiers %}
+  {% render '@vf-heading', {"type": modifier.type, "title": modifier.title} %}
+{% endfor %}
+
 ## Installation and Implementation
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-heading` with this command.

--- a/components/vf-heading/vf-heading.njk
+++ b/components/vf-heading/vf-heading.njk
@@ -17,17 +17,17 @@
 #}
 
 {% for modifier in vf_heading_modifiers %}
-  {% if modifier.type == "display" %}
+  {% if modifier.type == "display" -%}
     <h1 class="vf-text vf-text--heading-xl vf-text--invert">{{modifier.title}}</h1>
-  {% elif modifier.type == "extra-large" %}
+  {% elif modifier.type == "extra-large" -%}
     <h2 class="vf-text vf-text--heading-xl">{{modifier.title}}</h2>
-  {% elif modifier.type == "large" %}
+  {% elif modifier.type == "large" -%}
     <h3 class="vf-text vf-text--heading-l">{{modifier.title}}</h3>
-  {% elif modifier.type == "regular" %}
+  {% elif modifier.type == "regular" -%}
     <h4 class="vf-text vf-text--heading-r">{{modifier.title}}</h4>
-  {% elif modifier.type == "small" %}
+  {% elif modifier.type == "small" -%}
     <h5 class="vf-text vf-text--heading-s">{{modifier.title}}</h5>
-  {% else %}
+  {% else -%}
     {# catch all for if the heading type doesn't match #}
     <h5 class="vf-text vf-text--heading-s">{{modifier.title}}</h5>
   {% endif %}

--- a/fractal.js
+++ b/fractal.js
@@ -13,8 +13,6 @@ fractal.components.set('path', __dirname + '/components');
 /* Tell Fractal where the documentation pages will live */
 fractal.docs.set('path', __dirname + '/docs');
 
-/* Handlebars with custom helpers */
-const handlebars = require('gulp-compile-handlebars');
 const nunj = require('@frctl/nunjucks')({
   env: {
     lstripBlocks: true,
@@ -37,13 +35,11 @@ const nunj = require('@frctl/nunjucks')({
       const context = entity.isComponent ? entity.variants().default().context : entity.context;
       return context;
     }
-
   },
   // globals: {
   //   // global-name: global-val
   // },
   extensions: {
-    // extension-name: function extensionFunc(){}
     codeblock: require('./tools/vf-frctl-extensions/codeblock.js')
   }
 });
@@ -68,7 +64,7 @@ fractal.web.set('server.syncOptions', {
   browser: 'default',
   sync: true
 });
-/* Theme */
+
 const vfTheme = require('./tools/vf-frctl-theme');
 const vfThemeConfig = vfTheme({}, fractal);
 
@@ -96,11 +92,5 @@ fractal.components.set('statuses', {
     color: "#707372"
   }
 });
-
-// Customise Fractal templates
-// https://fractal.build/guide/customisation/web-themes#template-customisation
-// VFTheme.addLoadPath(__dirname + '/tools/frctl-mandelbrot-vf-subtheme/views');
-// Specify the static assets directory that contains the custom stylesheet.
-// VFTheme.addStatic(__dirname + '/tools/frctl-mandelbrot-vf-subtheme/assets', '/');
 
 fractal.web.theme(vfThemeConfig);

--- a/fractal.js
+++ b/fractal.js
@@ -15,7 +15,6 @@ fractal.docs.set('path', __dirname + '/docs');
 
 /* Handlebars with custom helpers */
 const handlebars = require('gulp-compile-handlebars');
-const hljs = require('highlight.js');
 const nunj = require('@frctl/nunjucks')({
   env: {
     lstripBlocks: true,
@@ -29,22 +28,9 @@ const nunj = require('@frctl/nunjucks')({
   // globals: {
   //   // global-name: global-val
   // },
-  // extensions: {
-  //   // extension-name: function extensionFunc(){}
-  // },
-  helpers: {
-    codeblockhtml: function(txt,context){
-      txt = txt.fn(context);
-      if(typeof txt == "undefined") return;
-      return '<code class="Code Code--lang-html vf-code-example"><pre class="vf-code-example__pre">' +
-      hljs.highlight('html', txt).value + '</pre></code>';
-    },
-    codeblockjs: function(txt,context){
-      txt = txt.fn(context);
-      if(typeof txt == "undefined") return;
-      return '<code class="Code Code--lang-js vf-code-example"><pre class="vf-code-example__pre">' +
-      hljs.highlight('js', txt).value + '</pre></code>';
-    }
+  extensions: {
+    // extension-name: function extensionFunc(){}
+    codeblock: require('./tools/vf-frctl-extensions/codeblock.js')
   }
 });
 

--- a/fractal.js
+++ b/fractal.js
@@ -22,9 +22,23 @@ const nunj = require('@frctl/nunjucks')({
     autoescape: false
     // Nunjucks environment opts: https://mozilla.github.io/nunjucks/api.html#configure
   },
-  // filters: {
-  //   // filter-name: function filterFunc(){}
-  // },
+  filters: {
+    // A filter and non-async version of frctl's context extension from
+    // https://github.com/frctl/nunjucks/blob/develop/src/extensions/context.js
+    // We mainly use this to make a pattern's YAML data available to REAMDE.md
+    // {% set context = '@vf-heading' | patternContexts %}
+    patternContexts:  function(pattern) {
+      const source = fractal.components;
+      const handle = pattern;
+      const entity = source.find(handle);
+      if (!entity) {
+        throw new Error(`Could not render component '${handle}' - component not found.`);
+      }
+      const context = entity.isComponent ? entity.variants().default().context : entity.context;
+      return context;
+    }
+
+  },
   // globals: {
   //   // global-name: global-val
   // },

--- a/tools/vf-frctl-extensions/REAMDE.md
+++ b/tools/vf-frctl-extensions/REAMDE.md
@@ -1,0 +1,1 @@
+This folder has Nunjucks extensions useful when manipulating Fractal-specific data.

--- a/tools/vf-frctl-extensions/codeblock.js
+++ b/tools/vf-frctl-extensions/codeblock.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const hljs = require('highlight.js');
+
+// Return a block of syntax as code with style formatting
+// uses: https://highlightjs.org/
+
+// Sample:
+// {% codeblock 'html' -%}
+//   <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
+//   <script src="https://dev.assets.emblstatic.net/vf/develop/scripts/scripts.js"></script>
+// {% endcodeblock %}
+
+module.exports = function(fractal){
+
+    function codeblockExtension() {
+
+        this.tags = ['codeblock'];
+
+        this.parse = function (parser, nodes, lexer) {
+            var tok = parser.nextToken();
+            var args = parser.parseSignature(null, true);
+            parser.advanceAfterBlockEnd(tok.value);
+            var body = parser.parseUntilBlocks('error', 'endcodeblock');
+            var errorBody = null;
+            if(parser.skipSymbol('error')) {
+                parser.skip(lexer.TOKEN_BLOCK_END);
+                errorBody = parser.parseUntilBlocks('endremote');
+            }
+
+            parser.advanceAfterBlockEnd();
+            return new nodes.CallExtension(this, 'run', args, [body, errorBody]);
+        };
+
+        this.run = function (context, format, body) {
+          // let format = format || 'html'; // if format is not set, use "html"
+          let txt = body();
+          if(typeof txt == "undefined") return;
+          txt = hljs.highlight(format, txt).value;
+
+          return `<code class="Code Code--lang-${format} vf-code-example"><pre class="vf-code-example__pre">${txt}</pre></code>`;
+        };
+
+    };
+
+    return new codeblockExtension();
+
+};


### PR DESCRIPTION
This:
- Ports the old handlebars codeblock helpers into a nunjucks extension
- Add a filter to expose the pattern YAML to the REAMDE.md (conceivably also useful to access other patterns' YAML with nunj templates)
    - `{% set context = '@vf-heading' | patternContexts %}`


Helps to deliver #302