### PR TITLE
chore: cleanup autocomment

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -8,20 +8,16 @@ issuesOpened: >
 # PR Opened
 pullRequestOpened: >
 
-  Thank you for requesting a review for this pull request (PR).
+  Thank you for requesting a review for this pull request (PR). If you have not done so already - please fill out the PR description with as much context as possible.
 
   If this PR has an associated issue - please add that to the PR description.
 
-  If you have not done so already - please fill out the PR description with as much context as possible.
+  ## Pull request review
 
-# Pull Request Ready For Review
-pullRequestReviewRequested: >
+  Before your PR can be merged in, it will need to be reviewed.
 
-  Have you added any relevant labels to this PR?
-
-  To help this process please make sure you have these things ready (if applicable).
-
-  - [ ] `package.json` updated accordingly.
-  - [ ] `README.md` fill out with required documentation.
-  - [ ] any `.scss` files correctly documented.
+  - [ ] add relevant labels to this PR
+  - [ ] `package.json` is updated accordingly
+  - [ ] `README.md` is filled out with required documentation
+  - [ ] any `.scss` files correctly documented
   - [ ] a detailed outlin on what this PR is expected to do


### PR DESCRIPTION
Mostly does two things:

- Reduces the amount of spam we're getting when a PR is made and review requested (and I think this phrasing might be more helfpul to external devs)
- Tries to fix [ ] checkbox formatting with 2 spaces at end of each line