### PR TITLE
CHORE: update-footer

### DIFF
--- a/components/vf-footer/vf-footer.njk
+++ b/components/vf-footer/vf-footer.njk
@@ -1,80 +1,80 @@
 <footer class="vf-footer | vf-body">
   <div class="vf-footer__inner">
-    <p class="vf-footer__notice">EMBL is Europe’s flagship laboratory for the life sciences – an intergovernmental organisation with more than 80 independent research groups covering the spectrum of molecular biology.</p>
+    <p class="vf-footer__notice">A description of a site or organisation and what its goals are.</p>
     <div class="vf-footer__links-group | vf-grid">
       <div class="vf-links">
-        <h4 class="vf-links__heading">Research</h3>
+        <h4 class="vf-links__heading">Category</h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Units</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Groups</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Publications</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">Services</h3>
+        <h4 class="vf-links__heading">Category</h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">By Topic</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">By A-Z</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Microscopes</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Images</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Library</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">Research</h3>
+        <h4 class="vf-links__heading">Category</h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Units</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Groups</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Publications</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">Research</h3>
+        <h4 class="vf-links__heading">Category</h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Units</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Groups</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Publications</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">Research</h3>
+        <h4 class="vf-links__heading">Category</h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Units</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Groups</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Publications</a>
+            <a class="vf-list__link" href="#">Entry</a>
           </li>
         </ul>
       </div>
@@ -83,19 +83,19 @@
     <section class="vf-footer__legal | vf-grid vf-grid__col-1">
       <ul class="vf-footer__list vf-footer__list--legal | vf-list vf-list--inline">
         <li class="vf-list__item">
-          <a href="#" class="vf-list__link">Help</a>
+          <a href="#" class="vf-list__link">Entry</a>
         </li>
         <li class="vf-list__item">
-          <a href="#" class="vf-list__link">Policies &amp; Guidelines</a>
+          <a href="#" class="vf-list__link">Entry</a>
         </li>
         <li class="vf-list__item">
-          <a href="#" class="vf-list__link">Privacy Policy</a>
+          <a href="#" class="vf-list__link">Entry</a>
         </li>
       </ul>
-      <p class="vf-footer__legal-text">Copyright © EMBL 2018.</p>
-      <p class="vf-footer__legal-text">Meyerhofstraße 1, 69117 Heidelberg, Germany.</p>
-      <p class="vf-footer__legal-text">Tel: +49 6221 387-0.</p>
-      <a class="vf-footer__link" href="#">Full contact details</a>
+      <p class="vf-footer__legal-text">Copyright © Your Organisation.</p>
+      <p class="vf-footer__legal-text">Maybe an address too, 5555, Somewhere, Earth.</p>
+      <p class="vf-footer__legal-text">Tel: +49 00 000 000.</p>
+      <a class="vf-footer__link" href="#">Another entry</a>
     </section>
   </div>
 </footer>

--- a/components/vf-footer/vf-footer.njk
+++ b/components/vf-footer/vf-footer.njk
@@ -3,143 +3,78 @@
     <p class="vf-footer__notice">EMBL is Europe’s flagship laboratory for the life sciences – an intergovernmental organisation with more than 80 independent research groups covering the spectrum of molecular biology.</p>
     <div class="vf-footer__links-group | vf-grid">
       <div class="vf-links">
