### PR TITLE
the one where remove stylelint from dev and save lots of time

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -354,7 +354,7 @@ gulp.task('vf-css-gen', function(done) {
 // -----------------------------------------------------------------------------
 
 gulp.task('vf-watch', function(done) {
-  gulp.watch(componentPath + '/**/*.scss', gulp.series(['vf-css', 'vf-scss-lint'])).on('change', reload);
+  gulp.watch(componentPath + '/**/*.scss', gulp.series(['vf-css'])).on('change', reload);
   gulp.watch(componentPath + '/**/*.js', gulp.series('vf-scripts')).on('change', reload);
   gulp.watch(componentPath + '/**/**/assets/*.svg', gulp.series('svg','vf-component-assets')).on('change', reload);
   gulp.watch([componentPath + '/**/**/assets/*', '!' + componentPath + '/**/**/assets/*.svg'], gulp.series('vf-component-assets')).on('change', reload);


### PR DESCRIPTION
having `stylelint` process every time a Sass file changes means that it takes an age to see your changes whilst working away on a component or feature.

This PR removes it from the Sass-y `vf-watch` task so it is only tested as a pre-push commit