### PR TITLE
Optimise gulp dev

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -73,7 +73,7 @@ module.exports = {
     var vfOpenBrowser = typeof global.vfOpenBrowser === "undefined" ? true : global.vfOpenBrowser;
     fractal.web.set('server.syncOptions', {
       watchOptions: {
-        ignored: path.join(__dirname, '**/*.scss'),
+        ignored: path.join(__dirname, './components/**/*.scss'),
       },
       open: vfOpenBrowser,
       browser: 'default',

--- a/fractal.js
+++ b/fractal.js
@@ -8,6 +8,7 @@ module.exports = {
     const logger         = fractal.cli.console;
     var vfName           = global.vfName || 'Visual Framework component library';
     const projectTitle   = vfName;
+    const path           = require('path');
 
     /* Set the title of the project */
     fractal.set('project.title', projectTitle);
@@ -71,6 +72,9 @@ module.exports = {
     fractal.web.set('server.sync', true);
     var vfOpenBrowser = typeof global.vfOpenBrowser === "undefined" ? true : global.vfOpenBrowser;
     fractal.web.set('server.syncOptions', {
+      watchOptions: {
+        ignored: path.join(__dirname, '**/*.scss'),
+      },
       open: vfOpenBrowser,
       browser: 'default',
       sync: true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -388,9 +388,10 @@ gulp.task('CSSGen', function(done) {
 // -----------------------------------------------------------------------------
 
 gulp.task('watch', function(done) {
-  gulp.watch('./**/*.scss', gulp.series(['css', 'scss-lint'])).on('change', reload);
+  gulp.watch('./components/**/*.scss', gulp.series(['css', 'scss-lint'])).on('change', reload);
   gulp.watch('./components/**/*.js', gulp.series('scripts')).on('change', reload);
-  gulp.watch('./components/**/**/assets/*', gulp.series('svg', 'component-assets')).on('change', reload);
+  gulp.watch('./components/**/**/assets/*.svg', gulp.series('svg','component-assets')).on('change', reload);
+  gulp.watch(['./components/**/**/assets/*', '!./components/**/**/assets/*.svg'], gulp.series('component-assets')).on('change', reload);
 });
 
 // -----------------------------------------------------------------------------
@@ -401,8 +402,8 @@ gulp.task('scripts', gulp.series(
   'scripts:es5', 'scripts:modern'
 ));
 
-gulp.task('dev', gulp.parallel(
-  'frctlStart', 'component-assets', 'css', 'scripts', 'watch'
+gulp.task('dev', gulp.series(
+  'component-assets', ['css', 'scripts'], 'frctlStart', 'watch'
 ));
 
 gulp.task('tokens', gulp.parallel(

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@visual-framework/vf-core",
-  "version": "2.0.0-apha.4",
+  "version": "2.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12548,7 +12548,8 @@
     "node-normalize-scss": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/node-normalize-scss/-/node-normalize-scss-8.0.0.tgz",
-      "integrity": "sha512-eQMVmvs2Hj33v3m/jstZOBGOr0lO+Rr3tamGdZxBtiUbJ/WXywsLz/LhVQDSugxG4TEnfYyGxdfbRVKNxw+x7g=="
+      "integrity": "sha512-eQMVmvs2Hj33v3m/jstZOBGOr0lO+Rr3tamGdZxBtiUbJ/WXywsLz/LhVQDSugxG4TEnfYyGxdfbRVKNxw+x7g==",
+      "dev": true
     },
     "node-notifier": {
       "version": "5.2.1",


### PR DESCRIPTION
Avoids a lot of thrashing in the generation, optimisation, and watching tasks. This was particularly painful on slower machines.

## Before

```
khawkins@khawkins-VirtualBox:~/Documents/git/vf-core$ gulp dev
[10:24:00] Using gulpfile ~/Documents/git/vf-core/gulpfile.js
[10:24:00] Starting 'dev'...
[10:24:00] Starting 'frctlStart'...
[10:24:00] Starting 'component-assets'...
[10:24:00] Starting 'css'...
[10:24:00] Starting 'scripts'...
[10:24:00] Starting 'watch'...
[10:24:02] Starting 'scripts:es5'...
[10:24:05] Finished 'scripts:es5' after 2.82 s
[10:24:05] Starting 'scripts:modern'...
[10:24:06] Finished 'scripts:modern' after 1.26 s
[10:24:06] Finished 'scripts' after 6.08 s
✔ Your Visual Framework component library is available at http://localhost:3000
[10:24:10] Finished 'frctlStart' after 10 s
[10:24:56] Finished 'css' after 56 s
[10:25:00] Starting 'css'...
[10:25:10] Finished 'css' after 9.89 s
[10:25:10] Starting 'scss-lint'...
[10:25:38] Finished 'component-assets' after 1.62 min
[10:25:43] Finished 'scss-lint' after 33 s
[10:25:43] Starting 'css'...
[10:25:49] Finished 'css' after 5.36 s
[10:25:49] Starting 'scss-lint'...
[10:25:56] Finished 'scss-lint' after 7.45 s
```

## After

```
khawkins@khawkins-VirtualBox:~/Documents/git/vf-core$ gulp dev
[11:07:07] Using gulpfile ~/Documents/git/vf-core/gulpfile.js
[11:07:07] Starting 'dev'...
[11:07:07] Starting 'component-assets'...
[11:07:10] Finished 'component-assets' after 2.75 s
[11:07:10] Starting 'css'...
[11:07:15] Finished 'css' after 5.12 s
[11:07:15] Starting 'scripts'...
[11:07:15] Starting 'scripts:es5'...
[11:07:16] Finished 'scripts:es5' after 496 ms
[11:07:16] Starting 'scripts:modern'...
[11:07:16] Finished 'scripts:modern' after 9.49 ms
[11:07:16] Finished 'scripts' after 507 ms
[11:07:16] Starting 'frctlStart'...
✔ Your Visual Framework component library is available at http://localhost:3000
[11:07:21] Finished 'frctlStart' after 5.54 s
[11:07:21] Starting 'watch'...
```