-        <h4 class="vf-links__heading">
-          <a class="vf-list__link" href="https://www.embl.de/research/index.php">Research</a>
-        </h4>
+        <h4 class="vf-links__heading">Research</h3>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/eipp/research_units/index.html">Research Units</a>
+            <a class="vf-list__link" href="#">Research Units</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/research/interdisciplinary_research/index.html">Interdisciplinary research</a>
+            <a class="vf-list__link" href="#">Research Groups</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/eipp/research_topics/index.html">Research topics</a>
+            <a class="vf-list__link" href="#">Publications</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">
-          <a class="vf-list__link" href="https://www.embl.de/services/index.html">Services</a>
-        </h4>
+        <h4 class="vf-links__heading">Services</h3>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/services/core_facilities/index.html">Core Facilities</a>
+            <a class="vf-list__link" href="#">By Topic</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/research/interdisciplinary_research/bioinformatics/index.html">Bioinformatics</a>
+            <a class="vf-list__link" href="#">By A-Z</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/services/itservices/index.html">IT services</a>
+            <a class="vf-list__link" href="#">Microscopes</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/services/cryo-em-platform/index.html">Cryo-Electron Microscopy Service Platform</a>
+            <a class="vf-list__link" href="#">Images</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="#">Library</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">
-          <a class="vf-list__link" href="https://www.embl.de/services/index.html">Training</a>
-        </h4>
+        <h4 class="vf-links__heading">Research</h3>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/eicat/index.html">EMBL International Centre for Advanced Training</a>
+            <a class="vf-list__link" href="#">Research Units</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/events/index.php?e=COU&o=ALL&t=FUTURE&sub=ALL&search=Show+Events">Courses & Conferences</a>
+            <a class="vf-list__link" href="#">Research Groups</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/eipp/index.html">EMBL International PhD Programme</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/postdocs/index.html">Postdoctoral Programme</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/undergraduates/index.html">Undergraduates</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/visitor-programme/index.html">Scientific Visitor Programme</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/e-learning/index.html">E-learning</a>
+            <a class="vf-list__link" href="#">Publications</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">
-          <a class="vf-list__link" href="https://www.embl.de/aboutus/general_information/index.html">About EMBL</a>
-        </h4>
+        <h4 class="vf-links__heading">Research</h3>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/aboutus/general_information/index.html">What is EMBL?</a>
+            <a class="vf-list__link" href="#">Research Units</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/aboutus/general_information/leadership/index.html">Leadership</a>
+            <a class="vf-list__link" href="#">Research Groups</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.it/research/faculty/index.php">Faculty</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/aboutus/general_information/leadership/council/index.html">Council</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://news.embl.de/">EMBL News</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/research/partnerships/index.html">Partnerships</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.it/aboutus/industry-relations/index.html">Industry</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.it/aboutus/communication_outreach/media_relations/index.html">Press</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/aboutus/support-embl/index.html">Support</a>
+            <a class="vf-list__link" href="#">Publications</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">
-          Find
-        </h4>
+        <h4 class="vf-links__heading">Research</h3>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.it/jobs/index.php">Jobs</a>
+            <a class="vf-list__link" href="#">Research Units</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/training/events/index.php">Courses & Conferences</a>
+            <a class="vf-list__link" href="#">Research Groups</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de/research/seminars/index.php">Seminars</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.it/aboutus/alumni/index.html">Alumni</a>
-          </li>
-        </ul>
-      </div>
-      <div class="vf-links">
-        <h4 class="vf-links__heading">
-          Locations
-        </h4>
-        <ul class="vf-links__list | vf-list">
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.es/">Barcelona</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.ebi.ac.uk/">EMBL-EBI Hinxton</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.de">Heidelberg</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl-hamburg.de">Hamburg</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.fr">Grenoble</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="https://www.embl.it">Rome</a>
+            <a class="vf-list__link" href="#">Publications</a>
           </li>
         </ul>
       </div>
@@ -148,19 +83,19 @@
     <section class="vf-footer__legal | vf-grid vf-grid__col-1">
       <ul class="vf-footer__list vf-footer__list--legal | vf-list vf-list--inline">
         <li class="vf-list__item">
-          <a href="https://dev.beta.embl.org/info/coming-soon/?link=help" class="vf-list__link">Help</a>
+          <a href="#" class="vf-list__link">Help</a>
         </li>
         <li class="vf-list__item">
-          <a href="https://dev.beta.embl.org/info/coming-soon/?link=policies" class="vf-list__link">Policies &amp; Guidelines</a>
+          <a href="#" class="vf-list__link">Policies &amp; Guidelines</a>
         </li>
         <li class="vf-list__item">
-          <a href="https://www.embl.it/aboutus/privacy_policy/index.html" class="vf-list__link">Privacy Policy</a>
+          <a href="#" class="vf-list__link">Privacy Policy</a>
         </li>
       </ul>
       <p class="vf-footer__legal-text">Copyright © EMBL 2018.</p>
       <p class="vf-footer__legal-text">Meyerhofstraße 1, 69117 Heidelberg, Germany.</p>
       <p class="vf-footer__legal-text">Tel: +49 6221 387-0.</p>
-      <a class="vf-footer__link" href="https://www.embl.de/aboutus/contact/index.html">Full contact details</a>
+      <a class="vf-footer__link" href="#">Full contact details</a>
     </section>
   </div>
 </footer>

--- a/components/vf-footer/vf-footer.njk
+++ b/components/vf-footer/vf-footer.njk
@@ -3,78 +3,143 @@
     <p class="vf-footer__notice">EMBL is Europe’s flagship laboratory for the life sciences – an intergovernmental organisation with more than 80 independent research groups covering the spectrum of molecular biology.</p>
     <div class="vf-footer__links-group | vf-grid">
       <div class="vf-links">
