### PR TITLE
component: embl breadcrumb path for active path

### DIFF
--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -215,19 +215,22 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
   breadcrumbTarget = breadcrumbTarget[0];
 
   if (type == 'primary') {
-    // remove any loading text
-    var loadingText = document.querySelectorAll('.embl-breadcrumbs-lookup__ghosting');
-    if (loadingText.length > 0) { loadingText[0].remove(); }
+
+    // don't show path of breadcrumb if it is the current path
+    if (new URL(breadcrumbUrl).pathname == window.location.pathname) {
+      breadcrumbUrl = null;
+    }
 
     // add breadcrumb
-    emblBreadcrumbPrimary.innerHTML += formatBreadcrumb(currentTerm.name_display,'null');
+    emblBreadcrumbPrimary.innerHTML += formatBreadcrumb(currentTerm.name_display,breadcrumbUrl);
 
-    // fetch parents
+    // fetch parents for primary path
     getBreadcrumbParentTerm(breadcrumbParents, facet);
   } else if (type == 'related') {
     // add breadcrumb
     emblBreadcrumbRelated.innerHTML += formatBreadcrumb(currentTerm.name_display,breadcrumbUrl);
   }
+
 }
 
 function emblBreadcrumbs() {


### PR DESCRIPTION
Shows the link for the active breadcrumb if it is not the current page.

That is, if the active crumb might be "Jane Group":

- We shouldn't show it as a link if we're on the group homepage
- We should show it as a link if we're not on the homepage

For groups we might also be able to rely on the group header, but this won't be there for all types of pages (landing pages, for example) and ensures a consitent behaviour across embl.org