### PR TITLE
Chore: set percy to run only on develop

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,6 +1,7 @@
 version: 1
 snapshot:
-  widths: [375, 800, 1330]
+  # widths: [375, 800, 1330]
+  widths: [1330]
 static-snapshots:
   base-url:
   snapshot-files:  '**/*.html'

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,7 +1,7 @@
 version: 1
 snapshot:
   # widths: [375, 800, 1330]
-  widths: [1330]
+  widths: [375, 1330]
 static-snapshots:
   base-url:
   snapshot-files:  '**/*.html'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,22 @@ branches:
 
 stages:
   - deploy
+  - percy
 
 before_script:
-  - npm install
-  - npm install -g gulp-cli
+  - yarn install
+  - yarn global add gulp-cli
   - gulp vf-build
   - "curl https://www.projectwallace.com/webhooks/v1/imports?token=$WALLACE_TOKEN -fsS --retry 3 -X POST -H 'Content-Type: text/css' -d @build/css/styles.css"
-  - npx percy snapshot build/components/preview/
+
+percy:
+  env:
+    - PERCY_TARGET_BRANCH=master
+  script:
+    - npx percy snapshot build/components/preview/
+  on:
+    branch:
+      - develop
 
 deploy:
   provider: pages


### PR DESCRIPTION
This limits the percy command to only run on commits to develop and compares against master.

We might also want to disable the github integration to stop comparissons on PRs, which has chewed through our alotment of screenshots.

This also set it only do mobile/desktop for a 33% savings :D

But it doesn't really matter until August as we've already gone through our quota!