-        <h4 class="vf-links__heading">Research</h3>
+        <h4 class="vf-links__heading">
+          <a class="vf-list__link" href="https://www.embl.de/research/index.php">Research</a>
+        </h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Units</a>
+            <a class="vf-list__link" href="https://www.embl.de/training/eipp/research_units/index.html">Research Units</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Groups</a>
+            <a class="vf-list__link" href="https://www.embl.de/research/interdisciplinary_research/index.html">Interdisciplinary research</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Publications</a>
+            <a class="vf-list__link" href="https://www.embl.de/training/eipp/research_topics/index.html">Research topics</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">Services</h3>
+        <h4 class="vf-links__heading">
+          <a class="vf-list__link" href="https://www.embl.de/services/index.html">Services</a>
+        </h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">By Topic</a>
+            <a class="vf-list__link" href="https://www.embl.de/services/core_facilities/index.html">Core Facilities</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">By A-Z</a>
+            <a class="vf-list__link" href="https://www.embl.de/research/interdisciplinary_research/bioinformatics/index.html">Bioinformatics</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Microscopes</a>
+            <a class="vf-list__link" href="https://www.embl.de/services/itservices/index.html">IT services</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Images</a>
-          </li>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Library</a>
+            <a class="vf-list__link" href="https://www.embl.de/services/cryo-em-platform/index.html">Cryo-Electron Microscopy Service Platform</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">Research</h3>
+        <h4 class="vf-links__heading">
+          <a class="vf-list__link" href="https://www.embl.de/services/index.html">Training</a>
+        </h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Units</a>
+            <a class="vf-list__link" href="https://www.embl.de/training/eicat/index.html">EMBL International Centre for Advanced Training</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Groups</a>
+            <a class="vf-list__link" href="https://www.embl.de/training/events/index.php?e=COU&o=ALL&t=FUTURE&sub=ALL&search=Show+Events">Courses & Conferences</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Publications</a>
+            <a class="vf-list__link" href="https://www.embl.de/training/eipp/index.html">EMBL International PhD Programme</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.de/training/postdocs/index.html">Postdoctoral Programme</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.de/training/undergraduates/index.html">Undergraduates</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.de/training/visitor-programme/index.html">Scientific Visitor Programme</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.de/training/e-learning/index.html">E-learning</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">Research</h3>
+        <h4 class="vf-links__heading">
+          <a class="vf-list__link" href="https://www.embl.de/aboutus/general_information/index.html">About EMBL</a>
+        </h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Units</a>
+            <a class="vf-list__link" href="https://www.embl.de/aboutus/general_information/index.html">What is EMBL?</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Groups</a>
+            <a class="vf-list__link" href="https://www.embl.de/aboutus/general_information/leadership/index.html">Leadership</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Publications</a>
+            <a class="vf-list__link" href="https://www.embl.it/research/faculty/index.php">Faculty</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.de/aboutus/general_information/leadership/council/index.html">Council</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://news.embl.de/">EMBL News</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.de/research/partnerships/index.html">Partnerships</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.it/aboutus/industry-relations/index.html">Industry</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.it/aboutus/communication_outreach/media_relations/index.html">Press</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.de/aboutus/support-embl/index.html">Support</a>
           </li>
         </ul>
       </div>
       <div class="vf-links">
-        <h4 class="vf-links__heading">Research</h3>
+        <h4 class="vf-links__heading">
+          Find
+        </h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Units</a>
+            <a class="vf-list__link" href="https://www.embl.it/jobs/index.php">Jobs</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Research Groups</a>
+            <a class="vf-list__link" href="https://www.embl.de/training/events/index.php">Courses & Conferences</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Publications</a>
+            <a class="vf-list__link" href="https://www.embl.de/research/seminars/index.php">Seminars</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.it/aboutus/alumni/index.html">Alumni</a>
+          </li>
+        </ul>
+      </div>
+      <div class="vf-links">
+        <h4 class="vf-links__heading">
+          Locations
+        </h4>
+        <ul class="vf-links__list | vf-list">
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.es/">Barcelona</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.ebi.ac.uk/">EMBL-EBI Hinxton</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.de">Heidelberg</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl-hamburg.de">Hamburg</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.fr">Grenoble</a>
+          </li>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="https://www.embl.it">Rome</a>
           </li>
         </ul>
       </div>
@@ -83,19 +148,19 @@
     <section class="vf-footer__legal | vf-grid vf-grid__col-1">
       <ul class="vf-footer__list vf-footer__list--legal | vf-list vf-list--inline">
         <li class="vf-list__item">
-          <a href="#" class="vf-list__link">Help</a>
+          <a href="https://dev.beta.embl.org/info/coming-soon/?link=help" class="vf-list__link">Help</a>
         </li>
         <li class="vf-list__item">
-          <a href="#" class="vf-list__link">Policies &amp; Guidelines</a>
+          <a href="https://dev.beta.embl.org/info/coming-soon/?link=policies" class="vf-list__link">Policies &amp; Guidelines</a>
         </li>
         <li class="vf-list__item">
-          <a href="#" class="vf-list__link">Privacy Policy</a>
+          <a href="https://www.embl.it/aboutus/privacy_policy/index.html" class="vf-list__link">Privacy Policy</a>
         </li>
       </ul>
       <p class="vf-footer__legal-text">Copyright © EMBL 2018.</p>
       <p class="vf-footer__legal-text">Meyerhofstraße 1, 69117 Heidelberg, Germany.</p>
       <p class="vf-footer__legal-text">Tel: +49 6221 387-0.</p>
-      <a class="vf-footer__link" href="#">Full contact details</a>
+      <a class="vf-footer__link" href="https://www.embl.de/aboutus/contact/index.html">Full contact details</a>
     </section>
   </div>
 </footer>


### PR DESCRIPTION
Makes the vf-footer pattern generic. 

Why?

- This also sorts the current situation where we have to update the contentHub and here
- Lets the contentHub be just a template
- De-conflicts the having embl-specific stuff in a generic vf pattern

This change won't break anything.