### PR TITLE
Bug: Autocomment formatting

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -8,7 +8,7 @@ issuesOpened: >
 # PR Opened
 pullRequestOpened: >
 
-  Thank you for requesting a review for this pull request (PR). If you have not done so already - please fill out the PR description with as much context as possible.
+  Thank you for requesting a review for this pull request (PR). If you have not done so already - please fill out the PR description with as much context as possible.<br/>
 
   If this PR has an associated issue - please add that to the PR description.
 
@@ -17,7 +17,11 @@ pullRequestOpened: >
   Before your PR can be merged in, it will need to be reviewed.
 
   - [ ] add relevant labels to this PR
+
   - [ ] `package.json` is updated accordingly
+
   - [ ] `README.md` is filled out with required documentation
+
   - [ ] any `.scss` files correctly documented
+
   - [ ] a detailed outlin on what this PR is expected to do


### PR DESCRIPTION
Continues effort to (attempt to) clean up formatting; this:

![image](https://user-images.githubusercontent.com/928100/60508716-88449180-9ccb-11e9-86fc-8bc93d96416f.png)
