### PR TITLE
Enhancement: gulp css building, linting

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -360,7 +360,7 @@ gulp.task('vf-css-gen', function(done) {
 // -----------------------------------------------------------------------------
 
 gulp.task('vf-watch', function(done) {
-  gulp.watch(componentPath + '/**/*.scss', gulp.series('vf-css','vf-lint:scss-soft-fail')).on('change', reload);
+  gulp.watch(componentPath + '/**/*.scss', gulp.series('vf-css')).on('change', reload);
   gulp.watch(componentPath + '/**/*.js', gulp.series('vf-scripts')).on('change', reload);
   gulp.watch(componentPath + '/**/**/assets/*.svg', gulp.series('svg','vf-component-assets')).on('change', reload);
   gulp.watch([componentPath + '/**/**/assets/*', '!' + componentPath + '/**/**/assets/*.svg'], gulp.series('vf-component-assets')).on('change', reload);
@@ -406,7 +406,7 @@ gulp.task('vf-scripts', gulp.series(
 ));
 
 gulp.task('vf-dev', gulp.series(
-  'vf-clean', 'vf-component-assets', ['vf-css', 'vf-scripts'], 'frctlStart', ['vf-watch', 'vf-lint:scss-soft-fail']
+  'vf-clean', 'vf-component-assets', ['vf-css', 'vf-scripts'], 'frctlStart', ['vf-lint:scss-soft-fail', 'vf-watch']
 ));
 
 // Build as a static site for CI


### PR DESCRIPTION
Addresses #412 and also address the "spirit" of that ticket, by:

- Making the css linting come after the css recompilation
- Adds a soft-fail css linting task that won't explode the local deve experience
- Fixes `vf-css` to use a better callback approach so that:
    1. You get an accurate idea of the css build time
    2. A real signal that the vf-css pipe stream has completed
    3. No longer get a flash of fractal before the css build has finished

And it should be a bit faster now that fractal and all the other gulp tasks won't try to run while the Sass is still building.
