### PR TITLE
Bug: vf-code example formatting

### DIFF
--- a/components/vf-code-example/README.md
+++ b/components/vf-code-example/README.md
@@ -2,6 +2,8 @@
 
 ## About
 
+If you're using the VF Nunjucks environment, you can utilise the `{% codeblock 'html' -%}{% endcodeblock %}` tag to assist generating pre-formatted content.
+
 ## Installation and Implementation
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-code-example` with this command.

--- a/components/vf-code-example/vf-code-example.njk
+++ b/components/vf-code-example/vf-code-example.njk
@@ -1,5 +1,9 @@
-<code class="vf-code-example">
-  <pre class="vf-code-example__pre">
-    &lt;your special code here /&gt;
-  </pre>
-</code>
+<pre class="vf-code-example__pre"><code class="Code Code--lang-html vf-code-example"><span class="hljs-tag">&lt;<span class="hljs-name">pre</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"vf-code-example__pre"</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">code</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"vf-code-example"</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">your</span> <span class="hljs-attr">special</span> <span class="hljs-attr">code</span> <span class="hljs-attr">here</span>&gt;</span>
+Maybe some html tags?
+<span class="hljs-tag">&lt;<span class="hljs-name">link</span> <span class="hljs-attr">rel</span>=<span class="hljs-string">"stylesheet"</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"https://aurl"</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">script</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"https://aurl"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">code</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">pre</span>&gt;</span>
+</code></pre>

--- a/components/vf-code-example/vf-code-example.scss
+++ b/components/vf-code-example/vf-code-example.scss
@@ -23,12 +23,11 @@ $vf-code-example-enable-hljs: true !default;
 .vf-content pre,
 .vf-code-example__pre {
   border: 1px;
-  display: inline-block;
+  display: grid;
   min-width: 0;
   overflow: auto;
   white-space: pre-wrap;
   @include padding--inline(all,map-get($vf-spacing-map, vf-spacing--s));
-  display: grid;
 }
 
 @if $vf-code-example-enable-hljs == true {

--- a/components/vf-code-example/vf-code-example.scss
+++ b/components/vf-code-example/vf-code-example.scss
@@ -20,10 +20,6 @@ $vf-code-example-enable-hljs: true !default;
   font-size: inherit;
 }
 
-.vf-code-example {
-  display: grid;
-}
-
 .vf-content pre,
 .vf-code-example__pre {
   border: 1px;
@@ -32,6 +28,7 @@ $vf-code-example-enable-hljs: true !default;
   overflow: auto;
   white-space: pre-wrap;
   @include padding--inline(all,map-get($vf-spacing-map, vf-spacing--s));
+  display: grid;
 }
 
 @if $vf-code-example-enable-hljs == true {

--- a/tools/vf-frctl-extensions/codeblock.js
+++ b/tools/vf-frctl-extensions/codeblock.js
@@ -38,7 +38,7 @@ module.exports = function(fractal){
           if(typeof txt == "undefined") return;
           txt = hljs.highlight(format, txt).value;
 
-          return `<code class="Code Code--lang-${format} vf-code-example"><pre class="vf-code-example__pre">${txt}</pre></code>`;
+          return `<pre class="vf-code-example__pre"><code class="Code Code--lang-${format} vf-code-example">${txt}</code></pre>`;
         };
 
     };

--- a/tools/vf-frctl-theme/views/pages/error.njk
+++ b/tools/vf-frctl-theme/views/pages/error.njk
@@ -13,9 +13,7 @@
     </div>
 
     {% if error.stack and error.status != '404' %}
-    <code class="Code Error-stack vf-code-example">
-        <pre class="vf-code-example__pre">{{ error.stack }}</pre>
-    </code>
+    <pre class="vf-code-example__pre"><code class="Code Error-stack vf-code-example">{{ error.stack }}</code></pre>
     {% endif %}
 
 </div>

--- a/tools/vf-frctl-theme/views/partials/browser/panel-html.njk
+++ b/tools/vf-frctl-theme/views/partials/browser/panel-html.njk
@@ -1,24 +1,24 @@
 {% import "macros/render.njk" as render %}
 {% if not ((entity.preview == '@preview--blocks') or (entity.preview == '@preview--elements')) %}
 <h3 class="vf-text vf-text-heading--4">Code example</h3>
-<code class="Code Code--lang-html vf-code-example">
+
   {% if entity.isVariant or entity.variants().size == 1 %}
-  <pre class="vf-code-example__pre">
-{% set renderedItem = render.entity(entity.render(null, renderEnv, {preview: false, collate: false},entity) | async(true)) | trim %}
-{% if renderedItem != '' %}
-{{ renderedItem }}
+  <pre class="vf-code-example__pre"><code class="Code Code--lang-html vf-code-example">
+{%- set renderedItem = render.entity(entity.render(null, renderEnv, {preview: false, collate: false},entity) | async(true)) | trim -%}
+{%- if renderedItem != '' -%}
+{{ renderedItem | trim }}
 {% else %}
 {{ entity.content | highlight('html') }}
-{% endif %}
-  </pre>
+{% endif -%}
+  </code></pre>
   {% else %}
   {% for variant in entity.variants().items() %}
 <a id="{{ variant.handle }}-code" href="#{{ variant.handle }}-code">Anchor (todo: `vf-link--anchor` or such)</a>
-<pre class="vf-code-example__pre">{{ '<span class="hljs-comment">&lt;!-- ' + variant.label + ' --&gt;</span>' }}
+<pre class="vf-code-example__pre"><code class="Code Code--lang-html vf-code-example">{{ '<span class="hljs-comment">&lt;!-- ' + variant.label + ' --&gt;</span>' }}
 {{ render.entity(variant.render(null, renderEnv, {preview: false, collate: false}) | async(true)) | trim }}
-</pre>
+</code></pre>
   {% endfor %}
   {% endif %}
-</code>
+
 <hr class="vf-divider vf-u-margin__bottom--md vf-u-margin__top--md">
 {% endif %}

--- a/tools/vf-frctl-theme/views/partials/browser/panel-resources.njk
+++ b/tools/vf-frctl-theme/views/partials/browser/panel-resources.njk
@@ -24,9 +24,9 @@
         {% if resource.isBinary and resource.isImage %}
             <img src="{{ path(frctl.theme.urlFromRoute('component-resource', {handle: compHandle, asset:resource.base} )) }}">
         {% elif not resource.isBinary %}
-        <code class="Code Code--lang-{{ resource.lang }} FileBrowser-code vf-code-example">
-          <pre class="vf-code-example__pre">{{ resource.contents | highlight(resource.lang) }}</pre>
-        </code>
+        <pre class="vf-code-example__pre">
+          <code class="Code Code--lang-{{ resource.lang }} FileBrowser-code vf-code-example">{{ resource.contents | highlight(resource.lang) }}</code>
+        </pre>
         {% else %}
           <p class="vf-text"><em>Previews are currently not available for this file type.</em></p>
         {% endif %}


### PR DESCRIPTION
Two things:

- Bug: fix nesting of code>pre …
   Should be `<pre><code>`: https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element
  Doing it the other way around is typically fine, but Chrome tries to flip the elements which leads to odd behaviour.

- Bug: use grid layout on pre tag not code …
  This is partly related to doing `<pre><code>` but in some cases affected the layout of code snippets, breaking each element onto its own line.
