### PR TITLE
fix: core-component-asset-paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -250,7 +250,7 @@ gulp.task('vf-scripts:modern', function() {
 // -----------------------------------------------------------------------------
 gulp.task('vf-component-assets', function() {
   return gulp
-    .src([componentPath + '/**/assets/**/*', componentPath + '/vf-core-components/**/assets/**/*'])
+    .src([componentPath + '/vf-core-components/**/assets/**/*', componentPath + '/**/assets/**/*'])
     .pipe(gulp.dest('./temp/build-files/assets'));
 });
 


### PR DESCRIPTION
anything in `/vf-core-omponents` should be scanned first to prevent unneeded sub-directories.

Doesn't matter directly in vf-core, but does to clients like vf-eleventy