### PR TITLE
Modularise fractal config for reuse as `require`

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -17,7 +17,8 @@ module.exports = {
     fractal.components.set('path', vfComponentPath);
 
     /* Tell Fractal where the documentation pages will live */
-    fractal.docs.set('path', __dirname + '/docs');
+    var vfDocsPath = global.vfDocsPath || __dirname + '/docs';
+    fractal.docs.set('path', vfDocsPath);
 
     const nunj = require('@frctl/nunjucks')({
       env: {
@@ -60,7 +61,8 @@ module.exports = {
     fractal.components.set('default.preview', `@preview`);
 
     /* build destination */
-    fractal.web.set('builder.dest', __dirname + '/build');
+    var vfBuilderPath = global.vfBuilderPath || __dirname + '/build';
+    fractal.web.set('builder.dest', vfBuilderPath);
 
     /* configure web */
     fractal.web.set('static.path', __dirname + '/public');

--- a/fractal.js
+++ b/fractal.js
@@ -1,96 +1,135 @@
-'use strict';
+module.exports = {
 
-/* Create a new Fractal instance and export it for use elsewhere if required */
-const fractal        = module.exports = require('@frctl/fractal').create();
-const projectTitle   = vfName;
+  // mode: 'build' or 'server'
+  initialize: function(mode, callback) {
 
-/* Set the title of the project */
-fractal.set('project.title', projectTitle);
+    /* Create a new Fractal instance and export it for use elsewhere if required */
+    const fractal        = module.exports = require('@frctl/fractal').create();
+    const logger         = fractal.cli.console;
+    const projectTitle   = vfName;
 
-/* Tell Fractal where the components will live */
-fractal.components.set('path', __dirname + '/components');
+    /* Set the title of the project */
+    fractal.set('project.title', projectTitle);
 
-/* Tell Fractal where the documentation pages will live */
-fractal.docs.set('path', __dirname + '/docs');
+    /* Tell Fractal where the components will live */
+    fractal.components.set('path', vfComponentPath);
 
-const nunj = require('@frctl/nunjucks')({
-  env: {
-    lstripBlocks: true,
-    trimBlocks: true,
-    autoescape: false
-    // Nunjucks environment opts: https://mozilla.github.io/nunjucks/api.html#configure
-  },
-  filters: {
-    // A filter and non-async version of frctl's context extension from
-    // https://github.com/frctl/nunjucks/blob/develop/src/extensions/context.js
-    // We mainly use this to make a component's YAML data available to REAMDE.md
-    // {% set context = '@vf-heading' | componentContexts %}
-    componentContexts:  function(component) {
-      const source = fractal.components;
-      const handle = component;
-      const entity = source.find(handle);
-      if (!entity) {
-        throw new Error(`Could not render component '${handle}' - component not found.`);
+    /* Tell Fractal where the documentation pages will live */
+    fractal.docs.set('path', __dirname + '/docs');
+
+    const nunj = require('@frctl/nunjucks')({
+      env: {
+        lstripBlocks: true,
+        trimBlocks: true,
+        autoescape: false
+        // Nunjucks environment opts: https://mozilla.github.io/nunjucks/api.html#configure
+      },
+      filters: {
+        // A filter and non-async version of frctl's context extension from
+        // https://github.com/frctl/nunjucks/blob/develop/src/extensions/context.js
+        // We mainly use this to make a component's YAML data available to REAMDE.md
+        // {% set context = '@vf-heading' | componentContexts %}
+        componentContexts:  function(component) {
+          const source = fractal.components;
+          const handle = component;
+          const entity = source.find(handle);
+          if (!entity) {
+            throw new Error(`Could not render component '${handle}' - component not found.`);
+          }
+          const context = entity.isComponent ? entity.variants().default().context : entity.context;
+          return context;
+        }
+      },
+      // globals: {
+      //   // global-name: global-val
+      // },
+      extensions: {
+        codeblock: require('./tools/vf-frctl-extensions/codeblock.js')(fractal)
       }
-      const context = entity.isComponent ? entity.variants().default().context : entity.context;
-      return context;
+    });
+
+    fractal.components.set('ext', '.njk'); // look for files with a .nunj file extension
+    fractal.components.engine(nunj); /* set as the default template engine for components */
+    fractal.docs.set('ext', '.njk'); // look for files with a .njk file extension
+    fractal.docs.engine(nunj); /* you can also use the same instance for documentation, if you like! */
+
+    /* configure components */
+    fractal.components.set('default.status', 'alpha');
+    fractal.components.set('default.preview', `@preview`);
+
+    /* build destination */
+    fractal.web.set('builder.dest', __dirname + '/build');
+
+    /* configure web */
+    fractal.web.set('static.path', __dirname + '/public');
+    fractal.web.set('server.sync', true);
+    fractal.web.set('server.syncOptions', {
+      open: true,
+      browser: 'default',
+      sync: true
+    });
+
+    const vfTheme = require('./tools/vf-frctl-theme');
+    const vfThemeConfig = vfTheme({}, fractal);
+
+    fractal.components.set('statuses', {
+      /* status definitions here */
+      alpha: {
+        label: "alhpa",
+        description: "Do not implement.",
+        color: "#DC0A28",
+        text: "#FFFFFF"
+      },
+      beta: {
+        label: "beta",
+        description: "Work in progress. Implement with caution.",
+        color: "#E89300"
+      },
+      live: {
+        label: "live",
+        description: "Ready to implement.",
+        color: "#19993B"
+      },
+      deprecated: {
+        label: "deprecated",
+        description: "Never use this again.",
+        color: "#707372"
+      }
+    });
+
+    fractal.web.theme(vfThemeConfig);
+
+    if (mode == 'server') {
+      fractal.set('project.environment.local', 'true');
+      const fractalServer = fractal.web.server({
+        sync: true
+      });
+      fractalServer.start().then(() => {
+        logger.success(`Your Visual Framework component library is available at ${fractalServer.url}`);
+        // logger.success(`Network URL: ${server.urls.sync.external}`);
+        console.log('done over here');
+        fractal.watch();
+        callback(fractal);
+      });
     }
-  },
-  // globals: {
-  //   // global-name: global-val
-  // },
-  extensions: {
-    codeblock: require('./tools/vf-frctl-extensions/codeblock.js')(fractal)
+
+    if (mode == 'build') {
+      fractal.set('project.environment.production', 'true');
+      const builder = fractal.web.builder();
+      builder.on('progress', (completed, total) =>
+        logger.update(`Exported ${completed} of ${total} items`, 'info')
+      );
+      builder.on('error', err => logger.error(err.message));
+      return builder.build().then(() => {
+        logger.success('Fractal build completed!');
+
+        // Copy compiled css/js and other assets
+        gulp.src('./public/**/*')
+        .pipe(gulp.dest('./build'));
+        logger.success('Copied `/public` assets.');
+        callback(fractal);
+      });
+    }
+
   }
-});
-
-fractal.components.set('ext', '.njk'); // look for files with a .nunj file extension
-fractal.components.engine(nunj); /* set as the default template engine for components */
-fractal.docs.set('ext', '.njk'); // look for files with a .njk file extension
-fractal.docs.engine(nunj); /* you can also use the same instance for documentation, if you like! */
-
-/* configure components */
-fractal.components.set('default.status', 'alpha');
-fractal.components.set('default.preview', `@preview`);
-
-/* build destination */
-fractal.web.set('builder.dest', __dirname + '/build');
-
-/* configure web */
-fractal.web.set('static.path', __dirname + '/public');
-fractal.web.set('server.sync', true);
-fractal.web.set('server.syncOptions', {
-  open: true,
-  browser: 'default',
-  sync: true
-});
-
-const vfTheme = require('./tools/vf-frctl-theme');
-const vfThemeConfig = vfTheme({}, fractal);
-
-fractal.components.set('statuses', {
-  /* status definitions here */
-  alpha: {
-    label: "alhpa",
-    description: "Do not implement.",
-    color: "#DC0A28",
-    text: "#FFFFFF"
-  },
-  beta: {
-    label: "beta",
-    description: "Work in progress. Implement with caution.",
-    color: "#E89300"
-  },
-  live: {
-    label: "live",
-    description: "Ready to implement.",
-    color: "#19993B"
-  },
-  deprecated: {
-    label: "deprecated",
-    description: "Never use this again.",
-    color: "#707372"
-  }
-});
-
-fractal.web.theme(vfThemeConfig);
+}

--- a/fractal.js
+++ b/fractal.js
@@ -6,12 +6,14 @@ module.exports = {
     /* Create a new Fractal instance and export it for use elsewhere if required */
     const fractal        = module.exports = require('@frctl/fractal').create();
     const logger         = fractal.cli.console;
+    var vfName           = global.vfName || 'Visual Framework component library';
     const projectTitle   = vfName;
 
     /* Set the title of the project */
     fractal.set('project.title', projectTitle);
 
     /* Tell Fractal where the components will live */
+    var vfComponentPath = global.vfComponentPath || __dirname + '/components';
     fractal.components.set('path', vfComponentPath);
 
     /* Tell Fractal where the documentation pages will live */
@@ -107,7 +109,6 @@ module.exports = {
       fractalServer.start().then(() => {
         logger.success(`Your Visual Framework component library is available at ${fractalServer.url}`);
         // logger.success(`Network URL: ${server.urls.sync.external}`);
-        console.log('done over here');
         fractal.watch();
         callback(fractal);
       });

--- a/fractal.js
+++ b/fractal.js
@@ -123,10 +123,6 @@ module.exports = {
       return builder.build().then(() => {
         logger.success('Fractal build completed!');
 
-        // Copy compiled css/js and other assets
-        gulp.src('./public/**/*')
-        .pipe(gulp.dest('./build'));
-        logger.success('Copied `/public` assets.');
         callback(fractal);
       });
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,6 +60,7 @@ const reload = browserSync.reload;
 const theoG = require('gulp-theo')
 const theo = require('theo')
 
+
 // -----------------------------------------------------------------------------
 // Sass and CSS Tasks
 // -----------------------------------------------------------------------------
@@ -333,9 +334,14 @@ gulp.task('frctlStart', function(done) {
   }
 });
 
-gulp.task('frctlBuild', function() {
+gulp.task('frctlBuild', function(done) {
   const fractal = require('./fractal.js').initialize('build',fractalReadyCallback);
   function fractalReadyCallback() {
+    // Copy compiled css/js and other assets
+    gulp.src('./public/**/*')
+      .pipe(gulp.dest('./build'));
+      console.info('Copied `/public` assets.');
+
     done();
   }
 });


### PR DESCRIPTION
This makes the fractal config reusable across the various ways we're looking to consume fractal; some features added/needed:
-  adds a callback so we can know when fractal has fully strapped and `fractal.components` is ready
- we can ask for a build or server installation
- pass in where fractal should look for components

This means we'll be able to: `const vfFractalBuild = require('@visual-framework/vf-core/fractal.js).initialize('server',fractalReadyCallback);` in things ranging from Eleventy to child pattern libraries.

aside: might also mean when we publish vf-core to npm we want to exclude `./components`