### PR TITLE
the one that fixes misspellings we haven't caught yet

### DIFF
--- a/components/vf-badge/vf-badge.scss
+++ b/components/vf-badge/vf-badge.scss
@@ -34,7 +34,7 @@ $vf-badge--tertiary-color--text: set-ui-color(vf-ui-color--white) !default;
 }
 
 .vf-badge--pill {
-  border-radius: vf-radius--pill;
+  border-radius: $vf-radius--pill;
 }
 
 .vf-badge--rounded {

--- a/components/vf-breadcrumbs/vf-breadcrumbs.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.scss
@@ -14,8 +14,8 @@
     display: flex;
   }
 }
-@media (max-wdith: $vf-breakpoint--lg - 1) {
-  .vf-breadcrumbs__list:not(.vf-breadcrumbs__list.vr-breadcrumbs__list--related) {
+@media (max-width: $vf-breakpoint--lg - 1) {
+  .vf-breadcrumbs__list:not(.vf-breadcrumbs__list--related) {
     display: block;
   }
 }

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -8,7 +8,7 @@
 
   display: grid;
   grid-template-rows: 216px repeat(6, 36px);
-  padding: 0 -16px;
+  padding: 0;
   transition: all .1s linear;
 
   &:hover {

--- a/components/vf-discussion/vf-discussion.scss
+++ b/components/vf-discussion/vf-discussion.scss
@@ -27,7 +27,7 @@
 
 
 .vf-discussion__author {
-  @include set-type(text-heading--5, $custom-margin-bottom: 14);
+  @include set-type(text-heading--5, $custom-margin-bottom: 14px);
 
   font-style: normal;
 }

--- a/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
+++ b/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
@@ -20,7 +20,6 @@
     margin-right: 10px;
     position: relative;
     top: 6px;
-    vertical-align: center;
     width: 16px;
   }
 

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -21,7 +21,7 @@
 }
 
 .vf-form__wrap .vf-form__label {
-  border-radius-top-left: 3px;
+  border-top-left-radius: 3px;
   display: block;
   line-height: 1;
   opacity: 0;
@@ -33,7 +33,6 @@
 }
 
 .vf-form__input .vf-form__wrap {
-  -moz-osx-font-smoothing: greyscale;
   -webkit-font-smoothing: antialiased;
   position: relative;
   text-rendering: optimizeLegibility;
@@ -91,7 +90,7 @@
 }
 
 .vf-form__wrap .vf-form__input label.vf-form__label {
-  border-radius-top-left: 3px;
+  border-top-left-radius: 3px;
   color: set-color(vf-color--grey--dark);
   display: block;
   left: 26px;

--- a/components/vf-form/vf-form__radio/vf-form__radio.scss
+++ b/components/vf-form/vf-form__radio/vf-form__radio.scss
@@ -22,7 +22,6 @@
     margin-right: 10px;
     position: relative;
     top: 6px;
-    vertical-align: center;
     width: 16px;
   }
 

--- a/components/vf-link/vf-link--disabled.scss
+++ b/components/vf-link/vf-link--disabled.scss
@@ -1,3 +1,3 @@
 .vf-link--disabled {
-  @include vf-disabled(vf-link--disabled-color);
+  @include vf-disabled($vf-link--disabled-color);
 }

--- a/components/vf-summary/vf-summary--publication.scss
+++ b/components/vf-summary/vf-summary--publication.scss
@@ -6,7 +6,7 @@ $vf-summary__publication-color--text: vf-color--grey;
   margin-bottom: 48px;
 
   .vf-summary__author {
-    margin--bottom: 0px; // need to look at typographic margins again
+    margin-bottom: 0px; // need to look at typographic margins again
   }
 
   .vf-summary__source {
@@ -31,19 +31,19 @@ $vf-summary__publication-color--text: vf-color--grey;
 
 
   .vf-summary__text {
-    @include set-type($vf-summary__publication__text-typography);
+    // @include set-type(body--5);
 
     color: set-color($vf-summary__publication-color--text);
     margin-bottom: 0;
   }
 
   .vf-summary__text .vf-link {
-    @media (max-width: $vf-breakpoint--r - 1px) {
+    @media (max-width: $vf-breakpoint--md - 1px) {
       &:first-child {
         display: block;
       }
     }
-    @media (min-width: $vf-breakpoint--r) {
+    @media (min-width: $vf-breakpoint--md) {
       margin-left: 8px;
     }
   }

--- a/components/vf-summary/vf-summary.variables.scss
+++ b/components/vf-summary/vf-summary.variables.scss
@@ -23,7 +23,7 @@ $vf-summary__date-typography: text-body--5;
 $vf-summary__date-color--text: vf-color--grey;
 
 // vf-summary__author variables
-$vf-summary__author-typography: body--s;
+$vf-summary__author-typography: text-body--5;
 $vf-summary__author-color--text: vf-color--grey;
 
 // vf-summary__category variables
@@ -59,3 +59,7 @@ $vf-summary--article__date-margin-right: .75rem;
 $vf-summary--news__category-margin-right: 1rem;
 
 $vf-summary--has-image-width: 50px;
+
+
+$vf-summary__publication__text-typography: text-body--5;
+$vf-summary__publication-color--text: vf-color--grey;


### PR DESCRIPTION
Whilst working on #497 I noticed several CSS errors in Firefox's console.

This PR rectify's them.

- missing `$` in variables
- declarations that don't work in the ruleset because of the other declarations
- other misspellings