### PR TITLE
Enhancement: update heading--l text size

### DIFF
--- a/components/vf-design-tokens/dist/json/vf-font--sans.ios.json
+++ b/components/vf-design-tokens/dist/json/vf-font--sans.ios.json
@@ -165,7 +165,7 @@
       "category": "font",
       "name": "headingL",
       "value": {
-        "fontSize": "24px",
+        "fontSize": "30px",
         "fontWeight": 500,
         "lineHeight": 1.333
       },

--- a/components/vf-design-tokens/dist/sass/vf-font--sans.scss
+++ b/components/vf-design-tokens/dist/sass/vf-font--sans.scss
@@ -52,7 +52,7 @@ $vf-font--sans-serif: (
   ),
 
   'heading--l': (
-    'font-size': 24px,
+    'font-size': 30px,
     'font-weight': 500,
     'line-height': 1.333
   ),

--- a/components/vf-design-tokens/src/typographic-scales/vf-font--sans.yml
+++ b/components/vf-design-tokens/src/typographic-scales/vf-font--sans.yml
@@ -102,7 +102,7 @@ props:
       pangram: "The five boxing wizards jump quickly."
   - name: heading--l
     value:
-      fontSize: 24px
+      fontSize: 30px
       fontWeight: 500
       lineHeight: 1.333
     meta:


### PR DESCRIPTION
Resolves issues that occur as `heading--l` and `heading--l-alit` were both 24px

For more background see: https://gitlab.ebi.ac.uk/emblorg/backlog/issues/215#note_45386

We could also resolve some of these issues by manually setting the `.vf-content h2` size, but that would be a bit of a hack and not get updates from vf-design-tokens.

This will have some knockon effects to other patterns, sometimes it may be a "change for the better" other times we may need to update a pattern to use `--l-alt`

The Sketch paragraph styles may also need to be updated.

Here's a gif of a couple patterns, updated size comes first. This looks much better for `vf-content` but we may need to change the containers to use `heading--l-alt`

![heading-sizes](https://user-images.githubusercontent.com/928100/60419971-d895f380-9be6-11e9-8937-24122e9f6299.gif)
