### PR TITLE
Bug: Handle optional js dependencies

### DIFF
--- a/components/embl-conditional-edit/embl-conditional-edit.js
+++ b/components/embl-conditional-edit/embl-conditional-edit.js
@@ -6,17 +6,17 @@
  * This will be dynamically run once emblContentHubSignalFinished is triggered.
  */
 function emblConditionalEdit() {
-  const emblConditionalEdit = document.querySelectorAll('[data-embl-js-conditional-edit]');
-  if (!emblConditionalEdit) {
+  const emblConditionalEditItems = document.querySelectorAll('[data-embl-js-conditional-edit]');
+  if (!emblConditionalEditItems) {
     // exit: lists not found
     return;
   }
-  if (emblConditionalEdit.length == 0) {
+  if (emblConditionalEditItems.length == 0) {
     // exit: lists not found
     return;
   }
 
-  Array.prototype.forEach.call(emblConditionalEdit, (element, i) => {
+  Array.prototype.forEach.call(emblConditionalEditItems, (element, i) => {
     emblConditionalEditDetectParam(location.href,element);
   });
 }

--- a/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
@@ -3,7 +3,7 @@
 
 import { vfBanner } from 'vf-banner/vf-banner';
 import { vfTabs } from 'vf-tabs/vf-tabs';
-
+import { emblConditionalEdit } from 'embl-conditional-edit/embl-conditional-edit';
 
 /**
  * Fetch html links from content.embl.org
@@ -94,6 +94,11 @@ function emblContentHubFetch() {
 
   // Show the remote content
   function emblContentHubGrabTheContent(targetLink,position,exportedContent) {
+
+    if (!exportedContent) {
+      console.log('No content found for this import, exiting. The import may have already been preformed.', targetLink);
+      return;
+    }
 
     // pickup the "meat" of the exported content
     exportedContent = exportedContent || targetLink.import.querySelector('.vf-content-hub-html');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chalk": "^2.4.2",
     "fast-glob": "^3.0.4",
     "gulp": "^4.0.2",
+    "gulp-delete-lines": "^0.0.7",
     "highlight.js": "^9.15.8",
     "install": "^0.12.2",
     "marked": "^0.6.1",

--- a/tools/gulp-tasks/vf-scripts.js
+++ b/tools/gulp-tasks/vf-scripts.js
@@ -10,6 +10,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation) {
   const rollup = require('gulp-better-rollup');
   const includePaths = require('rollup-plugin-includepaths');
   const babel = require('gulp-babel');
+  const deleteLines = require('gulp-delete-lines');
 
   // Rollup all JS imports into CJS and babel them to ES5
   gulp.task('vf-scripts:es5', function() {
@@ -49,6 +50,13 @@ module.exports = function(gulp, path, componentPath, buildDestionation) {
       }))
       // inlining the sourcemap into the exported .js file
       // .pipe(sourcemaps.write())
+      // When components are requested but no found, rollupJS leaves them as a node-style
+      // `require()`, this trims those
+      .pipe(deleteLines({
+         'filters': [
+         /require\('/i
+         ]
+       }))
       .pipe(gulp.dest(buildDestionation + '/scripts'));
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3657,6 +3657,19 @@ event-stream@~3.0.18:
     stream-combiner "~0.0.3"
     through "~2.3.1"
 
+event-stream@~3.1.0:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.1.7.tgz#b4c540012d0fe1498420f3d8946008db6393c37a"
+  integrity sha1-tMVAAS0P4UmEIPPYlGAI22OTw3o=
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.2"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
@@ -4787,6 +4800,14 @@ gulp-cssnano@^2.1.3:
     plugin-error "^1.0.1"
     vinyl-sourcemaps-apply "^0.2.1"
 
+gulp-delete-lines@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/gulp-delete-lines/-/gulp-delete-lines-0.0.7.tgz#512143429ce7ae7f2e0a8a309f7a0f61ea069555"
+  integrity sha1-USFDQpznrn8uCoown3oPYeoGlVU=
+  dependencies:
+    event-stream "~3.1.0"
+    gulp-util ">=2.2.0"
+
 gulp-notify@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/gulp-notify/-/gulp-notify-3.2.0.tgz#2ae8225009df881eef59be5dd5a2f1337387764e"
@@ -4920,7 +4941,7 @@ gulp-uglify@^3.0.2:
     uglify-js "^3.0.5"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-util@^3.0.3, gulp-util@^3.0.8:
+gulp-util@>=2.2.0, gulp-util@^3.0.3, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -6860,6 +6881,11 @@ map-obj@^2.0.0:
 map-stream@~0.0.3:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
+
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+  integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -10530,7 +10556,7 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
-stream-combiner@~0.0.3:
+stream-combiner@~0.0.3, stream-combiner@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
   dependencies:


### PR DESCRIPTION
Optional JS dependencies weren't working correctly. The `embl-conditional-edit` isn't required by `embl-content-hub-loader`, however by not including it as a `import`, it wasn't working. And if we did `import` it, it would break on sites when `embl-conditional-edit` wasn't included.

This solution works by:

1. We always list optional dependencies in parent JS as an `import`
2. If the JS isn't found, the gulp task strips out the compiled and failed `import` (which requireJS treats as non-browser compatible `require()`

This also sorts a minor variable name bug and check.