### PR TITLE
ENHANCEMENT - vf-grid--reset

### DIFF
--- a/components/vf-utility-classes/vf-utility-classes.scss
+++ b/components/vf-utility-classes/vf-utility-classes.scss
@@ -32,6 +32,11 @@
   @include type-modifiers;
 }
 
+// Sometimes content needs to escape a grid container, for example full-width content inside of `.vf-body`
+.vf-u-grid--reset {
+  grid-column: 1 / -1;
+}
+
 .vf-u-display-none {
   display: none;
 }


### PR DESCRIPTION
Sometimes content needs to escape a grid container, for example full-width content inside of `.vf-body`.

This formalises an adhoc approach that was appearing in some places, like the component library when needing to show components like the global footer at full-screen width in the middel of the page, or on the groups sites with the local `.vfwp-column-reset`