### PR TITLE
fixes incorrect set-type mixin declaration

### DIFF
--- a/components/vf-summary/vf-summary--publication.scss
+++ b/components/vf-summary/vf-summary--publication.scss
@@ -31,10 +31,10 @@ $vf-summary__publication-color--text: vf-color--grey;
 
 
   .vf-summary__text {
-    // @include set-type(body--5);
+    @include set-type(text-body--5);
 
     color: set-color($vf-summary__publication-color--text);
-    margin-bottom: 0;
+    margin-bottom: 0; // this also gets zeroed by vf-summary > *:last-child sometimes
   }
 
   .vf-summary__text .vf-link {


### PR DESCRIPTION
within 

```
.vf-summary--publication {
  .vf-summary__text {

  }
}
```

There was 
```
@include set-type(body--5);
``` 

where it needed to be 

```
@include set-type(text-body--5);
```

This fixes that one line.

Also added a note about the margin, again I think we need to look at margins … I'm thinking 'zeroing out' everything (per component) first and only adding to if it needs it -- in other words a reverse of our current margin setting and custom margin settings in the typography mixin etc.