### PR TITLE
BUG - vf-global-header site link, misc related issues

### DIFF
--- a/components/vf-global-header/vf-global-header.config.yml
+++ b/components/vf-global-header/vf-global-header.config.yml
@@ -3,5 +3,5 @@ label: Global Header
 preview: '@preview--nogrid'
 context:
   component-type: block
-
+  href: JavaScript:Void(0);
   text: Visual Framework for Life Science websites

--- a/components/vf-global-header/vf-global-header.njk
+++ b/components/vf-global-header/vf-global-header.njk
@@ -4,7 +4,7 @@
 
     {% render '@vf-logo--responsive' %}
 
-    <p class="vf-global-header__site-name">{{ text }}</p>
+    <a href="{{ href }}" class="vf-global-header__site-name | vf-global-header__link">{{ text }}</a>
 
     {% render '@vf-navigation--global' %}
 

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -1,7 +1,6 @@
 // vf-global-header
 
-$vf-global-header-background--color: set-ui-color(vf-ui-color--white);
-$vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
+@import 'vf-global-header.variables.scss';
 
 .vf-global-header {
   align-items: center;
@@ -24,6 +23,15 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
   align-self: center;
   display: block;
   margin: 0;
+}
+
+.vf-global-header__link {
+  @include inline-link(
+    $vf-link--color: $vf-global-header__link-text--color,
+    $vf-link--hover-color: $vf-global-header-text--color
+  );
+
+  text-decoration: none;
 }
 
 .vf-global-header {

--- a/components/vf-global-header/vf-global-header.variables.scss
+++ b/components/vf-global-header/vf-global-header.variables.scss
@@ -1,0 +1,3 @@
+$vf-global-header-background--color: set-ui-color(vf-ui-color--white);
+$vf-global-header-text--color: set-color(vf-color--grey--dark);
+$vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);

--- a/components/vf-logo/vf-logo--responsive.njk
+++ b/components/vf-logo/vf-logo--responsive.njk
@@ -1,3 +1,4 @@
+{% spaceless %}
 <a href="{{href}}"
 {# You're using an ID? Really?? That'll go here #}
 {% if id %} id="{{-id-}}"{% endif %}
@@ -5,3 +6,4 @@ class="vf-logo--responsive
 {%- if override_class %} | {{override_class}}{% endif -%}">
   <span class="vf-sr-only">{{sreen_reader_text}}</span>
 </a>
+{% endspaceless %}

--- a/components/vf-logo/vf-logo.config.yml
+++ b/components/vf-logo/vf-logo.config.yml
@@ -3,6 +3,6 @@ label: Logo
 
 context:
   component-type: element
-  href: http://www.embl.de
+  href: JavaScript:Void(0);
   sreen_reader_text: Visual Framework 2.0
   image: '/assets/vf-logo/assets/logo.png'

--- a/components/vf-logo/vf-logo.scss
+++ b/components/vf-logo/vf-logo.scss
@@ -7,14 +7,13 @@
   text-decoration: none;
 }
 
-
 .vf-logo--responsive {
   background-image: url('../assets/vf-logo/assets/logo-small.svg');
   background-repeat: no-repeat;
   background-size: auto 100%;
   display: flex;
   height: 25px;
-  min-width: 70px;
+  min-width: 50px;
 }
 
 @media (min-width: 500px) {

--- a/components/vf-navigation/vf-navigation.njk
+++ b/components/vf-navigation/vf-navigation.njk
@@ -1,3 +1,4 @@
+{% spaceless %}
 <nav class="vf-navigation {%- if classModifier %} vf-navigation--{{ classModifier }}{% endif %}">
   {% if heading %}
   <h3 class="vf-navigation__heading">{{ heading }}</h3>
@@ -10,3 +11,4 @@
     {% endfor %}
   </ul>
 </nav>
+{% endspaceless %}


### PR DESCRIPTION
This allows the `vf-global-header` site title to be a link.

Currently if using `vf-link`:

![image](https://user-images.githubusercontent.com/928100/61401120-07dc7e00-a8d2-11e9-92c3-70b003b8405c.png)

With PR:

![image](https://user-images.githubusercontent.com/928100/61401131-0e6af580-a8d2-11e9-99a7-daa1caf36acb.png)

Notes/other things that were bubbling up in vf-global-header:

- Utilises the otherwise unused `$vf-global-header__link-text--color` 
- Logo width was still set for EMBL logo
- Adds `spaceless` to remove some extra whitespace that was in the header

