### PR TITLE
HOTFIX - Pass missing param to codeblock extension

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -40,7 +40,7 @@ const nunj = require('@frctl/nunjucks')({
   //   // global-name: global-val
   // },
   extensions: {
-    codeblock: require('./tools/vf-frctl-extensions/codeblock.js')
+    codeblock: require('./tools/vf-frctl-extensions/codeblock.js')(fractal)
   }
 });
 


### PR DESCRIPTION
not having it stops the codeblock extension from working.