### PR TITLE
BUG - Remove extra spacing from vf-badge

### DIFF
--- a/components/vf-badge/vf-badge.njk
+++ b/components/vf-badge/vf-badge.njk
@@ -1,4 +1,5 @@
 {# Determine type of element to use, if not explicitly set -#}
+{% spaceless %}
 
 {% if href %}
   {% set tags = 'a' %}
@@ -36,3 +37,4 @@ class="vf-badge
    {{- html | safe if html else text -}}
 
 </{{tags}}>
+{% endspaceless %}


### PR DESCRIPTION
Was breaking formatting on render in whitespace-aware environments.