### PR TITLE
CHORE - tweaks for vf-component-rollup docs, integration

### DIFF
--- a/components/vf-componenet-rollup/README.md
+++ b/components/vf-componenet-rollup/README.md
@@ -14,10 +14,6 @@ $ yarn add --dev @visual-framework/vf-componenet-rollup
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
-
-```
-@import "@visual-framework/vf-componenet-rollup/index.scss";
-```
+Unlike other components, you probably won't want to `@import` this. Instead the `vf-core` project will compile this into a style.css and scripts.js.
 
 _Make sure you import any requirements along with the modules._

--- a/components/vf-componenet-rollup/README.md
+++ b/components/vf-componenet-rollup/README.md
@@ -6,7 +6,15 @@ The `vf-componenet-rollup` compiles component Sass and JS into style.css and scr
 
 ## Install
 
-This repository is distributed with [npm][npm]. After [installing npm][install-npm], you can install `vf-componenet-rollup` with this command.
+You'll likely want to configure this component to include or exclude Sass and JS files, we suggest cloning it to your local `./src/components`.
+
+Get an tarball of this component with:
+
+```
+yarn pack @visual-framework/vf-componenet-rollup
+```
+
+However for very generic VF projects, this component is also distributed with [npm][npm]. After [installing npm][install-npm], you can install `vf-componenet-rollup` with this command.
 
 ```
 $ yarn add --dev @visual-framework/vf-componenet-rollup

--- a/components/vf-componenet-rollup/README.md
+++ b/components/vf-componenet-rollup/README.md
@@ -1,4 +1,4 @@
-# vf-componenet-rollup Component
+# Componenet Rollup
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-componenet-rollup.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-componenet-rollup)
 

--- a/components/vf-componenet-rollup/vf-componenet-rollup.config.yml
+++ b/components/vf-componenet-rollup/vf-componenet-rollup.config.yml
@@ -1,0 +1,6 @@
+title: Visual Framework Componet Rollup
+label: Visual Framework Componet Rollup
+preview: '@preview--elements'
+status: beta
+context:
+  component-type: element

--- a/components/vf-componenet-rollup/vf-componenet-rollup.njk
+++ b/components/vf-componenet-rollup/vf-componenet-rollup.njk
@@ -1,0 +1,1 @@
+{# No template needed #}

--- a/components/vf-componenet-rollup/vf-componenet-rollup.njk
+++ b/components/vf-componenet-rollup/vf-componenet-rollup.njk
@@ -1,1 +1,2 @@
-{# No template needed #}
+<!-- The vf-component-rollup does not have an html output,
+     it is only used to collect css and js for a project. -->


### PR DESCRIPTION
A couple of minor edits to the rollup to make its use a bit clearer. Also add a `.yml` and `.njk` whose absence would make fractal brittle in some occasions.