### PR TITLE
resolves some small responsive issues for group pages (and components)

### DIFF
--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -14,6 +14,20 @@
   grid-column: main;
   margin-bottom: 48px;
 
+  & > :first-child {
+    grid-column: 1 / -1;
+    margin-right: var(--embl-grid-spacing-normaliser);
+
+    @media (min-width: 846px) {
+      grid-column: span 1;
+    }
+  }
+
+  & > *:not(:first-child) {
+    @media (max-width: 845px) {
+      grid-column: 1 / -1;
+    }
+  }
   @media (min-width: $vf-breakpoint--sm) {
     display: grid;
     grid-column-gap: var(--page-grid-gap);
@@ -24,20 +38,7 @@
     ;
     /* stylelint-enable */
   }
-
-  & > :first-child {
-    grid-column: 1 / -1;
-    margin-right: var(--embl-grid-spacing-normaliser);
-
-    @media (min-width: 846px) {
-      grid-column: span 1;
-    }
-  }
-  & > *:not(:first-child) {
-    @media (max-width: 845px) {
-      grid-column: 1 / -1;
-    }
-  }
+  
 }
 
 .embl-grid--has-centered-content {

--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -11,16 +11,19 @@
 
 
 .embl-grid {
-  display: grid;
   grid-column: main;
-  grid-column-gap: var(--page-grid-gap);
-  /* stylelint-disable declaration-colon-space-after */
-  grid-template-columns:
-    calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser))
-    repeat(auto-fit, minmax(288px, 1fr))
-  ;
-  /* stylelint-enable */
   margin-bottom: 48px;
