### PR TITLE
Bug: fix static build path for vf-card

### DIFF
--- a/components/vf-button/index.scss
+++ b/components/vf-button/index.scss
@@ -5,6 +5,7 @@
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';
+@import 'vf-utility-mixins';
 
 // component specific styles
 

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -15,4 +15,4 @@ context:
 
   title: Title Block
   text: two lines of text
-  image: /assets/vf-card/assets/vf-card-example.png
+  image: ../../assets/vf-card/assets/vf-card-example.png

--- a/components/vf-content/index.scss
+++ b/components/vf-content/index.scss
@@ -4,6 +4,7 @@
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';
+@import 'vf-utility-mixins';
 // other components being used
 
 @import 'vf-heading/vf-heading.scss';


### PR DESCRIPTION
This mainly fixes how vf-card was showing without the image when deployed. It relates to #364 on how we need to document this, probably in the pattern template too.

It also sneaks in a fix where the utility mixins were need for the hover effect for the button.