### PR TITLE
Bug: component variant name, demo

### DIFF
--- a/components/vf-heading/README.md
+++ b/components/vf-heading/README.md
@@ -4,11 +4,20 @@
 
 ## Demo
 
-{% set context = '@vf-heading' | componentContexts %}
+{% set context = '@vf-heading--display' | componentContexts %}
+{% render '@vf-heading', {"type": context.type, "html": context.heading, "style": "invert"} %}
 
-{% for modifier in context.vf_heading_modifiers %}
-  {% render '@vf-heading', {"type": modifier.type, "title": modifier.title} %}
-{% endfor %}
+{% set context = '@vf-heading--extra-large' | componentContexts %}
+{% render '@vf-heading', {"type": context.type, "html": context.heading} %}
+
+{% set context = '@vf-heading--large' | componentContexts %}
+{% render '@vf-heading', {"type": context.type, "html": context.heading} %}
+
+{% set context = '@vf-heading--regular' | componentContexts %}
+{% render '@vf-heading', {"type": context.type, "html": context.heading} %}
+
+{% set context = '@vf-heading--small' | componentContexts %}
+{% render '@vf-heading', {"type": context.type, "html": context.heading} %}
 
 ## Installation and Implementation
 

--- a/components/vf-heading/vf-heading.config.yml
+++ b/components/vf-heading/vf-heading.config.yml
@@ -32,5 +32,5 @@ variants:
   - name: small
     context:
       type: small
-      heading: This heading size is smalls
+      heading: This heading size is small
       tags: h4

--- a/components/vf-text/vf-text.config.yml
+++ b/components/vf-text/vf-text.config.yml
@@ -8,10 +8,10 @@ context:
 variants:
   - name: default
     hidden: true
-  - name: extra large
+  - name: extra-large
     context:
       text: This text is extra large
-      type: extra-large    
+      type: extra-large
   - name: large
     context:
       text: This text is large


### PR DESCRIPTION
A few minor fixes I stumbled on while working on #460: a name for a vf-text variant and the vf-headings demo