### PR TITLE
Correct css build directory

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ global.vfThemePath = './tools/vf-frctl-theme';
 const path = require('path');
 const componentPath = path.resolve(__dirname, 'components' );
 const SassInput = componentPath + '/vf-componenet-rollup/index.scss';
-const SassOutput = './build/css';
+const SassOutput = './public/css';
 
 // -----------------------------------------------------------------------------
 // Dependencies


### PR DESCRIPTION
Accidently changed from `/public` to `/build` in an earlier PR.

It actually does need to go into `/build`, but only after some other stuff is done.

Might should do a "/temp/build" directory...