### PR TITLE
Bug: Windows compatibility

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,8 +34,8 @@ global.vfNamespace = config.vfConfig.vfNamespace || "vf-";
 global.vfComponentPath = config.vfConfig.vfComponentPath || path.resolve('.', __dirname + '/components');
 global.vfBuildDestination = config.vfConfig.vfBuildDestination || __dirname + '/temp/build-files';
 global.vfThemePath = config.vfConfig.vfThemePath || './tools/vf-frctl-theme';
-const componentPath = path.resolve('.', global.vfComponentPath);
-const buildDestionation = path.resolve('.', global.vfBuildDestination);
+const componentPath = path.resolve('.', global.vfComponentPath).replace(/\\/g, '/');
+const buildDestionation = path.resolve('.', global.vfBuildDestination).replace(/\\/g, '/');
 
 // Gulp tasks live in their own files, for the sake of clarity.
 // These are done as JS Modules as it makes passing paramaters simpler and avoids

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -18,9 +18,10 @@ module.exports = function(gulp, buildDestionation) {
   gulp.task('vf-build',
     gulp.series(
       'vf-clean',
+      'vf-css:package-info',
       gulp.parallel (
         'vf-css:generate-component-css',
-        gulp.series('vf-css:package-info', 'vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
+        gulp.series('vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
         'vf-fractal:build'
       ),
       'vf-build:copy-assets'

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -55,6 +55,11 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
       // We'll check to see if the file exists before passing
       // it to sass for compilation
       importer: [function(url,prev,done) {
+
+        // windows compatibility
+        url = url.replace(/\\/g, '/');
+        prev = prev.replace(/\\/g, '/');
+
         var truncatedUrl = url.split(/[/]+/).pop();
         var parentFile = prev.split(/[/]+/).pop();
 
@@ -99,7 +104,8 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
           throw err
         data.forEach(function (value, i) {
           // Keep only the file name
-          var value = value.history[0].split(/[/]+/).pop();
+          value = value.history[0].replace(/\\/g, '/'); // windows compatibility
+          value = value.split(/[/]+/).pop();
 
           availableComponents[value] = true;
         });
@@ -202,7 +208,7 @@ module.exports = function(gulp, path, componentPath, buildDestionation, browserS
     recursive(componentPath, ['*.css'], function (err, files) {
       files.forEach(function(file) {
         // only generate CSS for index.scss files, but not for the vf rollup
-        if ((file.file.indexOf('index.scss') > -1) && (file.file_path.indexOf('vf-componenet-rollup/index.scss') == -1)) {
+        if ((file.file.indexOf('index.scss') > -1) && (file.file_path.replace(/\\/g, '/').indexOf('vf-componenet-rollup/index.scss') == -1)) {
           genCss(file);
         }
       });

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -33,9 +33,9 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   // take an array of sassTypes (paths), and componentPaths and add them to the sassPaths array
   function constructSassImportPaths(sassTypes, sassComponentDirectories) {
     for (let currentType = 0; currentType < sassTypes.length; currentType++) {
-      sassPaths.push(path.resolve('.', componentPath, sassTypes[currentType]).replace(/\\/g, '/'););
+      sassPaths.push(path.resolve('.', componentPath, sassTypes[currentType]).replace(/\\/g, '/'));
       for (let directory = 0; directory < sassComponentDirectories.length; directory++) {
-        sassPaths.push(path.resolve('.', componentPath, sassComponentDirectories[directory] + '/' + sassTypes[currentType]).replace(/\\/g, '/'););
+        sassPaths.push(path.resolve('.', componentPath, sassComponentDirectories[directory] + '/' + sassTypes[currentType]).replace(/\\/g, '/'));
       }
     }
   }

--- a/tools/gulp-tasks/vf-scripts.js
+++ b/tools/gulp-tasks/vf-scripts.js
@@ -16,7 +16,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
 
   // Construct jsPaths to import from componentDirectories
   for (let directory = 0; directory < componentDirectories.length; directory++) {
-    jsPaths.push(path.resolve('.', componentPath, componentDirectories[directory]));
+    jsPaths.push(path.resolve('.', componentPath, componentDirectories[directory]).replace(/\\/g, '/'));
   }
 
   // add any multi-component paths


### PR DESCRIPTION
Gets vf-core working on Windows by resolving issues around paths. (`\` `!=` `/`)

I'm sure there might be other things lurking about, but this seems to get all the gulp commands working and the outputs.