### PR TITLE
Enhancement: code background

### DIFF
--- a/components/vf-code-example/vf-code-example.scss
+++ b/components/vf-code-example/vf-code-example.scss
@@ -27,10 +27,10 @@ $vf-code-example-enable-hljs: true !default;
 .vf-content pre,
 .vf-code-example__pre {
   border: 1px;
+  display: inline-block;
   min-width: 0;
   overflow: auto;
   white-space: pre-wrap;
-  display: inline-block;
   @include padding--inline(all,map-get($vf-spacing-map, vf-spacing--s));
 }
 

--- a/components/vf-code-example/vf-code-example.scss
+++ b/components/vf-code-example/vf-code-example.scss
@@ -10,7 +10,7 @@ $vf-code-example-enable-hljs: true !default;
   // pre and code should always be monospace
   @include set-type(body--s,$vf-font-family--monospace);
 
-  @include padding--block(4px,4px);
+  @include padding--block(all,map-get($vf-spacing-map, vf-spacing--xs));
   background: set-ui-color(vf-ui-color--grey);
   border-radius: $vf-radius--xs;
 }
@@ -29,6 +29,9 @@ $vf-code-example-enable-hljs: true !default;
   border: 1px;
   min-width: 0;
   overflow: auto;
+  white-space: pre-wrap;
+  display: inline-block;
+  @include padding--inline(all,map-get($vf-spacing-map, vf-spacing--s));
 }
 
 @if $vf-code-example-enable-hljs == true {

--- a/components/vf-code-example/vf-code-example.scss
+++ b/components/vf-code-example/vf-code-example.scss
@@ -8,7 +8,16 @@ $vf-code-example-enable-hljs: true !default;
 .vf-code-example__pre,
 .vf-code-example {
   // pre and code should always be monospace
-  @include set-type(body--s,$vf-font-family--monospace, $custom-margin-bottom: 0);
+  @include set-type(body--s,$vf-font-family--monospace);
+
+  @include padding--block(4px,4px);
+  background: set-ui-color(vf-ui-color--grey);
+  border-radius: $vf-radius--xs;
+}
+
+.vf-content code,
+.vf-code-example {
+  font-size: inherit;
 }
 
 .vf-code-example {


### PR DESCRIPTION
I'm working a lot with code snippets at the moment and the lack of formatting has finally gotten to me. This is basically GitHub's approach with VF sizings.

Probably more to do here, but a placeholder until Mark has time to draft a design.


Current:

![image](https://user-images.githubusercontent.com/928100/61292360-4f2f1580-a7d1-11e9-8a6b-54b0fbb403a5.png)

After:

![image](https://user-images.githubusercontent.com/928100/61292451-7ede1d80-a7d1-11e9-9013-1f939a5ed61e.png)

