### PR TITLE
enhancement: use-heading--l-alt-for-some-patterns

### DIFF
--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -93,7 +93,7 @@
 }
 
 .vf-card__title {
-  @include set-type(heading--l);
+  @include set-type(heading--l-alt);
 
   transition: all .1s linear;
 }

--- a/components/vf-section-header/vf-section-header.scss
+++ b/components/vf-section-header/vf-section-header.scss
@@ -1,6 +1,6 @@
 // vf-section-header
 
 .vf-section-header__heading {
-  @include set-type(heading--l);
+  @include set-type(heading--l-alt);
   margin: 0;
 }

--- a/components/vf-summary/vf-summary.variables.scss
+++ b/components/vf-summary/vf-summary.variables.scss
@@ -10,7 +10,7 @@
 $vf-summary-margin-bottom: 2rem;
 
 // vf-summary__title variables
-$vf-summary__title-typography: heading--l;
+$vf-summary__title-typography: heading--l-alt;
 
 // vf-summary__body variables
 $vf-summary__body-typography: body--l;

--- a/components/vf-video-teaser/vf-video-teaser.scss
+++ b/components/vf-video-teaser/vf-video-teaser.scss
@@ -7,6 +7,6 @@
 
 
 .vf-video-teaser__title {
-  @include set-type(heading--l);
-  margin: 0 0 16px 0; 
+  @include set-type(heading--l-alt);
+  margin: 0 0 16px 0;
 }


### PR DESCRIPTION
Follows up on #443 by subing out `heading--l` for `heading--l-alt` in:

- vf-card
- vf-section-header
- vf-summary
- vf-video-teaser

Basically, where a bump from 30px to 24px was undesirable.

We may have a larger refactor of the naming of some of these tokens coming, but for now this "makes things look right", i think.