### PR TITLE
Feature/gulpfile optimisations

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,7 +146,7 @@ gulp.task('vf-css', function() {
   return gulp
     .src([componentPath+'/**/*.scss',componentPath+'/**/**/*.scss'], {
       allowEmpty: true,
-      ignore: [componentPath+'/**/index.scss',componentPath+'/**/**/index.scss','!'+componentPath+'/vf-core-components/vf-core/components/**/*.scss']
+      ignore: [componentPath+'/**/index.scss',componentPath+'/**/**/index.scss',componentPath+'/vf-core-components/vf-core/components/**/*.scss']
     })
     .pipe(ListStream.obj(function (err, data) {
       if (err)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,7 +146,7 @@ gulp.task('vf-css', function() {
   return gulp
     .src([componentPath+'/**/*.scss',componentPath+'/**/**/*.scss'], {
       allowEmpty: true,
-      ignore: [componentPath+'/**/index.scss',componentPath+'/**/**/index.scss']
+      ignore: [componentPath+'/**/index.scss',componentPath+'/**/**/index.scss','!'+componentPath+'/vf-core-components/vf-core/components/**/*.scss']
     })
     .pipe(ListStream.obj(function (err, data) {
       if (err)


### PR DESCRIPTION
This final small tweak is the last thing  we need to be able to drop `vf-core.js` from `vf-eleventy` and directly reuse the one from`node_modules/vf-core`:

https://github.com/visual-framework/vf-eleventy/blob/feature/fully-reuse-vf-core/gulpfile.js#L8:
```
require('./node_modules/\@visual-framework/vf-core/gulpfile.js');
```