+
+  @media (min-width: $vf-breakpoint--sm) {
+    display: grid;
+    grid-column-gap: var(--page-grid-gap);
+    /* stylelint-disable declaration-colon-space-after */
+    grid-template-columns:
+      calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser))
+      repeat(auto-fit, minmax(288px, 1fr))
+    ;
+    /* stylelint-enable */
+  }
 
   & > :first-child {
     grid-column: 1 / -1;

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -19,6 +19,7 @@ $button-hover-fix: -5px -5px rgba(0, 0, 0, 0);
 
   @include set-type(text-button--1);
 
+  align-self: center;
   appearance: none;
   backface-visibility: hidden;
   background-color: set-ui-color(vf-ui-color--black);

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -38,9 +38,9 @@ $button-hover-fix: -5px -5px rgba(0, 0, 0, 0);
   text-decoration: none;
   transform: translate(0, 0);
   transition: all linear 125ms;
-    // Ideally we want this to be 50ms but there's an issue in Webkit/Safari on box-shadow animations
-    // additionally we can't do a pseude :before/:after as we need to support <button> elements
-    // https://github.com/visual-framework/vf-core/pull/632
+  // Ideally we want this to be 50ms but there's an issue in Webkit/Safari on box-shadow animations
+  // additionally we can't do a pseude :before/:after as we need to support <button> elements
+  // https://github.com/visual-framework/vf-core/pull/632
 
 
   // Hover and Focus Styles

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -37,9 +37,10 @@ $button-hover-fix: -5px -5px rgba(0, 0, 0, 0);
   text-align: center;
   text-decoration: none;
   transform: translate(0, 0);
-  transition: all linear 125ms; // Ideally we want this to be 50ms but there's an issue in Webkit/Safari on box-shadow animations
-                                // additionally we can't do a pseude :before/:after as we need to support <button> elements
-                                // https://github.com/visual-framework/vf-core/pull/632
+  transition: all linear 125ms;
+    // Ideally we want this to be 50ms but there's an issue in Webkit/Safari on box-shadow animations
+    // additionally we can't do a pseude :before/:after as we need to support <button> elements
+    // https://github.com/visual-framework/vf-core/pull/632
 
 
   // Hover and Focus Styles

--- a/components/vf-footer/vf-footer.scss
+++ b/components/vf-footer/vf-footer.scss
@@ -65,10 +65,6 @@
   border-width: 1px 0;
   margin-bottom: 12px;
 
-  @media (min-width: $vf-breakpoint--lg) {
-    padding-bottom: 4rem;
-  }
-
   .vf-links__heading {
     @include set-type(text-body--6);
 
@@ -84,6 +80,11 @@
   .vf-links__item {
     margin-bottom: 0;
   }
+
+  @media (min-width: $vf-breakpoint--lg) {
+    padding-bottom: 4rem;
+  }
+  
 }
 
 .vf-footer .vf-links__link {

--- a/components/vf-footer/vf-footer.scss
+++ b/components/vf-footer/vf-footer.scss
@@ -36,12 +36,15 @@
 
 .vf-footer__legal {
   color: set-ui-color(vf-ui-color--white);
-  display: grid;
-  grid-template-columns: repeat(4, max-content);
 
   .vf-footer__legal-text,
   .vf-footer__link {
     padding-top: 12px;
+  }
+
+  @media (min-width: $vf-breakpoint--lg) {
+    display: grid;
+    grid-template-columns: repeat(4, max-content);
   }
 }
 
@@ -62,6 +65,10 @@
   border-width: 1px 0;
   margin-bottom: 12px;
 
+  @media (min-width: $vf-breakpoint--lg) {
+    padding-bottom: 4rem;
+  }
+
   .vf-links__heading {
     @include set-type(text-body--6);
 
@@ -70,7 +77,6 @@
   }
 
   .vf-links {
-    margin-bottom: 48px;
     padding-bottom: 0;
     padding-top: 12px;
   }

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -56,6 +56,8 @@
     [main-end]
     minmax(var(--page-grid-gap), 60px)
   ;
+  padding-top: 36px;
+
   @media (max-width: 1023px) {
     grid-template-columns:
       var(--page-grid-gap)
@@ -67,7 +69,6 @@
     ;
   }
   /* stylelint-enable */
-  padding-top: 36px;
 }
 
 .vf-inlay__content--full-width {

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -25,7 +25,11 @@
   /* stylelint-enable */
 
   &:last-of-type {
-    @include margin--block(bottom, $vf-inlay__spacing--bottom);
+    @include margin--block(bottom, $vf-inlay__spacing--bottom--narrow);
+
+    @media (min-width: 1024px) {
+      @include margin--block(bottom, $vf-inlay__spacing--bottom);
+    }
   }
 
   // overides vf-grid's natural inclination to be full width

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -56,6 +56,16 @@
     [main-end]
     minmax(var(--page-grid-gap), 60px)
   ;
+  @media (max-width: 1023px) {
+    grid-template-columns:
+      var(--page-grid-gap)
+      [main-start]
+        minmax(auto, 100%)
+        minmax(auto, 22.125em)
+      [main-end]
+      var(--page-grid-gap)
+    ;
+  }
   /* stylelint-enable */
   padding-top: 36px;
 }

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -1,4 +1,4 @@
-// vf-inlay 
+// vf-inlay
 
 @import 'package.variables.scss';
 // Debug information from component's `package.json`:
@@ -53,12 +53,12 @@
   grid-column: 2 / 3;
   /* stylelint-disable declaration-colon-space-after, indentation */
   grid-template-columns:
-    minmax(var(--page-grid-gap), 60px)
+    minmax(var(--page-grid-gap), 1em)
     [main-start]
       minmax(auto, 100%)
       minmax(auto, 22.125em)
     [main-end]
-    minmax(var(--page-grid-gap), 60px)
+    minmax(var(--page-grid-gap), 1em)
   ;
   padding-top: 36px;
 

--- a/components/vf-inlay/vf-inlay.variables.scss
+++ b/components/vf-inlay/vf-inlay.variables.scss
@@ -6,5 +6,5 @@
 // Default component variables
 // ------------------------------------------------------------
 
-
+$vf-inlay__spacing--bottom--narrow: 36px;
 $vf-inlay__spacing--bottom: 100px;

--- a/components/vf-masthead/vf-masthead--supports.scss
+++ b/components/vf-masthead/vf-masthead--supports.scss
@@ -1,5 +1,9 @@
 .vf-header .vf-masthead {
   grid-column: 1 / -1;
+
+  @media (max-width: 1023px) {
+    @include padding--inline(all, map-get($vf-spacing-map, vf-spacing--md));
+  }
 }
 
 .embl-group-header__header .vf-masthead {

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -31,6 +31,10 @@ $vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
   margin: 0 auto;
   max-width: 76.5em;
   width: 100%;
+
+  @media (max-width: $vf-breakpoint--sm) {
+    padding: 1em;
+  }
 }
 
 .vf-masthead__title {

--- a/components/vf-navigation/vf-navigation--main.scss
+++ b/components/vf-navigation/vf-navigation--main.scss
@@ -21,10 +21,6 @@
     z-index: set-layer(vf-z-index--negative);
   }
 
-  @media (max-width: 1023px) {
-    box-sizing: border-box;
-  }
-
   .vf-navigation__list {
     display: block;
 
@@ -81,6 +77,7 @@
   }
 
   @media (max-width: $vf-breakpoint--lg - 1) {
+    box-sizing: border-box;
     padding: 0 1rem;
   }
 }

