### PR TITLE
Fix: docs should soft fail when vf-design-tokens aren't present

### DIFF
--- a/docs/styles/colours.config.js
+++ b/docs/styles/colours.config.js
@@ -2,8 +2,22 @@
 
 const path = require('path');
 
-module.exports = {
-  context: {
-    colors: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-colors.ios.json'))
+// Only generate the colour tokens if the vf-design-tokens are installed.
+// That is: if this is a full VF desing system, we probably have design tokens,
+// if not we're likely running as a VF component system and we don't want things
+// to blow up
+try {
+  if (path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-colors.ios.json')) {
+    module.exports = {
+      context: {
+        colors: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-colors.ios.json'))
+      }
+    };
   }
-};
+} catch(err) {
+  module.exports = {
+    context: {
+      colors: null
+    }
+  }
+}

--- a/docs/styles/spacing.config.js
+++ b/docs/styles/spacing.config.js
@@ -10,14 +10,14 @@ try {
   if (path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-colors.ios.json')) {
     module.exports = {
       context: {
-        colors: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-spacing.ios.json'))
+        spacing: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-spacing.ios.json'))
       }
     };
   }
 } catch(err) {
   module.exports = {
     context: {
-      colors: null
+      spacing: null
     }
   }
 }

--- a/docs/styles/spacing.config.js
+++ b/docs/styles/spacing.config.js
@@ -2,8 +2,22 @@
 
 const path = require('path');
 
-module.exports = {
-  context: {
-    spacing: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-spacing.ios.json'))
+// Only generate the colour tokens if the vf-design-tokens are installed.
+// That is: if this is a full VF desing system, we probably have design tokens,
+// if not we're likely running as a VF component system and we don't want things
+// to blow up
+try {
+  if (path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-colors.ios.json')) {
+    module.exports = {
+      context: {
+        colors: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-spacing.ios.json'))
+      }
+    };
   }
-};
+} catch(err) {
+  module.exports = {
+    context: {
+      colors: null
+    }
+  }
+}

--- a/docs/styles/typography.config.js
+++ b/docs/styles/typography.config.js
@@ -10,14 +10,14 @@ try {
   if (path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-colors.ios.json')) {
     module.exports = {
       context: {
-        colors: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-font--sans.ios.json'))
+        typography: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-font--sans.ios.json'))
       }
     };
   }
 } catch(err) {
   module.exports = {
     context: {
-      colors: null
+      typography: null
     }
   }
 }

--- a/docs/styles/typography.config.js
+++ b/docs/styles/typography.config.js
@@ -2,8 +2,22 @@
 
 const path = require('path');
 
-module.exports = {
-  context: {
-    typography: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-font--sans.ios.json'))
+// Only generate the colour tokens if the vf-design-tokens are installed.
+// That is: if this is a full VF desing system, we probably have design tokens,
+// if not we're likely running as a VF component system and we don't want things
+// to blow up
+try {
+  if (path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-colors.ios.json')) {
+    module.exports = {
+      context: {
+        colors: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-font--sans.ios.json'))
+      }
+    };
   }
-};
+} catch(err) {
+  module.exports = {
+    context: {
+      colors: null
+    }
+  }
+}


### PR DESCRIPTION
This is a workaround so the doc compilation in fractal will softfail when `vf-design-tokens` aren't present.

A few notes:

1. When the docs don't compile, the fractal components aren't available
2. This is mostly an issue for `vf-eleventy` sites, but fractal should be compiling the vf-core docs anyways 🤷‍♂ 
3. ☝️ That could also be an issue in `vf-core` if/when we move vf-design-tokens as an npm install

To me all that continues to suggest that we still need a more "holistic" way to approach the docs, so this PR is more of an "alpha-level" fix.