### PR TITLE
Fix naming of fonts on npm

### DIFF
--- a/components/vf-font-plex-mono/CHANGELOG.md
+++ b/components/vf-font-plex-mono/CHANGELOG.md
@@ -5,7 +5,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 0.0.24 (2019-02-28)
 
-**Note:** Version bump only for package @visual-framework/vf-plex-mono-font
+**Note:** Version bump only for package @visual-framework/vf-font-plex-mono
 
 
 
@@ -13,7 +13,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 0.0.23 (2019-02-28)
 
-**Note:** Version bump only for package @visual-framework/vf-plex-mono-font
+**Note:** Version bump only for package @visual-framework/vf-font-plex-mono
 
 
 

--- a/components/vf-font-plex-mono/package.json
+++ b/components/vf-font-plex-mono/package.json
@@ -1,16 +1,16 @@
 {
   "version": "0.0.24",
-  "name": "@visual-framework/vf-plex-mono-font",
-  "description": "vf-plex-mono-font component",
+  "name": "@visual-framework/vf-font-plex-mono",
+  "description": "vf-font-plex-mono component",
   "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
-  "style": "vf-plex-mono-font.css",
+  "style": "vf-font-plex-mono.css",
   "sass": "index.scss",
   "files": [
     "index.scss",
-    "vf-plex-mono-font.scss",
-    "vf-plex-mono-font.css"
+    "vf-font-plex-mono.scss",
+    "vf-font-plex-mono.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-font-plex-mono/package.json
+++ b/components/vf-font-plex-mono/package.json
@@ -10,7 +10,10 @@
   "files": [
     "index.scss",
     "vf-font-plex-mono.scss",
-    "vf-font-plex-mono.css"
+    "vf-font-plex-mono.css",
+    "vf-font-plex-mono.config.yml",
+    "vf-font-plex-mono.njk",
+    "assets/**"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-font-plex-sans/CHANGELOG.md
+++ b/components/vf-font-plex-sans/CHANGELOG.md
@@ -5,7 +5,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 0.0.24 (2019-02-28)
 
-**Note:** Version bump only for package @visual-framework/vf-plex-sans-font
+**Note:** Version bump only for package @visual-framework/vf-font-plex-sans
 
 
 
@@ -13,7 +13,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 0.0.23 (2019-02-28)
 
-**Note:** Version bump only for package @visual-framework/vf-plex-sans-font
+**Note:** Version bump only for package @visual-framework/vf-font-plex-sans
 
 
 

--- a/components/vf-font-plex-sans/package.json
+++ b/components/vf-font-plex-sans/package.json
@@ -1,16 +1,16 @@
 {
   "version": "0.0.24",
-  "name": "@visual-framework/vf-plex-sans-font",
-  "description": "vf-plex-sans-font component",
+  "name": "@visual-framework/vf-font-plex-sans",
+  "description": "vf-font-plex-sans component",
   "homepage": "https://visual-framework.github.io/vf-core/",
   "author": "VF",
   "license": "Apache 2.0",
-  "style": "vf-plex-sans-font.css",
+  "style": "vf-font-plex-sans.css",
   "sass": "index.scss",
   "files": [
     "index.scss",
-    "vf-plex-sans-font.scss",
-    "vf-plex-sans-font.css"
+    "vf-font-plex-sans.scss",
+    "vf-font-plex-sans.css"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {

--- a/components/vf-font-plex-sans/package.json
+++ b/components/vf-font-plex-sans/package.json
@@ -10,7 +10,10 @@
   "files": [
     "index.scss",
     "vf-font-plex-sans.scss",
-    "vf-font-plex-sans.css"
+    "vf-font-plex-sans.css",
+    "vf-font-plex-sans.config.yml",
+    "vf-font-plex-sans.njk",
+    "assets/**"
   ],
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {


### PR DESCRIPTION
Was leading to the wrong name when npm installing. 

