### PR TITLE
Chore: don't send backstop files to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ build
 .max-age
 .gitlab-ci.yml
 temp
+backstop_data


### PR DESCRIPTION
Just a cleanup thing I suppose.