### PR TITLE
adds initial autocomment bot things

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,0 +1,18 @@
+# Comment to a new issue.
+issuesOpened: >
+
+Thank you for raising an issue. We will try and get back to you as soon as possible.
+
+Please make sure you have given us as much context as possible.
+
+# Pull Request Ready For Review
+
+pullRequestReviewRequested: >
+
+Thank you for requesting a review for this pull request (PR).
+
+To help this process please make sure you have these things ready (if applicable).
+
+- [ ] `package.json` updated accordingly.
+- [ ] `README.md` fill out with required documentation.
+- [ ] any `.scss` files correctly documented.

--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -11,6 +11,8 @@ pullRequestReviewRequested: >
 
 Thank you for requesting a review for this pull request (PR).
 
+Have you added any relevant labels to this PR?
+
 To help this process please make sure you have these things ready (if applicable).
 
 - [ ] `package.json` updated accordingly.

--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -5,11 +5,17 @@ Thank you for raising an issue. We will try and get back to you as soon as possi
 
 Please make sure you have given us as much context as possible.
 
-# Pull Request Ready For Review
-
-pullRequestReviewRequested: >
+# PR Opened
+pullRequestOpened: >
 
 Thank you for requesting a review for this pull request (PR).
+
+If this PR has an associated issue - please add that to the PR description.
+
+If you have not done so already - please fill out the PR description with as much context as possible.
+
+# Pull Request Ready For Review
+pullRequestReviewRequested: >
 
 Have you added any relevant labels to this PR?
 
@@ -18,3 +24,4 @@ To help this process please make sure you have these things ready (if applicable
 - [ ] `package.json` updated accordingly.
 - [ ] `README.md` fill out with required documentation.
 - [ ] any `.scss` files correctly documented.
+- [ ] a detailed outlin on what this PR is expected to do


### PR DESCRIPTION
I think it would be a good thing to have some automated things for certain parts of the process of raising issues or PRs for the repo.

I think this also needs a look at the processes too, for example - make the PR - add the labels, then ask for a review