### PR TITLE
Increase specificity of utility classes

### DIFF
--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -133,9 +133,9 @@ html, button {
 
 /* All Visual Framework Utility and high-specificity components */
 
-@import 'vf-utility-classes/vf-utility-classes.scss';
 @import 'vf-heading/vf-heading.scss';
 @import 'vf-text/vf-text.scss';
+@import 'vf-utility-classes/vf-utility-classes.scss';
 
 // This is a demonstration of vf-core's ability to warn and proceed on missing
 // sass imports


### PR DESCRIPTION
Utility classes sizes should have more specificity than text/heading (especially needed when overriding default margins in edge cases)