### PR TITLE
Feature: verbose output of component version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ components/**/*.css
 backstop_data/html_report/
 bitmaps_test/
 temp
+package.variables.scss

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Deploy the pattern library to gh-pages
 language: node_js
 node_js:
-  - 11
+  - 10
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Deploy the pattern library to gh-pages
 language: node_js
 node_js:
-  - 10
+  - 11
 
 branches:
   except:

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -6,8 +6,8 @@
  * Include this style sheet as a quick way to get *everything*,
  * or follow the guide at github.com/visual-framework/vf-core
  * to learn how to build custom and optimised CSS.
- *
- * Component: #{map-get($componentInfo, 'name')}
+ */
+/*! Component: #{map-get($componentInfo, 'name')}
  * Version: #{map-get($componentInfo, 'version')}
  * Location: #{map-get($componentInfo, 'location')}
  * VF Core version in use: #{map-get($componentInfo, 'vfCoreVersion')}

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -1,3 +1,4 @@
+@import 'package.variables.scss';
 /*
  *
  * styles.css
@@ -6,6 +7,10 @@
  * or follow the guide at github.com/visual-framework/vf-core
  * to learn how to build custom and optimised CSS.
  *
+ * Component: #{map-get($componentInfo, 'name')}
+ * Version: #{map-get($componentInfo, 'version')}
+ * Location: #{map-get($componentInfo, 'location')}
+ * VF Core version in use: #{map-get($componentInfo, 'vfCoreVersion')}
  */
 
 @import 'vf-global-custom-properties.scss';
