### PR TITLE
updates figure and logo to make use of | path correctly so it works

### DIFF
--- a/components/vf-box/vf-box.njk
+++ b/components/vf-box/vf-box.njk
@@ -12,5 +12,5 @@ class="vf-box
 
 ">
   <h3 class="vf-box__heading">{{- heading -}}</h3>
-  <p class="vf-box__text">{{- text -}}/p>
+  <p class="vf-box__text">{{- text -}}</p>
 </div>

--- a/components/vf-figure/vf-figure.njk
+++ b/components/vf-figure/vf-figure.njk
@@ -3,6 +3,6 @@
 {% if id %} id="{{-id-}}"{% endif %}
 class="vf-figure
 {%- if override_class %} | {{override_class}}{% endif -%}">
-  <img class="vf-figure__image" src="{{imageUrl}}" alt="{{alttext}}">
+  <img class="vf-figure__image" src="{{imageUrl | path}}" alt="{{alttext}}">
   <figcaption class="vf-figure__caption">{{- html | safe if html else text -}}</figcaption>
 </figure>

--- a/components/vf-logo/vf-logo.config.yml
+++ b/components/vf-logo/vf-logo.config.yml
@@ -5,3 +5,4 @@ context:
   component-type: element
   href: http://www.embl.de
   sreen_reader_text: Visual Framework 2.0
+  image: '/assets/vf-logo/assets/logo.png'

--- a/components/vf-logo/vf-logo.njk
+++ b/components/vf-logo/vf-logo.njk
@@ -3,6 +3,6 @@
 {% if id %} id="{{-id-}}"{% endif %}
 class="vf-logo
 {%- if override_class %} | {{override_class}}{% endif -%}">
-  <img src="{{ '/assets/vf-logo/assets/logo.png' | path }}" alt="{{ _config.project.title }}">
+  <img src="{{ image | path }}" alt="{{ _config.project.title }}">
   <span class="vf-sr-only">{{sreen_reader_text}}</span>
 </a>


### PR DESCRIPTION
for images to work when we run a build script to create a static version of the component library we need to make sure the yaml and nunjucks files are correct.

yaml should have the correct path in quotes: `"/components/vf-component/assets/vf-component-image.jpg"` within the context:

```
context:
  image: "/components/vf-component/assets/vf-component-image.jpg"
```

and within the nunjucks file we should use the `| path` as part of calling the data:

```
<img src="{{ image | path }}">
```

This fixes the two cases of `vf-elements` that had this problem