### PR TITLE
the one where we put autoprefixer and cssnano into the build task

### DIFF
--- a/tools/gulp-tasks/_gulp_rollup.js
+++ b/tools/gulp-tasks/_gulp_rollup.js
@@ -31,8 +31,13 @@ module.exports = function(gulp, path, componentPath, buildDestionation) {
   ));
 
   // Build as a static site for CI
-  gulp.task('vf-build', gulp.series(
-    'vf-clean', 'vf-css-gen', 'vf-css', 'vf-component-assets', 'vf-scripts', 'vf-fractal:build'
+  gulp.task('vf-build',
+
+    gulp.series(
+      'vf-clean',
+      gulp.parallel ('vf-css-gen',
+        gulp.series('vf-css', 'vf-css-build', 'vf-component-assets', 'vf-scripts'),
+      'vf-fractal:build')
   ));
 
   gulp.task('vf-prepush-test', gulp.parallel(

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -142,8 +142,8 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
   });
 
   // Sass Build-Time things
+  // Take the built styles.css and autoprefixer it, then runs cssnano and saves it with a .min.css suffix
   gulp.task('vf-css-build', function(done) {
-    // const SassOutput = SassOutput + 'styles.css';
     return gulp
       .src(SassOutput + '/styles.css')
       .pipe(autoprefixer(autoprefixerOptions))

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -120,7 +120,6 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
             })
           )
           // .pipe(autoprefixer(autoprefixerOptions))
-          .pipe(envs.reset)
           .pipe(browserSync.stream())
           .pipe(sourcemaps.write())
           .pipe(rename(

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -119,7 +119,8 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
               return 'Problem at file: ' + error.message;
             })
           )
-          .pipe(autoprefixer(autoprefixerOptions))
+          // .pipe(autoprefixer(autoprefixerOptions))
+          .pipe(envs.reset)
           .pipe(browserSync.stream())
           .pipe(sourcemaps.write())
           .pipe(rename(
@@ -128,18 +129,36 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
             }
           ))
           .pipe(gulp.dest(SassOutput))
-          .pipe(cssnano())
-          .pipe(rename(
-            {
-              suffix: '.min'
-            }
-          ))
-          .pipe(gulp.dest(SassOutput))
+          // .pipe(cssnano())
+          // .pipe(rename(
+          //   {
+          //     suffix: '.min'
+          //   }
+          // ))
+          // .pipe(gulp.dest(SassOutput))
           .on('end', function() {
             done();
           });
       }
+  });
 
+  // Sass Build-Time things
+  gulp.task('vf-css-build', function(done) {
+    // const SassOutput = SassOutput + 'styles.css';
+    return gulp
+      .src(SassOutput + '/styles.css')
+      .pipe(autoprefixer(autoprefixerOptions))
+      .pipe(gulp.dest(SassOutput))
+      .pipe(cssnano())
+      .pipe(rename(
+        {
+          suffix: '.min'
+        }
+      ))
+      .pipe(gulp.dest(SassOutput))
+      .on('end', function() {
+        done();
+      });
   });
 
   // Sass Lint


### PR DESCRIPTION
This should complete #483.

Rather than get bogged down in working with Node Environments and as what we're wanting to do can be done after Sass has compiled, I have created a new task `vf-css-build` which takes the `styles.css` file, runs `autoprefixer` and then saves it, then runs `cssnano` and saves it with a `.min.css` suffix. 

This seems to have cut down `vf-css` for me by quite some margin (for my crawling 2016 MacBook).

I've also adapted `vf-build` so that we make use of `gulp.parallel` so certain tasks can go off and 'do their thing' alongside others which should speed the processes up a little bit. 