### PR TITLE
Chore/dependency cleanup

### DIFF
--- a/components/embl-content-meta-properties/package.json
+++ b/components/embl-content-meta-properties/package.json
@@ -21,8 +21,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.16",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/embl-grid/package.json
+++ b/components/embl-grid/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/embl-logo/package.json
+++ b/components/embl-logo/package.json
@@ -24,8 +24,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-activity-group/package.json
+++ b/components/vf-activity-group/package.json
@@ -25,9 +25,7 @@
   "dependencies": {
     "@visual-framework/vf-activity-list": "^0.0.30",
     "@visual-framework/vf-grid": "^0.0.29",
-    "@visual-framework/vf-heading": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-heading": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-activity-list/package.json
+++ b/components/vf-activity-list/package.json
@@ -24,9 +24,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-blockquote": "^0.0.29",
-    "@visual-framework/vf-list": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-list": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-badge/package.json
+++ b/components/vf-badge/package.json
@@ -27,8 +27,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-blockquote/package.json
+++ b/components/vf-blockquote/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-box/package.json
+++ b/components/vf-box/package.json
@@ -28,8 +28,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-breadcrumbs/package.json
+++ b/components/vf-breadcrumbs/package.json
@@ -26,9 +26,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-list": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-button/package.json
+++ b/components/vf-button/package.json
@@ -27,8 +27,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-code-example/package.json
+++ b/components/vf-code-example/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-content/package.json
+++ b/components/vf-content/package.json
@@ -33,9 +33,7 @@
     "@visual-framework/vf-heading": "^0.0.29",
     "@visual-framework/vf-link": "^0.0.29",
     "@visual-framework/vf-list": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "@visual-framework/vf-text": "^0.0.29",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-text": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-divider/package.json
+++ b/components/vf-divider/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-favicon/package.json
+++ b/components/vf-favicon/package.json
@@ -24,8 +24,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-figure/package.json
+++ b/components/vf-figure/package.json
@@ -24,8 +24,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-form/vf-form__checkbox/package.json
+++ b/components/vf-form/vf-form__checkbox/package.json
@@ -24,9 +24,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-form__item": "^0.0.30",
-    "@visual-framework/vf-form__label": "^0.0.26",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-form__label": "^0.0.26"
   },
   "keywords": [
     "fractal",

--- a/components/vf-form/vf-form__core/package.json
+++ b/components/vf-form/vf-form__core/package.json
@@ -24,8 +24,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-form/vf-form__helper/package.json
+++ b/components/vf-form/vf-form__helper/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-form/vf-form__input/package.json
+++ b/components/vf-form/vf-form__input/package.json
@@ -24,9 +24,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-form__item": "^0.0.30",
-    "@visual-framework/vf-form__label": "^0.0.26",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-form__label": "^0.0.26"
   },
   "keywords": [
     "fractal",

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -24,9 +24,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-form__helper": "^0.0.29",
-    "@visual-framework/vf-form__label": "^0.0.26",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-form__label": "^0.0.26"=
   },
   "keywords": [
     "fractal",

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-form__helper": "^0.0.29",
-    "@visual-framework/vf-form__label": "^0.0.26"=
+    "@visual-framework/vf-form__label": "^0.0.26"
   },
   "keywords": [
     "fractal",

--- a/components/vf-global-header/package.json
+++ b/components/vf-global-header/package.json
@@ -24,9 +24,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-logo": "^0.0.28",
-    "@visual-framework/vf-navigation": "^0.0.30",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-navigation": "^0.0.30"
   },
   "keywords": [
     "fractal",

--- a/components/vf-grid-page/package.json
+++ b/components/vf-grid-page/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-grid/package.json
+++ b/components/vf-grid/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-header/package.json
+++ b/components/vf-header/package.json
@@ -25,9 +25,7 @@
   "dependencies": {
     "@visual-framework/vf-global-header": "^0.0.30",
     "@visual-framework/vf-masthead": "^0.0.30",
-    "@visual-framework/vf-navigation": "^0.0.30",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-navigation": "^0.0.30"
   },
   "keywords": [
     "fractal",

--- a/components/vf-heading/package.json
+++ b/components/vf-heading/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-intro/package.json
+++ b/components/vf-intro/package.json
@@ -24,9 +24,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-heading": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "@visual-framework/vf-text": "^0.0.29",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-text": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-link-list/package.json
+++ b/components/vf-link-list/package.json
@@ -25,8 +25,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-heading": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-sass-config": "^0.0.26"
   },
   "keywords": [
     "fractal",

--- a/components/vf-link/package.json
+++ b/components/vf-link/package.json
@@ -14,6 +14,8 @@
     "vf-link.variables.scss",
     "vf-link.css",
     "vf-link.njk",
+    "vf-link--disabled.njk",
+    "vf-link--primary.njk",
     "vf-link--secondary.njk",
     "vf-link.config.yml"
   ],
@@ -26,8 +28,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-list/package.json
+++ b/components/vf-list/package.json
@@ -26,8 +26,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-logo/package.json
+++ b/components/vf-logo/package.json
@@ -25,8 +25,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-masthead/package.json
+++ b/components/vf-masthead/package.json
@@ -16,9 +16,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-grid": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-grid": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-navigation/package.json
+++ b/components/vf-navigation/package.json
@@ -30,9 +30,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-list": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-list": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-news-container/package.json
+++ b/components/vf-news-container/package.json
@@ -24,10 +24,8 @@
   },
   "dependencies": {
     "@visual-framework/vf-grid": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
     "@visual-framework/vf-section-header": "^0.0.30",
-    "@visual-framework/vf-summary": "^0.0.30",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-summary": "^0.0.30"
   },
   "keywords": [
     "fractal",

--- a/components/vf-page-header/package.json
+++ b/components/vf-page-header/package.json
@@ -23,9 +23,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-heading": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-sass-config/package.json
+++ b/components/vf-sass-config/package.json
@@ -20,7 +20,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-section-header/package.json
+++ b/components/vf-section-header/package.json
@@ -24,9 +24,7 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-heading": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-heading": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-summary-container/package.json
+++ b/components/vf-summary-container/package.json
@@ -25,10 +25,8 @@
   "dependencies": {
     "@visual-framework/embl-grid": "^0.0.29",
     "@visual-framework/vf-grid": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
     "@visual-framework/vf-section-header": "^0.0.30",
-    "@visual-framework/vf-summary": "^0.0.30",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-summary": "^0.0.30"
   },
   "keywords": [
     "fractal",

--- a/components/vf-summary/package.json
+++ b/components/vf-summary/package.json
@@ -36,9 +36,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-heading": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "@visual-framework/vf-text": "^0.0.29",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-text": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-tabs/package.json
+++ b/components/vf-tabs/package.json
@@ -25,8 +25,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-text/package.json
+++ b/components/vf-text/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-utility-classes/package.json
+++ b/components/vf-utility-classes/package.json
@@ -21,8 +21,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/components/vf-video-container/package.json
+++ b/components/vf-video-container/package.json
@@ -24,11 +24,9 @@
   },
   "dependencies": {
     "@visual-framework/embl-grid": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
     "@visual-framework/vf-section-header": "^0.0.30",
     "@visual-framework/vf-video": "^0.0.29",
-    "@visual-framework/vf-video-teaser": "^0.0.30",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-video-teaser": "^0.0.30"
   },
   "keywords": [
     "fractal",

--- a/components/vf-video-teaser/package.json
+++ b/components/vf-video-teaser/package.json
@@ -25,9 +25,7 @@
   },
   "dependencies": {
     "@visual-framework/vf-heading": "^0.0.29",
-    "@visual-framework/vf-link": "^0.0.29",
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
+    "@visual-framework/vf-link": "^0.0.29"
   },
   "keywords": [
     "fractal",

--- a/components/vf-video/package.json
+++ b/components/vf-video/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.26",
-    "node-normalize-scss": "^8.0.0"
   },
   "keywords": [
     "fractal",

--- a/tools/component-generator/templates/_package.json
+++ b/tools/component-generator/templates/_package.json
@@ -17,7 +17,6 @@
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
   "dependencies": {
-    "@visual-framework/vf-sass-config": "^0.0.12"
   },
   "keywords": [
     "fractal",


### PR DESCRIPTION
Remove vf-sass-config, node-normalize: 
These are top-level dependencies for the VF, so it's doesn't help including them and adds possibilities for out-of-date version issues.

This also adds a couple missing files to vf-link's package.json -- I still need to make another PR for the package.json to use a the `.npmignore`.