### PR TITLE
enhancement: dont-link-breadcrumbs-without-url

### DIFF
--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -152,7 +152,7 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
         console.warn('embl-js-breadcumbs-lookup: No matching parent found; Stopping parent lookup.');
         return;
       }
-      activeParent.url = activeParent.url || '#addPatternForTermsWithNoUrl';
+      activeParent.url = activeParent.url || '#no_url_specified';
 
       if (activeParent.name.indexOf(' root term') > 0) {
         // if we've reached a root term, abort lookups and don't insert a root term as a crumb
@@ -196,7 +196,7 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
    */
   function formatBreadcrumb(termName,breadcrumbUrl) {
     var newBreadcrumb = '<li class="vf-breadcrumbs__item">';
-    if (breadcrumbUrl && breadcrumbUrl !== 'null') {
+    if (breadcrumbUrl && breadcrumbUrl !== 'null' && breadcrumbUrl !== '#no_url_specified') {
       newBreadcrumb += '<a href="'+breadcrumbUrl+'" class="vf-breadcrumbs__link">' + termName + '</a>';
     } else {
       newBreadcrumb += termName;
@@ -246,7 +246,7 @@ function emblBreadcrumbs() {
       // If `name_display` is not set, use the internal name
       if (term.name_display === '') term.name_display = term.name;
       // handle null URL
-      if (term.url === '') term.url = 'https://embl.org/#no_url_specified';
+      if (term.url === '') term.url = '#no_url_specified';
     });
 
     // Invoke embl-content-meta-properties function to pull tags from page


### PR DESCRIPTION
In embl-breadcrumbs-lookup, the current desire is that when we don't have a working url, to not link the term.