### PR TITLE
the one where we tokenise the z-index

### DIFF
--- a/components/vf-banner/vf-banner--fixed.scss
+++ b/components/vf-banner/vf-banner--fixed.scss
@@ -7,5 +7,5 @@
   padding: 0;
   position: fixed;
   width: 100%;
-  z-index: 5150;
+  z-index: set-layer(vf-z-index--banner);
 }

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -20,7 +20,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 5150;
+  z-index: set-layer(vf-z-index--banner);
 }
 
 .vf-banner__content {

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -36,7 +36,6 @@ a.vf-card {
 
   .vf-card__content {
     grid-row: 2 / -1;
-    z-index: 101;
   }
 
   &:hover {

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -22,6 +22,7 @@
 @import 'vf-font-families.variables.scss';
 @import 'vf-links.variables.scss';
 @import 'vf-spacing.map.scss';
+@import 'vf-zindex.map.scss';
 
 @import 'vf-colors.custom-properties.scss';
 @import 'vf-ui-colors.custom-properties.scss';

--- a/components/vf-design-tokens/dist/json/vf-zindex.ios.json
+++ b/components/vf-design-tokens/dist/json/vf-zindex.ios.json
@@ -1,0 +1,34 @@
+{
+  "properties": [
+    {
+      "type": "number",
+      "category": "layer",
+      "name": "vfZIndexNegative",
+      "value": -1
+    },
+    {
+      "type": "number",
+      "category": "layer",
+      "name": "vfZIndexFormInput",
+      "value": 1
+    },
+    {
+      "type": "number",
+      "category": "layer",
+      "name": "vfZIndexFormLabel",
+      "value": 1
+    },
+    {
+      "type": "number",
+      "category": "layer",
+      "name": "vfZIndexBanner",
+      "value": 5150
+    },
+    {
+      "type": "number",
+      "category": "layer",
+      "name": "vfZIndexMasthead",
+      "value": 5150
+    }
+  ]
+}

--- a/components/vf-design-tokens/dist/sass/custom-properties/vf-zindex.custom-properties.scss
+++ b/components/vf-design-tokens/dist/sass/custom-properties/vf-zindex.custom-properties.scss
@@ -1,0 +1,12 @@
+// This file has been dynamically generated from design tokens
+// Please do NOT edit directly.
+
+// Source: maps/vf-zindex.yml
+
+:root {
+  --vf-z-index--negative: -1;
+  --vf-z-index--form-input: 1;
+  --vf-z-index--form-label: 1;
+  --vf-z-index--banner: 5150;
+  --vf-z-index--masthead: 5150;
+}

--- a/components/vf-design-tokens/dist/sass/maps/vf-zindex.map.scss
+++ b/components/vf-design-tokens/dist/sass/maps/vf-zindex.map.scss
@@ -1,0 +1,12 @@
+// This file has been dynamically generated from design tokens
+// Please do NOT edit directly.
+
+// Source: maps/vf-zindex.yml
+
+$vf-zindex-map: (
+  'vf-z-index--negative': (-1),
+  'vf-z-index--form-input': (1),
+  'vf-z-index--form-label': (1),
+  'vf-z-index--banner': (5150),
+  'vf-z-index--masthead': (5150),
+);

--- a/components/vf-design-tokens/src/maps/vf-zindex.yml
+++ b/components/vf-design-tokens/src/maps/vf-zindex.yml
@@ -1,0 +1,14 @@
+props:
+  - name: vf-z-index--negative
+    value: -1
+  - name: vf-z-index--form-input
+    value: 1
+  - name: vf-z-index--form-label
+    value: 1
+  - name: vf-z-index--banner
+    value: 5150
+  - name: vf-z-index--masthead
+    value: 5150
+global:
+  type: number
+  category: layer

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -29,7 +29,7 @@
   top: -16px;
   transition: all .2s ease-in-out;
   visibility: hidden;
-  z-index: 1;
+  z-index: set-layer(vf-z-index--form-label);
 }
 .vf-form__input {
   position: relative;
@@ -102,7 +102,7 @@
   top: -24px;
   transition: all .2s ease-in-out;
   visibility: hidden;
-  z-index: 1;
+  z-index: set-layer(vf-z-index--form-label);
 }
 
 .vf-form__input .vf-form__is-active .vf-form__label {
@@ -126,7 +126,7 @@
   right: 15px;
   top: 1px;
   transition: all .2s ease-in-out;
-  z-index: 1;
+  z-index: set-layer(vf-z-index--form-input);
 }
 
 .vf-form__input .vf-form__is-required.vf-form__is-active::before {

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -30,8 +30,6 @@ $vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
   align-self: unset;
   display: inline-flex;
   flex-direction: column-reverse;
-  // margin: 0 auto;
-  z-index: 2;
 }
 
 
@@ -62,7 +60,7 @@ $vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
 
   color: inherit;
   text-decoration: none;
-  z-index: 5150;
+  z-index: set-layer(vf-z-index--masthead);
 }
 
 .vf-masthead__subheading {
@@ -75,7 +73,7 @@ $vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
 .vf-masthead__subheading a {
   color: inherit;
   text-decoration: none;
-  z-index: 5150;
+  z-index: set-layer(vf-z-index--masthead);
 }
 
 
@@ -102,7 +100,7 @@ $vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
     }
   }
   .vf-masthead__subheading {
-    z-index: 5150;
+    z-index: set-layer(vf-z-index--masthead);
   }
 }
 
