### PR TITLE
BUG - vf-build asset copy task misses js

### DIFF
--- a/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
@@ -187,7 +187,7 @@ function emblContentHubFetch() {
     var dateRemainingList = document.querySelector('.'+emblContentHubGenerateID(position)).querySelectorAll('.date-days-remaining');
     var todayDate = new Date();
     if (dateRemainingList.length > 0) {
-      for (dateRemainingIndex = 0; dateRemainingIndex < dateRemainingList.length; dateRemainingIndex++) {
+      for (let dateRemainingIndex = 0; dateRemainingIndex < dateRemainingList.length; dateRemainingIndex++) {
         var dateValue = parseInt(dateRemainingList[dateRemainingIndex].getAttribute('data-datetime')) * 1000;
         dateValue = new Date(dateValue);
         var numberOfDiffDays = days_between(dateValue, todayDate);

--- a/tools/gulp-tasks/_gulp_rollup.js
+++ b/tools/gulp-tasks/_gulp_rollup.js
@@ -21,6 +21,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation) {
   require(path.resolve('.', __dirname + '/vf-scripts.js'))(gulp, path, componentPath, buildDestionation);
   require(path.resolve('.', __dirname + '/vf-fractal.js'))(gulp, path, componentPath, buildDestionation);
   require(path.resolve('.', __dirname + '/vf-watch.js'))(gulp, path, componentPath, reload);
+  require(path.resolve('.', __dirname + '/vf-build.js'))(gulp, buildDestionation);
 
   // -----------------------------------------------------------------------------
   // Main tasks
@@ -28,16 +29,6 @@ module.exports = function(gulp, path, componentPath, buildDestionation) {
 
   gulp.task('vf-dev', gulp.series(
     'vf-clean', 'vf-component-assets', ['vf-css', 'vf-scripts'], 'vf-fractal:start', ['vf-lint:scss-soft-fail', 'vf-watch']
-  ));
-
-  // Build as a static site for CI
-  gulp.task('vf-build',
-
-    gulp.series(
-      'vf-clean',
-      gulp.parallel ('vf-css-gen',
-        gulp.series('vf-css', 'vf-css-build', 'vf-component-assets', 'vf-scripts'),
-      'vf-fractal:build')
   ));
 
   gulp.task('vf-prepush-test', gulp.parallel(

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Build tasks to generate a deployable static site,
+ * most frequent use case will be for CI deployments.
+ */
+
+module.exports = function(gulp, buildDestionation) {
+
+  // Copy compiled css/js and other assets
+  gulp.task('vf-build:copy-assets', function() {
+    return gulp.src(buildDestionation + '/**/*')
+      .pipe(gulp.dest('./build'));
+      console.info('Copied `/temp/build-files` assets.');
+  });
+
+  // Rollup all-in-one build as a static site for CI
+  gulp.task('vf-build',
+    gulp.series(
+      'vf-clean',
+      gulp.parallel (
+        'vf-css-gen',
+        gulp.series('vf-css', 'vf-css-build', 'vf-component-assets', 'vf-scripts'),
+        'vf-fractal:build'
+      ),
+      'vf-build:copy-assets'
+  ));
+
+
+  return gulp;
+};

--- a/tools/gulp-tasks/vf-fractal.js
+++ b/tools/gulp-tasks/vf-fractal.js
@@ -18,11 +18,6 @@ module.exports = function(gulp, path, componentPath, buildDestionation) {
   gulp.task('vf-fractal:build', function(done) {
     const fractal = require(fractalConfig).initialize('build',fractalReadyCallback);
     function fractalReadyCallback() {
-      // Copy compiled css/js and other assets
-      gulp.src(buildDestionation + '/**/*')
-        .pipe(gulp.dest('./build'));
-        console.info('Copied `/temp/build-files` assets.');
-
       done();
     }
   });

--- a/tools/vf-frctl-theme/views/partials/foot.njk
+++ b/tools/vf-frctl-theme/views/partials/foot.njk
@@ -4,7 +4,7 @@
 {% if frctl.env.server %}
 <script src="{{ path('/scripts/scripts.js') }}?cachebust={{ frctl.theme.get('version') }}"></script>
 {% else %}
-<script src="https://dev.assets.emblstatic.net/vf/develop/scripts/scripts.js?cachebust={{ frctl.theme.get('version') }}"></script>
+<script src="https://dev.assets.emblstatic.net/vf/develop/scripts/scripts.js"></script>
 {% endif %}
 
 <script>

--- a/tools/vf-frctl-theme/views/partials/stylesheets.njk
+++ b/tools/vf-frctl-theme/views/partials/stylesheets.njk
@@ -1,7 +1,7 @@
 {% if frctl.env.server %}
 <link rel="stylesheet" href="{{ path('/css/styles.css') }}?cachebust={{ frctl.theme.get('version') }}" type="text/css">
 {% else %}
-<link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css?cachebust={{ frctl.theme.get('version') }}" type="text/css">
+<link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css" type="text/css">
 {% endif %}
 {% for stylesheet in frctl.theme.get('styles') %}
 <link rel="stylesheet" href="{{ path(stylesheet) }}?cachebust={{ frctl.theme.get('version') }}" type="text/css">


### PR DESCRIPTION
This resolves a bug that was exposed by #509, where `gulp vf-fractal:build` was responsible for asset copying. 

That was the wrong spot to do so — and in 509 the bug was exposed by using `parallel` for `vf-fractal:build`, it was resulting the JS assets being missed from deployment. 

Note that https://dev.assets.emblstatic.net/vf/develop/scripts/scripts.js is currently a 403 (missing and denied)