### PR TITLE
ContentHub layout issues

### DIFF
--- a/components/embl-content-hub-loader/embl-content-hub-loader.scss
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.scss
@@ -2,8 +2,10 @@
 
 @import 'embl-content-hub-loader.variables.scss';
 
-// "This page was intentionally left blank"
-
-// .embl-content-hub-loader {
-//
-// }
+// contentHub html caries an extra div that should be outside of the grid layout
+.vf-content-hub-html {
+  grid-column: 1 / -1;
+  // @todo: this should probably be .embl-content-hub-html, but that requires a
+  //        disruptive change in the contenthub itself and will impact many systems.
+  //        that change will require coordination
+}

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -112,6 +112,7 @@ html, button {
 
 @import 'vf-activity-group/vf-activity-group.scss';
 @import 'vf-intro/vf-intro.scss';
+@import 'embl-content-hub-loader/embl-content-hub-loader.scss';
 
 @import 'vf-banner/vf-banner.scss';
   @import 'vf-banner/vf-banner--phase.scss';


### PR DESCRIPTION
Adds `.vf-content-hub-html`. This sorts issues around the needed wrapping div in contentHub content that shouldn't be a layout element.

Currently visible as a problem at https://dev.beta.embl.org/