### PR TITLE
Bug: logo fixes

### DIFF
--- a/components/embl-logo/embl-logo.config.yml
+++ b/components/embl-logo/embl-logo.config.yml
@@ -8,8 +8,9 @@ status: alpha
 # Per-variant options
 variants:
   - name: responsive
+    hidden: true
     context:
-      deprecated_text: "'@embl-logo--responsive' is deprecated, please use render '@embl-logo'"
+      deprecated_text: "'@embl-logo--responsive' is deprecated, use '@embl-logo'"
 context:
   # custom-values: passed as {{custom-values}}
   component-type: embl-element

--- a/components/embl-logo/embl-logo.njk
+++ b/components/embl-logo/embl-logo.njk
@@ -1,4 +1,4 @@
 <a href="/" class="embl-logo">
   <span class="vf-sr-only" for="text">{{ logo_text}}</span>
 </a>
- {% if deprecated_text %}<!-- {{ deprecated_text }} -->{% endif %}
+{% if deprecated_text %}<!-- {{ deprecated_text }} -->{% endif %}

--- a/components/embl-logo/embl-logo.scss
+++ b/components/embl-logo/embl-logo.scss
@@ -12,13 +12,13 @@
 }
 
 @media (min-width: 500px) {
-  .embl-logo--responsive {
+  .embl-logo {
     background-image: url('../assets/embl-logo/assets/logo-medium.svg');
     height: 28px;
   }
 }
 @media (min-width: 999px) {
-  .embl-logo--responsive {
+  .embl-logo {
     background-image: url('../assets/embl-logo/assets/logo.svg');
     height: 30px;
   }

--- a/components/vf-logo/vf-logo.config.yml
+++ b/components/vf-logo/vf-logo.config.yml
@@ -10,6 +10,11 @@ variants:
   - name: default
     context:
       hidden_text: false
+  - name: responsive
+    hidden: true
+    context:
+      hidden_text: false
+      deprecated_text: "'@vf-logo--responsive' is deprecated, use '@vf-logo'"
   - name: hidden text
     context:
       hidden_text: true

--- a/components/vf-logo/vf-logo.njk
+++ b/components/vf-logo/vf-logo.njk
@@ -5,3 +5,4 @@ class="vf-logo {%- if override_class %} | {{override_class}}{% endif -%}">
   <img class="vf-logo__image" src="{{ image }}" alt="{{ logo_text }}">
   <span class="vf-logo__text{% if hidden_text %} vf-sr-only{% endif %}">{{logo_text}}</span>
 </a>
+{% if deprecated_text %}<!-- {{ deprecated_text }} -->{% endif %}


### PR DESCRIPTION
Follow on fixes to #545 and #548 around classnames and leaving `vf-logo--responsive` as deprecated to not break things.