@@ -113,7 +111,7 @@ $vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
   margin-bottom: 12px;
   margin-left: auto;
   max-width: 288px;
-  z-index: 5150;
+  z-index: set-layer(vf-z-index--masthead);
 }
 
 .vf-masthead__form__item {

--- a/components/vf-navigation/vf-navigation--additional.scss
+++ b/components/vf-navigation/vf-navigation--additional.scss
@@ -24,7 +24,7 @@
     right: 50%;
     top: 0;
     width: 100vw;
-    z-index: -1;
+    z-index: set-layer(vf-z-index--negative);
   }
 
   .vf-navigation__heading {

--- a/components/vf-navigation/vf-navigation--main.scss
+++ b/components/vf-navigation/vf-navigation--main.scss
@@ -15,7 +15,7 @@
     position: absolute;
     right: 50%;
     width: 100vw;
-    z-index: -1;
+    z-index: set-layer(vf-z-index--negative);
   }
 
   .vf-navigation__list {

--- a/components/vf-sass-config/functions/set-layer.scss
+++ b/components/vf-sass-config/functions/set-layer.scss
@@ -1,0 +1,3 @@
+@function set-layer($layer) {
+  @return map-get($vf-zindex-map, $layer);
+}

--- a/components/vf-sass-config/functions/vf-functions.scss
+++ b/components/vf-sass-config/functions/vf-functions.scss
@@ -1,3 +1,4 @@
 @import 'map-deep-get';
 @import 'string-replace';
 @import 'set-color';
+@import 'set-layer';

--- a/components/vf-sass-config/mixins/_utility--slide.scss
+++ b/components/vf-sass-config/mixins/_utility--slide.scss
@@ -27,7 +27,7 @@
       position: absolute;
       width: 101%;
 
-      z-index: -1;
+      z-index: set-layer(vf-z-index--negative);
 
       @if $direction == 'up' {
         bottom: -#{$shift-distance};

--- a/components/vf-sass-config/variables/vf-variables.scss
+++ b/components/vf-sass-config/variables/vf-variables.scss
@@ -9,6 +9,7 @@
 @import 'vf-font-families.variables.scss';
 @import 'vf-links.variables.scss';
 @import 'vf-spacing.map.scss';
+@import 'vf-zindex.map.scss';
 
 @import 'vf-colors.custom-properties.scss';
 @import 'vf-ui-colors.custom-properties.scss';

--- a/components/vf-summary/vf-summary--profile.scss
+++ b/components/vf-summary/vf-summary--profile.scss
@@ -42,8 +42,6 @@
   --vf-text-margin--bottom: 24px;
 
   @include set-type($vf-summary__body-typography);
-
-  z-index: $vf-summary__link--z-index;
 }
 
 

--- a/components/vf-summary/vf-summary.scss
+++ b/components/vf-summary/vf-summary.scss
@@ -71,8 +71,6 @@
 
 .vf-summary__link {
   @include inline-link();
-
-  z-index: $vf-summary__link--z-index;
 }
 
 .vf-summary__link--overlay {

--- a/components/vf-summary/vf-summary.variables.scss
+++ b/components/vf-summary/vf-summary.variables.scss
@@ -33,8 +33,6 @@ $vf-summary__category-color--text: vf-color--grey;
 // vf-summary__button variables
 $vf-summary__button-typography: text-button--1;
 
-$vf-summary__link--z-index: 5150;
-
 
 // ------------------------------------------------------------
 // vf-summary css custom properties


### PR DESCRIPTION
this PR addresses most of the things in #19:

- creates a new design token file and Sass map for `z-index`
- creates a `set-layer` Sass function 
- replaces hardcoded `z-index` in component Sass files with the `set-layer` function
- removes unneeded `z-index` declarations that were not doing anything. 