### PR TITLE
changes css:production to not overwrite the style.css with minified css

### DIFF
--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -209,11 +209,6 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
       .pipe(autoprefixer(autoprefixerOptions))
       .pipe(gulp.dest(SassOutput))
       .pipe(cssnano())
-      .pipe(rename(
-        {
-          suffix: '.min'
-        }
-      ))
       .pipe(gulp.dest(SassOutput))
       .on('end', function() {
         done();


### PR DESCRIPTION
this edits the `css:production` task to remove the generation of a new `.min.css` file and overwrite the existing `styles.css` file for production.

Closes #549 