### PR TITLE
BUG - vf-footer visited link colour

### DIFF
--- a/components/vf-footer/vf-footer.njk
+++ b/components/vf-footer/vf-footer.njk
@@ -6,13 +6,13 @@
         <h4 class="vf-links__heading">Category</h4>
         <ul class="vf-links__list | vf-list">
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Entry</a>
+            <a class="vf-list__link" href="#aLink">A link</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Entry</a>
+            <a class="vf-list__link" href="#anotherLink">Another link</a>
           </li>
           <li class="vf-list__item">
-            <a class="vf-list__link" href="#">Entry</a>
+            <a class="vf-list__link" href="#thirdLink">Third link</a>
           </li>
         </ul>
       </div>

--- a/components/vf-footer/vf-footer.scss
+++ b/components/vf-footer/vf-footer.scss
@@ -37,9 +37,9 @@
 
 .vf-footer__link {
   @include inline-link(
-    $vf-link--color: set-ui-color(vf-ui-color--white),
-    $vf-link--hover-color: set-color(vf-color--grey--lightest),
-    $vf-link--visited-color: $vf-link--visited-color
+    $vf-link--color: $vf-footer-link--color,
+    $vf-link--hover-color: $vf-footer-link--hover-color,
+    $vf-link--visited-color: $vf-footer-link--visited-color
   );
 }
 
@@ -72,17 +72,17 @@
 
 .vf-footer .vf-links__link {
   @include inline-link(
-    $vf-link--color: set-ui-color(vf-ui-color--white),
-    $vf-link--hover-color: set-color(vf-color--grey--lightest),
-    $vf-link--visited-color: $vf-link--visited-color
+    $vf-link--color: $vf-footer-link--color,
+    $vf-link--hover-color: $vf-footer-link--hover-color,
+    $vf-link--visited-color: $vf-footer-link--visited-color
   );
 }
 
 .vf-footer .vf-list__link {
   @include inline-link(
-    $vf-link--color: set-ui-color(vf-ui-color--white),
-    $vf-link--hover-color: set-color(vf-color--grey--lightest),
-    $vf-link--visited-color: $vf-link--visited-color
+    $vf-link--color: $vf-footer-link--color,
+    $vf-link--hover-color: $vf-footer-link--hover-color,
+    $vf-link--visited-color: $vf-footer-link--visited-color
   );
   margin-right: 24px;
 }

--- a/components/vf-footer/vf-footer.variables.scss
+++ b/components/vf-footer/vf-footer.variables.scss
@@ -5,3 +5,7 @@
 // ------------------------------------------------------------
 // Default component variables
 // ------------------------------------------------------------
+
+$vf-footer-link--color: set-ui-color(vf-ui-color--white);
+$vf-footer-link--hover-color: set-color(vf-color--grey--lightest);
+$vf-footer-link--visited-color: set-color(vf-color--grey--lightest);


### PR DESCRIPTION
Passed colour was nearly the same as the background, also adds component variables.

Currently:

![image](https://user-images.githubusercontent.com/928100/61861952-47f0c180-aecd-11e9-8ae0-10751d7148b7.png)

With fix:

(non-visited on left) 

![image](https://user-images.githubusercontent.com/928100/61862058-7f5f6e00-aecd-11e9-9c2d-300bbe38aad1.png)