@@ -51,6 +56,7 @@ html, button {
  * We put this first so it will have the least specificity
  */
 @import 'vf-content/vf-content.scss';
+@import 'vf-test/vf-test.scss';
 
 /* All Visual Framework grids */
 

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -56,7 +56,6 @@ html, button {
  * We put this first so it will have the least specificity
  */
 @import 'vf-content/vf-content.scss';
-@import 'vf-test/vf-test.scss';
 
 /* All Visual Framework grids */
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,6 +34,7 @@ global.vfNamespace = config.vfConfig.vfNamespace || "vf-";
 global.vfComponentPath = config.vfConfig.vfComponentPath || path.resolve('.', __dirname + '/components');
 global.vfBuildDestination = config.vfConfig.vfBuildDestination || __dirname + '/temp/build-files';
 global.vfThemePath = config.vfConfig.vfThemePath || './tools/vf-frctl-theme';
+global.vfVersion = config.version || 'not-specified';
 const componentPath = path.resolve('.', global.vfComponentPath);
 const buildDestionation = path.resolve('.', global.vfBuildDestination);
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "stylelint": "^10.1.0",
     "stylelint-scss": "^3.8.0",
     "theo": "^8.1.3",
+    "vinyl-source-stream": "^2.0.0",
     "yeoman-generator": "^3.2.0",
     "yosay": "^2.0.2"
   },

--- a/tools/component-generator/index.js
+++ b/tools/component-generator/index.js
@@ -99,6 +99,7 @@ module.exports = class extends Generator {
       this.templatePath('_component.scss'),
       this.destinationPath(totalPath + outputFile),
       {
+        isNpmComponent: this.props.npm,
         componentName: fileName
       }
     );

--- a/tools/component-generator/templates/_component.scss
+++ b/tools/component-generator/templates/_component.scss
@@ -11,7 +11,7 @@
 @import 'package.variables.scss';
 // Debug information from component's `package.json`:
 // ---
-/*
+/*!
  * Component: #{map-get($componentInfo, 'name')}
  * Version: #{map-get($componentInfo, 'version')}
  * Location: #{map-get($componentInfo, 'location')}

--- a/tools/component-generator/templates/_component.scss
+++ b/tools/component-generator/templates/_component.scss
@@ -7,6 +7,17 @@
 // If you don't have any Sass, you can trim this block down to:
 // "This page was intentionally left blank"
 
+<% if (isNpmComponent) { -%>
+@import 'package.variables.scss';
+// Debug information from component's `package.json`:
+// ---
+/*
+ * Component: #{map-get($componentInfo, 'name')}
+ * Version: #{map-get($componentInfo, 'version')}
+ * Location: #{map-get($componentInfo, 'location')}
+ */
+<% } -%>
+
 @import '<%= componentName %>.variables.scss';
 
 .<%= componentName %> {

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -18,9 +18,11 @@ module.exports = function(gulp, buildDestionation) {
   gulp.task('vf-build',
     gulp.series(
       'vf-clean',
-      'vf-css:generate-component-css',
-      'vf-css:package-info', 'vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts',
-      'vf-fractal:build',
+      gulp.parallel (
+        'vf-css:generate-component-css',
+        gulp.series('vf-css:package-info', 'vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
+        'vf-fractal:build'
+      ),
       'vf-build:copy-assets'
   ));
 

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -18,10 +18,9 @@ module.exports = function(gulp, buildDestionation) {
   gulp.task('vf-build',
     gulp.series(
       'vf-clean',
-      'vf-css:package-info',
       gulp.parallel (
         'vf-css:generate-component-css',
-        gulp.series('vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
+        gulp.series('vf-css:package-info', 'vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
         'vf-fractal:build'
       ),
       'vf-build:copy-assets'

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -18,9 +18,10 @@ module.exports = function(gulp, buildDestionation) {
   gulp.task('vf-build',
     gulp.series(
       'vf-clean',
+      'vf-css:package-info',
       gulp.parallel (
-        'vf-css-gen',
-        gulp.series('vf-css', 'vf-css-build', 'vf-component-assets', 'vf-scripts'),
+        'vf-css:generate-component-css',
+        gulp.series('vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
         'vf-fractal:build'
       ),
       'vf-build:copy-assets'

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -18,11 +18,9 @@ module.exports = function(gulp, buildDestionation) {
   gulp.task('vf-build',
     gulp.series(
       'vf-clean',
-      gulp.parallel (
-        'vf-css:generate-component-css',
-        gulp.series('vf-css:package-info', 'vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
-        'vf-fractal:build'
-      ),
+      'vf-css:generate-component-css',
+      'vf-css:package-info', 'vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts',
+      'vf-fractal:build',
       'vf-build:copy-assets'
   ));
 

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -112,7 +112,8 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
         // }
 
         // only intervene in index.scss rollups
-        if (parentFile == 'index.scss') {
+        // ignore `package.variables.scss` as it is dynamically made and gulp doesn't see it quickly enough
+        if (parentFile == 'index.scss' && url != 'package.variables.scss') {
           if (availableComponents[url]) {
             done(url);
           } else if (availableComponents['_'+truncatedUrl]) {
@@ -144,7 +145,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
       })
       .pipe(ListStream.obj(function (err, data) {
         if (err)
-          throw err
+          throw err;
         data.forEach(function (value, i) {
           // Keep only the file name
           var value = value.history[0].split(/[/]+/).pop();
@@ -163,7 +164,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
           .on(
             'error',
             notify.onError(function(error) {
-              process.emit('exit') // this fails precommit, but allows guld dev to work
+              process.emit('exit') // this fails precommit, but allows `gulp vf-dev` to work
               return 'Problem at file: ' + error.message;
             })
           )

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -77,7 +77,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
     }
 
     recursive(componentPath, ['*.css', '*.scss', '*.md', '*.njk'], function (err, files) {
-      files.forEach(function(file) {
+      files.forEach(function(file, index, array) {
         // only process when a package.json is found
         if ((file.file.indexOf('package.json') > -1)) {
           return fs.createReadStream(file.dir+'/package.json')
@@ -87,12 +87,13 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
             .pipe(gulp.dest(file.dir));
         } else {
           // do nothing
+        }
+
+        if (index + 1 == array.length) {
           done();
         }
       });
-    });
-    done();
-
+    })
   });
 
   gulp.task('vf-css:build', function(done) {

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -60,9 +60,9 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
       return new Transform({
         objectMode: true,
         transform: (data, _, done) => {
-          location = 'components/' + location.split('components/')[1]
-          let name = JSON.parse(data.toString()).name;
-          let version = JSON.parse(data.toString()).version;
+          location = 'components/' + location.split('components/')[1];
+          let name = JSON.parse(data.contents.toString()).name;
+          let version = JSON.parse(data.contents.toString()).version;
 
           var output = `$componentInfo: (
              name: "` + name + `",
@@ -77,13 +77,13 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
     }
 
     recursive(componentPath, ['*.css', '*.scss', '*.md', '*.njk'], function (err, files) {
-
       files.forEach(function(file, index, array) {
         // only process when a package.json is found
         if ((file.file.indexOf('package.json') > -1)) {
-          return fs.createReadStream(file.dir+'/package.json')
+          console.log(file.dir);
+          return gulp.src(file.dir+'/package.json')
             .pipe(packageJsonToScss(file.dir))
-            .pipe(source('package.json'))
+            .pipe(source(file.file_path))
             .pipe(rename('package.variables.scss'))
             .pipe(gulp.dest(file.dir));
         } else {
@@ -91,11 +91,10 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
         }
 
         if (index + 1 == array.length) {
-          console.log('all done')
           done();
         }
       });
-    })
+    });
 
   });
 

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -76,25 +76,16 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
       })
     }
 
-    // let trimToVersion = new Transform({
-    //     transform: (chunk, encoding, done) => {
-    //     }
-    // });
-
     recursive(componentPath, ['*.css', '*.scss', '*.md', '*.njk'], function (err, files) {
       files.forEach(function(file) {
         // only process when a package.json is found
         if ((file.file.indexOf('package.json') > -1)) {
           return fs.createReadStream(file.dir+'/package.json')
             .pipe(packageJsonToScss(file.dir))
-            // .pipe(jsonSass({
-            //   prefix: ' ',
-            // }))
             .pipe(source('package.json'))
             .pipe(rename('package.variables.scss'))
             .pipe(gulp.dest(file.dir));
         } else {
-          // console.log(file.file);
           // do nothing
           done();
         }

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -80,7 +80,6 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
       files.forEach(function(file, index, array) {
         // only process when a package.json is found
         if ((file.file.indexOf('package.json') > -1)) {
-          console.log(file.dir);
           return gulp.src(file.dir+'/package.json')
             .pipe(packageJsonToScss(file.dir))
             .pipe(source(file.file_path))

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -77,6 +77,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
     }
 
     recursive(componentPath, ['*.css', '*.scss', '*.md', '*.njk'], function (err, files) {
+
       files.forEach(function(file, index, array) {
         // only process when a package.json is found
         if ((file.file.indexOf('package.json') > -1)) {
@@ -90,10 +91,12 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
         }
 
         if (index + 1 == array.length) {
+          console.log('all done')
           done();
         }
       });
     })
+
   });
 
   gulp.task('vf-css:build', function(done) {
@@ -190,7 +193,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
 
   // Sass Build-Time things
   // Take the built styles.css and autoprefixer it, then runs cssnano and saves it with a .min.css suffix
-  gulp.task('vf-css-build', function(done) {
+  gulp.task('vf-css:production', function(done) {
     return gulp
       .src(SassOutput + '/styles.css')
       .pipe(autoprefixer(autoprefixerOptions))
@@ -230,6 +233,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
 
   // -----------------------------------------------------------------------------
   // CSS Generator Tasks
+  // Generate per-compone .css files
   // -----------------------------------------------------------------------------
 
   var genCss = function (option) {
@@ -245,7 +249,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
       .pipe(gulp.dest(option.dir));
   };
 
-  gulp.task('vf-css-gen', function(done) {
+  gulp.task('vf-css:generate-component-css', function(done) {
     recursive(componentPath, ['*.css'], function (err, files) {
       files.forEach(function(file) {
         // only generate CSS for index.scss files, but not for the vf rollup

--- a/yarn.lock
+++ b/yarn.lock
@@ -11758,6 +11758,14 @@ vinyl-fs@^3.0.0:
     vinyl "^2.0.0"
     vinyl-sourcemap "^1.1.0"
 
+vinyl-source-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vinyl-source-stream/-/vinyl-source-stream-2.0.0.tgz#f38a5afb9dd1e93b65d550469ac6182ac4f54b8e"
+  integrity sha1-84pa+53R6Ttl1VBGmsYYKsT1S44=
+  dependencies:
+    through2 "^2.0.3"
+    vinyl "^2.1.0"
+
 vinyl-sourcemap@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz#92a800593a38703a8cdb11d8b300ad4be63b3e16"


### PR DESCRIPTION
For #524

This:
- Generates a per-component (and .gitignore-d) `package.variables.scss`
- Outputs a comment in compiled CSS:
```css
 * Component: @visual-framework/vf-componenet-rollup
 * Version: 1.0.0-beta.3
 * Location: components/vf-componenet-rollup
```