--- a/components/vf-navigation/vf-navigation--main.scss
+++ b/components/vf-navigation/vf-navigation--main.scss
@@ -21,6 +21,10 @@
     z-index: set-layer(vf-z-index--negative);
   }
 
+  @media (max-width: 1023px) {
+    box-sizing: border-box;
+  }
+
   .vf-navigation__list {
     display: block;
 

--- a/components/vf-summary/vf-summary--news.scss
+++ b/components/vf-summary/vf-summary--news.scss
@@ -43,9 +43,9 @@
     }
   }
 
-  @media (min-width:600px) {
-    grid-template-columns: minmax(0, auto) 1fr;
+  @media (min-width: 600px) {
     grid-row-gap: unset;
+    grid-template-columns: minmax(0, auto) 1fr;
   }
 
 }

--- a/components/vf-summary/vf-summary--news.scss
+++ b/components/vf-summary/vf-summary--news.scss
@@ -1,7 +1,7 @@
 .vf-summary--news {
 
   grid-column-gap: 0;
-  grid-template-columns: minmax(0, auto) 1fr;
+  grid-row-gap: 16px;
   grid-template-rows: auto;
   margin-bottom: 48px;
 
@@ -41,6 +41,11 @@
     & > .vf-summary__category {
       margin-top: -16px; // so that if there's not a category there's space between title and text
     }
+  }
+
+  @media (min-width:600px) {
+    grid-template-columns: minmax(0, auto) 1fr;
+    grid-row-gap: unset;
   }
 
 }


### PR DESCRIPTION
I thought I'd have a quick look at the group pages on a narrow viewport and there's several little bugs that we need to address.

This list is not exhaustive, and will probably be added to to create a much larger PR for 'responsive fixes'.

- [x] `vf-navigation--main` needs `box-sizing: border-box` when the navigation is in a 'block' layout.
- [x] `vf-masthead` needs some inline padding on a narrow viewport
- [x] `vf-inlay` grid needs narrower outer columns, or no columns at all on narrow viewport
- [x] `vf-inlay__content` no grid required at narrow viewport **update:** this relies on `embl-grid` too
- [x] `vf-inlay` needs less bottom margin at a narrow viewport
- [x] `emb-grid` at narrow viewport needs removing
- [x] `vf-summary` grid too thin at a narrow viewport
- [x] `vf-footer` links have to large a margin bottom at a narrow viewport
- [x] `vf-footer-legal` change grid at a narrow viewport

27/09/19
- [x] `vf-banner` spacing needs adjusting at small/medium viewports