### PR TITLE
Concept for showing the documentation in the readme

### DIFF
--- a/components/vf-heading/README.md
+++ b/components/vf-heading/README.md
@@ -2,13 +2,29 @@
 
 ## About
 
+Basic headline styles.
+
 ## Demo
 
 {% set context = '@vf-heading' | patternContexts %}
 
 {% for modifier in context.vf_heading_modifiers %}
   {% render '@vf-heading', {"type": modifier.type, "title": modifier.title} %}
+  {# blank space needed for html sample rendering #}
+  ```html
+  {% render '@vf-heading', {"type": modifier.type, "title": modifier.title} %}
+  ```
 {% endfor %}
+
+---
+
+## Nunjucks template
+
+{% verbatim %}
+    {% render '@vf-heading', {"type": "large", "title": "Your headline"} %}
+{% endverbatim %}
+
+---
 
 ## Installation and Implementation
 

--- a/components/vf-heading/vf-heading.config.yml
+++ b/components/vf-heading/vf-heading.config.yml
@@ -3,7 +3,7 @@ label: Headings
 preview: '@preview--elements'
 status: beta
 variants:
-  - name: template
+  - name: default
     hidden: true
 context:
   pattern-type: element

--- a/components/vf-heading/vf-heading.njk
+++ b/components/vf-heading/vf-heading.njk
@@ -7,28 +7,19 @@
   Set our data for the template
 #}
 
-{% if type and title %}
-  {% set vf_heading_modifiers = [{ "type": type, "title" : title}] %}
-{% endif %}
-
-{#
-  Template
-  If type && title are not passed it will use default modifiers in the pattern YAML
-#}
-
-{% for modifier in vf_heading_modifiers %}
-  {% if modifier.type == "display" -%}
-    <h1 class="vf-text vf-text--heading-xl vf-text--invert">{{modifier.title}}</h1>
-  {% elif modifier.type == "extra-large" -%}
-    <h2 class="vf-text vf-text--heading-xl">{{modifier.title}}</h2>
-  {% elif modifier.type == "large" -%}
-    <h3 class="vf-text vf-text--heading-l">{{modifier.title}}</h3>
-  {% elif modifier.type == "regular" -%}
-    <h4 class="vf-text vf-text--heading-r">{{modifier.title}}</h4>
-  {% elif modifier.type == "small" -%}
-    <h5 class="vf-text vf-text--heading-s">{{modifier.title}}</h5>
-  {% else -%}
+{%- if type and title -%}
+  {%- if type == "display" -%}
+    <h1 class="vf-text vf-text--heading-xl vf-text--invert">{{title}}</h1>
+  {%- elif type == "extra-large" -%}
+    <h2 class="vf-text vf-text--heading-xl">{{title}}</h2>
+  {%- elif type == "large" -%}
+    <h3 class="vf-text vf-text--heading-l">{{title}}</h3>
+  {%- elif type == "regular" -%}
+    <h4 class="vf-text vf-text--heading-r">{{title}}</h4>
+  {%- elif type == "small" -%}
+    <h5 class="vf-text vf-text--heading-s">{{title}}</h5>
+  {%- else -%}
     {# catch all for if the heading type doesn't match #}
-    <h5 class="vf-text vf-text--heading-s">{{modifier.title}}</h5>
+    <h5 class="vf-text vf-text--heading-s">{{title}}</h5>
   {% endif %}
-{% endfor %}
+{% endif %}


### PR DESCRIPTION
So this relates to the documentation discussions and is a further iteration on approach we might use to show the documentation in the readme area.

![image](https://user-images.githubusercontent.com/928100/54927940-6e005800-4f13-11e9-9301-2f5711722433.png)

Upsides:
- the `.njk` file isn't used as a demo but a real template
- the demo is used in the readme and shown there

Downside/mided:
- the real README.md file won't have the rendered code but rather the code used to make the demo ... i guess that's a feature depending on your view of the use case. 
