### PR TITLE
Allow `vf_lede_text` to be set in `vf-intro`

### DIFF
--- a/components/vf-intro/vf-intro.njk
+++ b/components/vf-intro/vf-intro.njk
@@ -3,8 +3,8 @@
   <div>
     <h1 class="vf-intro__heading {% if vf_intro_phase %}vf-intro__heading--has-tag{% endif %}
 ">{{vf_intro_heading}} {% if vf_intro_phase %}<a href="" class="vf-badge vf-badge--primary vf-badge--phases">{{vf_intro_phase}}</a>{% endif %}</h1>
-    {% render '@vf-lede', {"vf_lede_text": vf_intro_lede} %} 
-    {% asyncEach intro_text in vf_intro_text %}
+    {% render '@vf-lede', {"vf_lede_text": vf_intro_lede} %}
+    {% asyncEach intro_text in vf_intro_text -%}
       <p class="vf-intro__text">{{intro_text}}</p>
     {% endeach %}
   </div>

--- a/components/vf-intro/vf-intro.njk
+++ b/components/vf-intro/vf-intro.njk
@@ -3,7 +3,7 @@
   <div>
     <h1 class="vf-intro__heading {% if vf_intro_phase %}vf-intro__heading--has-tag{% endif %}
 ">{{vf_intro_heading}} {% if vf_intro_phase %}<a href="" class="vf-badge vf-badge--primary vf-badge--phases">{{vf_intro_phase}}</a>{% endif %}</h1>
-    {% render '@vf-lede', {"vf-lede-text": vf_intro_lede} %} 
+    {% render '@vf-lede', {"vf_lede_text": vf_intro_lede} %} 
     {% asyncEach intro_text in vf_intro_text %}
       <p class="vf-intro__text">{{intro_text}}</p>
     {% endeach %}

--- a/components/vf-lede/vf-lede.config.yml
+++ b/components/vf-lede/vf-lede.config.yml
@@ -12,4 +12,4 @@ status: alpha
 context:
   component-type: block
   # custom-values: passed as {{custom-values}}
-  vf-lede-text: Lede text is a generic type of conent for different diseases in which cells divide many more times than usual. <a href="#">This abnormal growth</a> can affect many cell types in almost any part of the body.
+  vf_lede_text: Lede text is a generic type of conent for different diseases in which cells divide many more times than usual. <a href="#">This abnormal growth</a> can affect many cell types in almost any part of the body.

--- a/components/vf-lede/vf-lede.njk
+++ b/components/vf-lede/vf-lede.njk
@@ -1,1 +1,1 @@
-<p class="vf-lede">{{ _self.context["vf-lede-text"] | safe }}</p>
+<p class="vf-lede">{{ vf_lede_text | safe }}</p>


### PR DESCRIPTION
Using `_self.context["vf-lede-text"]` means that the vf-lede config.yml  text will always be used