### PR TITLE
Copy any npm-installed component assets

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -247,7 +247,7 @@ gulp.task('scripts:modern', function() {
 // -----------------------------------------------------------------------------
 gulp.task('component-assets', function() {
   return gulp
-    .src(['./components/**/**/assets/**/*'])
+    .src(['./components/**/assets/**/*','./components/vf-core-components/**/assets/**/*'])
     .pipe(gulp.dest('./public/assets'));
 });
 


### PR DESCRIPTION
The previous method worked, but npm installed components were landing in a subdirectory.