### PR TITLE
the one where publications have a short summary component added

### DIFF
--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -114,6 +114,7 @@ html, button {
   @import 'vf-summary/vf-summary--article.scss';
   @import 'vf-summary/vf-summary--job.scss';
   @import 'vf-summary/vf-summary--profile.scss';
+  @import 'vf-summary/vf-summary--publication.scss';
   @import 'vf-summary/vf-summary--news.scss';
   @import 'vf-summary/vf-summary--has-image.scss';
 

--- a/components/vf-sass-utilities/vf-et-al.scss
+++ b/components/vf-sass-utilities/vf-et-al.scss
@@ -1,0 +1,11 @@
+.vf-et-al {
+  position: relative;
+
+  &::after {
+    color: inherit;
+    content: 'et al.';
+    font: inherit;
+    position: relative;
+    right: 0;
+  }
+}

--- a/components/vf-sass-utilities/vf-sass-utilities.scss
+++ b/components/vf-sass-utilities/vf-sass-utilities.scss
@@ -9,4 +9,5 @@
 
 @import 'vf-sass-utilities.variables.scss';
 
-@import 'vf-screen-reader.scss'
+@import 'vf-screen-reader.scss';
+@import 'vf-et-al.scss';

--- a/components/vf-summary/README.md
+++ b/components/vf-summary/README.md
@@ -2,6 +2,12 @@
 
 ## About
 
+### Publications Summary
+
+The `vf-summary--publication` can be nested inside a vf-box where it takes the vf-box colours.
+
+If the `vf-summary__author` list is truncated to a certain number of authors you will need to add vf-et-al to the `<p>` - `<p class="vf-summary__author | vf-et-al">` - for it to add et al to the end of the list.
+
 ## Installation and Implementation
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-summary` with this command.

--- a/components/vf-summary/vf-summary--profile.scss
+++ b/components/vf-summary/vf-summary--profile.scss
@@ -57,7 +57,7 @@
   }
 }
 
-.vf-sumary--mobile {
+.vf-summary--mobile {
   position: relative;
 
   &::after {

--- a/components/vf-summary/vf-summary--publication.njk
+++ b/components/vf-summary/vf-summary--publication.njk
@@ -1,0 +1,20 @@
+<article class="vf-summary vf-summary--publication">
+  <h3 class="vf-summary__title">
+    <a href="#" class="vf-summary__link">
+      Computer modeling in developmental biology: growing today, essential tomorrow.
+    </a>
+  </h3>
+  <p class="vf-summary__author">
+    Jimenez RC, Albar JP, Bhak J, Blatter MC, Blicher T, Brazas MD, Brooksbank C, Budd A, De Las Rivas J, Dreyer J, van Driel MA, Dunn MJ, Fernandes PL, van Gelder CW, Hermjakob H, Ioannidis V, Judge DP, Kahlem P, Korpelainen E, Kraus HJ, Loveland J, Mayer C, McDowall J, Moran F, Mulder N, Nyronen T, Rother K, Salazar GA, Schneider R, Via A, Villaveces JM, Yu P, Schneider MV, Attwood TK, Corpas M.
+  </p>
+  <p class="vf-summary__source">
+    The Journal of cell biology
+    <span class="vf-summary__date">2019</span>
+  </p>
+
+  <p class="vf-summary__text">
+    144(23):4214-4225. doi: 10.1242/dev.151274.
+    <a class="vf-link" href="#">Europe</a>
+    <a class="vf-link" href="#">PMC</a>
+  </p>
+</article>

--- a/components/vf-summary/vf-summary--publication.scss
+++ b/components/vf-summary/vf-summary--publication.scss
@@ -15,7 +15,8 @@ $vf-summary__publication-color--text: vf-color--grey;
     .vf-summary__date {
       margin-left: 4px;
       position: relative;
-      &::before, &::after {
+      &::before,
+      &::after {
         position: absolute;
       }
       &::before {
@@ -34,16 +35,16 @@ $vf-summary__publication-color--text: vf-color--grey;
 
     color: set-color($vf-summary__publication-color--text);
     margin-bottom: 0;
+  }
 
-    .vf-link {
-      @media (max-width: $vf-breakpoint--r - 1px) {
-        &:first-child {
-          display: block;
-        }
+  .vf-summary__text .vf-link {
+    @media (max-width: $vf-breakpoint--r - 1px) {
+      &:first-child {
+        display: block;
       }
-      @media (min-width: $vf-breakpoint--r) {
-        margin-left: 8px;
-      }
+    }
+    @media (min-width: $vf-breakpoint--r) {
+      margin-left: 8px;
     }
   }
 
@@ -61,6 +62,6 @@ $vf-summary__publication-color--text: vf-color--grey;
 
   // vf-summary--publication inside of a vf-box will have more than one item in the vf-box, so we need to add some vertical spacing for more than one publication item in a box
   .vf-box &:not(:first-of-type) {
-      margin-bottom: 12px;
+    margin-bottom: 12px;
   }
 }

--- a/components/vf-summary/vf-summary--publication.scss
+++ b/components/vf-summary/vf-summary--publication.scss
@@ -1,0 +1,66 @@
+// vf-summary__publication variables
+$vf-summary__publication__text-typography: body--s;
+$vf-summary__publication-color--text: vf-color--grey;
+
+.vf-summary--publication {
+  margin-bottom: 48px;
+
+  .vf-summary__author {
+    margin--bottom: 0px; // need to look at typographic margins again
+  }
+
+  .vf-summary__source {
+    margin-bottom: 8px;
+
+    .vf-summary__date {
+      margin-left: 4px;
+      position: relative;
+      &::before, &::after {
+        position: absolute;
+      }
+      &::before {
+        content: '(';
+        left: -4px;
+      }
+      &::after {
+        content: ')';
+      }
+    }
+  }
+
+
+  .vf-summary__text {
+    @include set-type($vf-summary__publication__text-typography);
+
+    color: set-color($vf-summary__publication-color--text);
+    margin-bottom: 0;
+
+    .vf-link {
+      @media (max-width: $vf-breakpoint--r - 1px) {
+        &:first-child {
+          display: block;
+        }
+      }
+      @media (min-width: $vf-breakpoint--r) {
+        margin-left: 8px;
+      }
+    }
+  }
+
+  // vf-summary--publication can also sit inside a vf-box - so we need to adjust some sizes
+  .vf-box & {
+
+    .vf-summary__title {
+      font-size: 16px;
+      margin-bottom: 4px;
+    }
+    .vf-summary__author {
+      margin-bottom: 4px;
+    }
+  }
+
+  // vf-summary--publication inside of a vf-box will have more than one item in the vf-box, so we need to add some vertical spacing for more than one publication item in a box
+  .vf-box &:not(:first-of-type) {
+      margin-bottom: 12px;
+  }
+}

--- a/components/vf-summary/vf-summary.scss
+++ b/components/vf-summary/vf-summary.scss
@@ -12,6 +12,30 @@
     margin-bottom: 0;
   }
 
+  // vf-summary can also sit inside a vf-box - so we need to adjust some things to match
+  .vf-box & {
+    .vf-summary__title {
+      color: inherit;
+    }
+    .vf-summary__link {
+      color: inherit;
+    }
+    .vf-summary__date {
+      color: inherit;
+    }
+    .vf-summary__text {
+      color: inherit;
+    }
+    .vf-summary__source {
+      color: inherit;
+    }
+    .vf-summary__author {
+      color: inherit;
+    }
+    .vf-link {
+      color: inherit;
+    }
+  }
 }
 
 .vf-summary__button {
@@ -38,6 +62,13 @@
   color: set-color($vf-summary__date-color--text);
 }
 
+.vf-summary__source {
+  @include set-type($vf-summary__date-typography);
+
+  color: set-color($vf-summary__date-color--text);
+  font-style: italic;
+}
+
 .vf-summary__link {
   @include inline-link();
 
@@ -62,4 +93,11 @@
 
 .vf-summary__title {
   @include set-type($vf-summary__title-typography);
+}
+
+.vf-summary__author {
+  @include set-type($vf-summary__author-typography);
+
+  color: set-color($vf-summary__author-color--text);
+  font-style: italic;
 }

--- a/components/vf-summary/vf-summary.variables.scss
+++ b/components/vf-summary/vf-summary.variables.scss
@@ -22,6 +22,10 @@ $vf-summary__meta-typography: body--s;
 $vf-summary__date-typography: body--s;
 $vf-summary__date-color--text: vf-color--grey;
 
+// vf-summary__author variables
+$vf-summary__author-typography: body--s;
+$vf-summary__author-color--text: vf-color--grey;
+
 // vf-summary__category variables
 $vf-summary__category-typography: body--s;
 $vf-summary__category-color--text: vf-color--grey;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -171,7 +171,6 @@ gulp.task('vf-css', function(done) {
             return 'Problem at file: ' + error.message;
           })
         )
-        .pipe(autoprefixer(autoprefixerOptions))
         .pipe(browserSync.stream())
         .pipe(sourcemaps.write())
         .pipe(rename(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -171,6 +171,7 @@ gulp.task('vf-css', function(done) {
             return 'Problem at file: ' + error.message;
           })
         )
+        .pipe(autoprefixer(autoprefixerOptions))
         .pipe(browserSync.stream())
         .pipe(sourcemaps.write())
         .pipe(rename(


### PR DESCRIPTION
This adds the `vf-summary--publication` component as well as a new helper class of `vf-et-al`.

The `vf-summary--publication` can be nested inside a `vf-box` where it takes the `vf-box` colours.

If the `vf-summary__author` list is truncated to a certain number of authors you will need to add `vf-et-al` to the `<p>` - `<p class="vf-summary__author | vf-et-al` - for it to add *et al* to the end of the list.

This _should_ cover all three use cases for publication summaries that are [here](https://gitlab.ebi.ac.uk/emblorg/backlog/issues/225). [here](https://gitlab.ebi.ac.uk/emblorg/backlog/issues/226), and [here](https://gitlab.ebi.ac.uk/emblorg/backlog/issues/227)