### PR TITLE
Bug/load vf-core version directly from `node_modules/vf-core`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,13 +24,14 @@ const path = require('path');
 // todo: this could/should become a JS module
 const fs = require('fs');
 const config = JSON.parse(fs.readFileSync('./package.json'));
+const vfCoreConfig = JSON.parse(fs.readFileSync(require.resolve('@visual-framework/vf-core/package.json')));
 config.vfConfig = config.vfConfig || [];
 global.vfName = config.vfConfig.vfName || "Visual Framework 2.0";
 global.vfNamespace = config.vfConfig.vfNamespace || "vf-";
 global.vfComponentPath = config.vfConfig.vfComponentPath || path.resolve('.', __dirname + '/components');
 global.vfBuildDestination = config.vfConfig.vfBuildDestination || __dirname + '/temp/build-files';
 global.vfThemePath = config.vfConfig.vfThemePath || './tools/vf-frctl-theme';
-global.vfVersion = config.version || 'not-specified';
+global.vfVersion = vfCoreConfig.version || 'not-specified';
 const componentPath = path.resolve('.', global.vfComponentPath).replace(/\\/g, '/');
 const componentDirectories = config.vfConfig.vfComponentDirectories || ['vf-core-components'];
 const buildDestionation = path.resolve('.', global.vfBuildDestination).replace(/\\/g, '/');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,13 @@ const path = require('path');
 // todo: this could/should become a JS module
 const fs = require('fs');
 const config = JSON.parse(fs.readFileSync('./package.json'));
-const vfCoreConfig = JSON.parse(fs.readFileSync(require.resolve('@visual-framework/vf-core/package.json')));
+let vfCoreConfig;
+if (config.name === '@visual-framework/vf-core') {
+  vfCoreConfig = JSON.parse(fs.readFileSync('./package.json'));
+} else {
+  // load vfCoreConfig from node_modules
+  vfCoreConfig = JSON.parse(fs.readFileSync(require.resolve('@visual-framework/vf-core/package.json')));
+}
 config.vfConfig = config.vfConfig || [];
 global.vfName = config.vfConfig.vfName || "Visual Framework 2.0";
 global.vfNamespace = config.vfConfig.vfNamespace || "vf-";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,9 +23,12 @@ const path = require('path');
 // all settings are optional
 // todo: this could/should become a JS module
 const fs = require('fs');
+// Load your local project's package.json config
 const config = JSON.parse(fs.readFileSync('./package.json'));
+// Load the vf-core package.json config
 let vfCoreConfig;
 if (config.name === '@visual-framework/vf-core') {
+  // if being run from within the vf-core project, use the local package.json
   vfCoreConfig = JSON.parse(fs.readFileSync('./package.json'));
 } else {
   // load vfCoreConfig from node_modules


### PR DESCRIPTION
This wasn't directly impacting vf-core, but is a config issue in sites that use vf-core as a dependency. In short, it resulted in the vf-core version being reported as the client version.
