### PR TITLE
bug: spacing-token-naming

### DIFF
--- a/components/vf-banner/vf-banner.variables.scss
+++ b/components/vf-banner/vf-banner.variables.scss
@@ -1,11 +1,11 @@
 $vf-gdpr-banner-color--background: set-color(vf-color--grey--dark);
 $vf-gdpr-banner-color--text: set-ui-color(vf-ui-color--white);
-$vf-gdpr-banner-padding: map-get($vf-spacing-map, vf-spacing-r);
+$vf-gdpr-banner-padding: map-get($vf-spacing-map, vf-spacing--r);
 
 $vf-notice-banner-color--background: set-color(vf-color--grey--dark);
 
 $vf-notice-banner-color--text: set-ui-color(vf-ui-color--white);
-$vf-notice-banner-padding: map-get($vf-spacing-map, vf-spacing-r);
+$vf-notice-banner-padding: map-get($vf-spacing-map, vf-spacing--r);
 
 $vf-phase-banner-color--background: set-ui-color(vf-ui-color--yellow);
 $vf-phase-banner-color--text: set-color(vf-color--grey--dark);

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -76,7 +76,7 @@
   @include set-type(body--s);
 
   padding: 8px;
-  // @include padding(all, map-get($vf-spacing-map, vf-spacing-s));
+  // @include padding(all, map-get($vf-spacing-map, vf-spacing--s));
 
   &.vf-button--rounded {
     border-radius: 8px;

--- a/components/vf-content/vf-content.config.yml
+++ b/components/vf-content/vf-content.config.yml
@@ -1,5 +1,5 @@
 title: Content
 label: Content
-preview: '@preview--containers'
+preview: '@preview'
 context:
   component-type: container

--- a/components/vf-content/vf-content.njk
+++ b/components/vf-content/vf-content.njk
@@ -21,6 +21,16 @@
     1. Interactions with industry and technology transfer
     1. Playing a leading role in the integration of life science research
 
+    ### Further examples of bullets
+
+    - A bulleted item
+      - A nested bulleted item
+      - A nested bulleted item
+    - A bulleted item
+    - A bulleted item
+    - A bulleted item
+    - A bulleted item
+
   {% endmarkdown %}
 
   <h3>What is EMBL?</h3>
@@ -49,5 +59,5 @@
 
   <blockquote>
     <p>We are a group of user experience specialists in an international scientific organisation</p><p>Our aim is to help teams design services to meet the needs of their users</p><p>We believe in openness , transparency, working collaboratively and iteratively, continuously learning and sharing knowledge throughout the organisation</p><p><cite>EMBl-EBI Web Development UX Team Mission</cite></p>
-  </blockquote>  
+  </blockquote>
 </div>

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -89,11 +89,16 @@
   li:not([class*='vf-']) {
     @include set-type(body--l);
 
-    margin-bottom: map-get($vf-spacing-map, vf-spacing-s);
+    margin-bottom: map-get($vf-spacing-map, vf-spacing--s);
+
+    > ul:not([class*='vf-']),
+    > ol:not([class*='vf-']) {
+      margin-top: map-get($vf-spacing-map, vf-spacing--s);
+    }
   }
 
   li:not([class*='vf-']):last-of-type {
-    margin-bottom: map-get($vf-spacing-map, vf-spacing-r);
+    margin-bottom: map-get($vf-spacing-map, vf-spacing--r);
   }
 
   hr:not([class*='vf-']) {

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -51,7 +51,7 @@
 
 .vf-inlay__content--full-width {
   grid-column: 2 / -2;
-  @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
+  @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--l));
 }
 
 .vf-inlay__content--main {
@@ -61,7 +61,7 @@
   @media (min-width: 1100px) {
     grid-column: 2 / 3;
   }
-  @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
+  @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--l));
 }
 
 .vf-inlay__content--additional {

--- a/components/vf-link-list/vf-link-list.scss
+++ b/components/vf-link-list/vf-link-list.scss
@@ -12,7 +12,7 @@
 
   .vf-list__item {
     @include set-type(body--l);
-    @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
+    @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--l));
 
     align-items: center;
   }
@@ -74,7 +74,7 @@
   }
 
   .vf-links__item {
-    margin-bottom: map-get($vf-spacing-map, vf-spacing-s);
+    margin-bottom: map-get($vf-spacing-map, vf-spacing--s);
   }
 }
 

--- a/components/vf-page-header/vf-page-header.scss
+++ b/components/vf-page-header/vf-page-header.scss
@@ -3,7 +3,7 @@
 $vf-page-header__sub-heading-text--color: set-color(vf-color--grey);
 
 .vf-page-header {
-  @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing-l));
+  @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--l));
 
   display: flex;
   flex-direction: column-reverse;

--- a/components/vf-sass-config/mixins/_divider.scss
+++ b/components/vf-sass-config/mixins/_divider.scss
@@ -2,7 +2,7 @@
 
 @mixin divider() {
   background-color: set-ui-color(vf-ui-color--grey--light);
-  margin: 0 map-get($vf-spacing-map, vf-spacing-s);
+  margin: 0 map-get($vf-spacing-map, vf-spacing--s);
   height: 1px;
   border: none;
 }

--- a/components/vf-sass-config/mixins/_lists.scss
+++ b/components/vf-sass-config/mixins/_lists.scss
@@ -1,5 +1,4 @@
 
-
 @mixin list($classname, $type: null) {
   @if $type == null {
     list-style-type: none;
@@ -56,13 +55,13 @@
   @if $classname != null {
     @at-root .#{$classname} {
       @at-root  .#{$classname}__item {
-        margin-bottom: map-get($vf-spacing-map, vf-spacing-r);
+        margin-bottom: map-get($vf-spacing-map, vf-spacing--r);
       }
     }
   }
   @else {
     li {
-      margin-bottom: map-get($vf-spacing-map, vf-spacing-r);
+      margin-bottom: map-get($vf-spacing-map, vf-spacing--r);
     }
   }
 }


### PR DESCRIPTION
1. The spacing token names missed an update, that is: `vf-spacing-r` should be `vf-spacing--r`
1. Also resolves an issue where nested `.vf-content ul li > ul` needed margin at the top; gif of fix:

![spacing](https://user-images.githubusercontent.com/928100/60509016-3ea87680-9ccc-11e9-8419-64f32cc81537.gif)
