### PR TITLE
Documentation: Improve vf-sass-config documentation

### DIFF
--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -16,7 +16,6 @@
 @import 'vf-global-custom-properties.scss';
 
 @import 'vf-global-variables.scss';
-@import '_vf-variables.shame.scss';
 @import 'vf-global-variables.scss';
 @import 'vf-border-radius.variables.scss';
 @import 'vf-breakpoints.variables.scss';
@@ -163,3 +162,6 @@ html, button {
 // This is a demonstration of vf-core's ability to warn and proceed on missing
 // sass imports
 @import 'vf-somepattern/vf-i-dont-exist.scss';
+
+// If you have any locoal overrides, put them in:
+@import 'vf-local-overrides/vf-local-overrides.scss';

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -16,7 +16,6 @@
 @import 'vf-global-custom-properties.scss';
 
 @import 'vf-global-variables.scss';
-@import 'vf-global-variables.scss';
 @import 'vf-border-radius.variables.scss';
 @import 'vf-breakpoints.variables.scss';
 @import 'vf-colors.map.scss';

--- a/components/vf-sass-config/README.md
+++ b/components/vf-sass-config/README.md
@@ -14,7 +14,7 @@ Note: these utilise `vf-design-tokens`
 
 ### map-deep-get.scss
 
-`map-deep-get($map, $keys`
+`map-deep-get($map, $keys)`
 
 ### set-layer.scss
 

--- a/components/vf-sass-config/README.md
+++ b/components/vf-sass-config/README.md
@@ -1,46 +1,168 @@
-# Sass Config functions
+# Sass Config and templates
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-sass-config.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-sass-config)
 
 Mixins, functions and variables to power all `vf-core` components.
 
-Note: these utilise the `vf-design-tokens`
+Note: these utilise `vf-design-tokens`
 
 ## Functions
 
-- _set-color.scss
-- map-deep-get.scss
-- set-layer.scss
-- string-replace.scss
-- vf-functions.scss
+### set-color.scss
+
+ `set-color($color-name)`
+
+### map-deep-get.scss
+
+`map-deep-get($map, $keys`
+
+### set-layer.scss
+
+`set-layer($layer)`
+
+### string-replace.scss
+
+`str-replace($name, $number)`
+
+Slice off the first amount($number) of characters from the $name value passed. Primarily used to replace the start of variables for the utility class generation.
+
+### vf-functions.scss
+
+Rollup of all functions.
 
 ## Mixins
 
-- _blockquote.scss
-- _button.scss
-- _divider.scss
-- _figure.scss
-- _helpers.scss
-- _links.scss
-- _lists.scss
-- _margin.scss
-- _padding.scss
-- _text-color.scss
-- _typography.scss
-- _utility--color.scss
-- _utility--slide.scss
-- _utility--spacing.scss
-- _utility--typography.scss
-- _vf-mixins.scss
-- _vf-utility-mixins.scss
-- vf-disabled.scss
+### blockquote.scss
+
+Reusable styling for html blockquote elements.
+
+`@include blockquote;`
+
+### button.scss  
+
+Reusable styling for button elements
+
+`@include vf-button;`
+
+### divider.scss   
+
+Reusable styling for divider elements and styling
+
+`@include vf-divider;`
+
+### figure.scss    
+
+Reusable styling for figures with optional caption styling
+
+`@include figure($has-caption: true);`
+
+### helpers.scss  
+
+Nothing, yet.
+
+### links.scss     
+
+Styling for links.
+
+`@include inline-link(
+  $vf-link--color: $vf-link--color,
+  $vf-link--hover-color: $vf-link--hover-color,
+  $vf-link--visited-color: $vf-link--visited-color,
+  $vf-include-normalisations: $vf-include-normalisations);`
+
+`@include button-link(
+  $vf-link--color: $vf-link--color,
+  $vf-link--hover-color: $vf-link--hover-color,
+  $vf-link--visited-color: $vf-link--visited-color);`
+
+`button-link--ghost(
+  $vf-link--color: $vf-link--color,
+  $vf-link--hover-color: $vf-link--hover-color,
+  $vf-link--visited-color: $vf-link--visited-color);`  
+
+### lists.scss     
+
+Styling for list types
+
+`@include($classname: optional-classname-to-usm, $type: null, unordered, ordered or inline);`
+
+### margin.scss    
+
+Margin, recommended to use with sizing maps
+
+`@include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--lg));`
+
+- `margin-block`: specify one value for bottom and top, top or bottom
+- `margin-all`: specify one value for left or right, left or right
+- `margin`: specify all or a value for each
+
+### padding.scss   
+
+Padding, recommended to use with sizing maps
+
+`@include padding--block(bottom, map-get($vf-spacing-map, vf-spacing--lg));`
+
+- `padding-block`: specify one value for bottom and top, top or bottom
+- `padding-all`: specify one value for left or right, left or right
+- `padding`: specify all or a value for each
+
+
+### text-color.scss
+
+**Currently not used**. Intelligently pick if white or black should be used as a contrasting colour
+
+### typography.scss
+
+Generate correct font information when included into an element.
+Recommended to use with typography and sizing maps
+
+`@include set-type(text-body--3, $global-font-family, $custom-margin-bottom: vf-spacing--lg)`
+
+### utility--color.scss
+
+Generate lists of values in design token maps. Intended for use by the `vf-utility-classes` component
+
+### utility--slide.scss
+
+A non-jitter causing way to slide elements up/down on hover.
+
+`@include vf-slide-on-hover($shift-distance, $direction:up);`
+
+### utility--spacing.scss
+
+Generate lists of values in design token maps. Intended for use by the `vf-utility-classes` component
+
+### utility--typography.scss
+
+Generate lists of values in design token maps. Intended for use by the `vf-utility-classes` component
+
+### vf-mixins.scss
+
+Rollup of all mixins.
+
+### vf-utility-mixins.scss
+
+Rollup of all utility mixins.
+
+### vf-disabled.scss
+
+For disable link elements, actions
+@include vf-disabled($vf-link--disabled-color);
 
 ## Variables
 
-- _vf-variables.shame.scss
-- vf-global-custom-properties.scss
-- vf-global-variables.scss
-- vf-variables.scss
+### vf-global-custom-properties.scss
+
+Native CSS properties, currently limited to document spacing.
+
+### vf-global-variables.scss
+
+Global Sass variable defaults for the high-level page look of typography, page width,
+deprecated component text, if normalisations should be included.
+
+### vf-variables.scss
+
+Rollup of global Sass variables.
 
 ## Install
 

--- a/components/vf-sass-config/functions/string-replace.scss
+++ b/components/vf-sass-config/functions/string-replace.scss
@@ -1,7 +1,7 @@
 // str-replace function
 // --------------------
 
-// This is used to slice off the first amount($number) of characters from the $name value passed.
+// Slice off the first amount($number) of characters from the $name value passed.
 // Primarily used to replace the start of variables for the utility class generation.
 
 @function str-replace($name, $number) {

--- a/components/vf-sass-config/mixins/_blockquote.scss
+++ b/components/vf-sass-config/mixins/_blockquote.scss
@@ -1,16 +1,16 @@
 // Reusable styling for html blockquote elements
-// @include blockquote;
+// @include blockquote();
 
-@mixin blockquote() {
+@mixin blockquote($custom-margin-bottom: vf-spacing--0, $custom-border-color: vf-color--grey--lightest) {
   @include set-type(text-body--2);
-  margin: 0;
+  @include margin--block(bottom, map-get($vf-spacing-map, $custom-margin-bottom));
   border: 0;
   padding: 10px 8px 10px 32px;
   position: relative;
 
   &::before {
     content: '';
-    border-left: 4px solid map-get($vf-colors-map, vf-color--grey--lightest);
+    border-left: 4px solid map-get($vf-colors-map, $custom-border-color);
     position: absolute;
     left: 12px;
     height: 100%;

--- a/components/vf-sass-config/mixins/_blockquote.scss
+++ b/components/vf-sass-config/mixins/_blockquote.scss
@@ -1,3 +1,6 @@
+// Reusable styling for html blockquote elements
+// @include blockquote;
+
 @mixin blockquote() {
   @include set-type(text-body--2);
   margin: 0;

--- a/components/vf-sass-config/mixins/_button.scss
+++ b/components/vf-sass-config/mixins/_button.scss
@@ -1,3 +1,6 @@
+// Reusable styling for button elements
+// @include vf-button;
+
 @mixin vf-button {
   appearance: none;
   border: 0;

--- a/components/vf-sass-config/mixins/_button.scss
+++ b/components/vf-sass-config/mixins/_button.scss
@@ -1,7 +1,7 @@
 // Reusable styling for button elements
-// @include vf-button;
+// @include vf-button();
 
-@mixin vf-button {
+@mixin vf-button() {
   appearance: none;
   border: 0;
   cursor: pointer;

--- a/components/vf-sass-config/mixins/_divider.scss
+++ b/components/vf-sass-config/mixins/_divider.scss
@@ -1,4 +1,5 @@
-// vf-divider
+// Reusable styling for divider elements and styling
+// @include vf-divider;
 
 @mixin divider() {
   background-color: set-ui-color(vf-ui-color--grey--light);

--- a/components/vf-sass-config/mixins/_figure.scss
+++ b/components/vf-sass-config/mixins/_figure.scss
@@ -1,3 +1,6 @@
+// Reusable styling for figures with optional caption styling
+// @include figure($has-caption: true);
+
 @mixin figure($has-caption: true) {
   margin: 0;
   &__image {

--- a/components/vf-sass-config/mixins/_helpers.scss
+++ b/components/vf-sass-config/mixins/_helpers.scss
@@ -1,0 +1,1 @@
+// Nothing, yet

--- a/components/vf-sass-config/mixins/_links.scss
+++ b/components/vf-sass-config/mixins/_links.scss
@@ -1,3 +1,5 @@
+// Styling for inline links
+
 @mixin inline-link(
   $vf-link--color: $vf-link--color,
   $vf-link--hover-color: $vf-link--hover-color,

--- a/components/vf-sass-config/mixins/_lists.scss
+++ b/components/vf-sass-config/mixins/_lists.scss
@@ -1,3 +1,5 @@
+// Styling for list types
+// @include($classname: optional-classname-to-use, $type: null, unordered, ordered or inline);
 
 @mixin list($classname, $type: null) {
   @if $type == null {

--- a/components/vf-sass-config/mixins/_margin.scss
+++ b/components/vf-sass-config/mixins/_margin.scss
@@ -1,3 +1,9 @@
+// Margin, recommended to use with sizing maps
+// @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--lg));
+// margin-block: specify one value for bottom and top, top or bttom
+// margin-all: specify one value for left or right, left or right
+// margin: specify all or a value for each
+
 @mixin margin--block($size1, $size2) {
   @if $size1 == all {
     margin-bottom: $size2;

--- a/components/vf-sass-config/mixins/_padding.scss
+++ b/components/vf-sass-config/mixins/_padding.scss
@@ -1,3 +1,9 @@
+// Padding, recommended to use with sizing maps
+// @include padding--block(bottom, map-get($vf-spacing-map, vf-spacing--lg));
+// padding-block: specify one value for bottom and top, top or bttom
+// padding-all: specify one value for left or right, left or right
+// padding: specify all or a value for each
+
 @mixin padding--block($size1, $size2) {
   @if $size1 == all {
     padding-bottom: $size2;

--- a/components/vf-sass-config/mixins/_text-color.scss
+++ b/components/vf-sass-config/mixins/_text-color.scss
@@ -1,11 +1,5 @@
-// @function choose-contrast-color($color) {
-//   @if (lightness($color) > 50) {
-//     @return #000000; // Lighter backgorund, return dark color
-//   } @else {
-//     @return #ffffff; // Darker background, return light color
-//   }
-// }
-
+// Intelligently pick if white or black should be used as a contrasting colour
+// Currently not used
 
 @mixin choose-contrast-color($n) {
   $color-brightness: round((red($n) * 299) + (green($n) * 587) + (blue($n) * 114) / 1000);
@@ -19,3 +13,11 @@
     color: black;
   }
 }
+
+// @function choose-contrast-color($color) {
+//   @if (lightness($color) > 50) {
+//     @return #000000; // Lighter backgorund, return dark color
+//   } @else {
+//     @return #ffffff; // Darker background, return light color
+//   }
+// }

--- a/components/vf-sass-config/mixins/_typography.scss
+++ b/components/vf-sass-config/mixins/_typography.scss
@@ -1,4 +1,7 @@
-// mixin to generate correct font information when included into an element
+// Generate correct font information when included into an element
+// Recommended to use with typography and sizing maps
+// @include set-type(text-body--3, $global-font-family, $custom-margin-bottom: vf-spacing--lg)
+
 // $custom-margin-bottom: variable, auto, disable
 @mixin set-type($font-size, $global-font-family: $global-font-family, $custom-margin-bottom: auto) {
   @if $global-font-family != $vf-font-family--monospace {

--- a/components/vf-sass-config/mixins/_utility--color.scss
+++ b/components/vf-sass-config/mixins/_utility--color.scss
@@ -1,5 +1,6 @@
+// Generate lists of values in design token maps.
+// Intended for use by the `vf-utility-classes` component
 @mixin color-modifiers($attribute: 'color', $prefix: '-') {
-
   @each $name, $hex in $vf-colors-map {
     $name: str-replace($name, 10);
     &#{$prefix}#{$name} {
@@ -8,9 +9,7 @@
   }
 }
 
-
 @mixin ui-color-modifiers($attribute: 'color', $prefix: '-') {
-
   @each $name, $hex in $vf-ui-colors-map {
     $name: str-replace($name, 13);
     &#{$prefix}#{$name} {

--- a/components/vf-sass-config/mixins/_utility--slide.scss
+++ b/components/vf-sass-config/mixins/_utility--slide.scss
@@ -1,4 +1,6 @@
-// A non-jitter causing way to slide elements up/down on hover
+// A non-jitter causing way to slide elements up/down on hover.
+// @include vf-slide-on-hover($shift-distance, $direction:up);
+//
 // via https://codepen.io/csilverman/post/fixing-the-jitter-bug
 // Basic usage:
 //   .card {

--- a/components/vf-sass-config/mixins/_utility--spacing.scss
+++ b/components/vf-sass-config/mixins/_utility--spacing.scss
@@ -1,3 +1,6 @@
+// Generate lists of values in design token maps.
+// Intended for use by the `vf-utility-classes` component
+
 @mixin spacing-modifiers($attribute: 'padding', $prefix: '-') {
 
   @each $name, $hex in $vf-spacing-map {

--- a/components/vf-sass-config/mixins/_utility--typography.scss
+++ b/components/vf-sass-config/mixins/_utility--typography.scss
@@ -1,5 +1,7 @@
-@mixin type-modifiers() {
+// Generate lists of values in design token maps.
+// Intended for use by the `vf-utility-classes` component
 
+@mixin type-modifiers() {
   @each $font-group, $ruleset in $vf-font--sans-serif {
     &__#{$font-group} {
       font-size: map-get($ruleset, font-size);

--- a/components/vf-sass-config/mixins/_vf-mixins.scss
+++ b/components/vf-sass-config/mixins/_vf-mixins.scss
@@ -1,3 +1,5 @@
+// Rollup of all mixins
+
 @import 'helpers.scss';
 @import 'button.scss';
 @import 'blockquote.scss';

--- a/components/vf-sass-config/mixins/_vf-utility-mixins.scss
+++ b/components/vf-sass-config/mixins/_vf-utility-mixins.scss
@@ -1,3 +1,5 @@
+// Rollup of all utility mixins.
+
 @import '_utility--color.scss';
 @import '_utility--slide.scss';
 @import '_utility--spacing.scss';

--- a/components/vf-sass-config/mixins/vf-disabled.scss
+++ b/components/vf-sass-config/mixins/vf-disabled.scss
@@ -1,3 +1,6 @@
+// For disable link elements, actions
+// @include vf-disabled($vf-link--disabled-color);
+
 
 $vf-link--disabled-color: $vf-link--disabled-color;
 

--- a/components/vf-sass-config/variables/vf-global-custom-properties.scss
+++ b/components/vf-sass-config/variables/vf-global-custom-properties.scss
@@ -1,3 +1,4 @@
+// Native CSS properties, currently limited to document spacing.
 :root {
   --page-grid-gap: 16px;
   --embl-grid-module--prime: 200px;

--- a/components/vf-sass-config/variables/vf-global-variables.scss
+++ b/components/vf-sass-config/variables/vf-global-variables.scss
@@ -1,21 +1,21 @@
+// Global Sass variable defaults for the high-level page look of typography, page width,
+// deprecated component text, if normalisations should be included.
+
 // typography variables
 @import 'vf-font-families.variables.scss';
 $use-global-typography: true !default;
-$global-font-family: $vf-font-family--sans-serif;
-$vf-text-margin--bottom: 16px;
+$global-font-family: $vf-font-family--sans-serif !default;
+$vf-text-margin--bottom: 16px !default;
 
 // grid variables
-
-$global-grid-column-gap: 1em;
-$global-page-max-width: 76.5em;
+$global-grid-column-gap: 1em !default;
+$global-page-max-width: 76.5em !default;
 
 // deprecation variables
-
-$vf-deprecation-warning: 'This component has been deprecated. Consult the component\'s README.md for migration tips.';
+$vf-deprecation-warning: 'This component has been deprecated. Consult the component\'s README.md for migration tips.' !default;
 
 // normalisation variables
 //
 // This is set to true to remove styling that is added to the VF 2.0 codebase from older VF 1.0 code that
 // could also be included on the same page.
-
 $vf-include-normalisations: true !default;

--- a/components/vf-sass-config/variables/vf-variables.scss
+++ b/components/vf-sass-config/variables/vf-variables.scss
@@ -1,3 +1,5 @@
+// Rollup of global Sass variables.
+
 @import 'vf-border-radius.variables.scss';
 @import 'vf-breakpoints.variables.scss';
 @import 'vf-colors.map.scss';

--- a/components/vf-sass-config/vf-sass-config.config.yml
+++ b/components/vf-sass-config/vf-sass-config.config.yml
@@ -1,5 +1,5 @@
 # The title shown on the component page
-title: Sass config functions
+title: Sass config and templates
 # Label shown on index pages
 label: Sass config
 status: beta

--- a/components/vf-sass-config/vf-sass-config.njk
+++ b/components/vf-sass-config/vf-sass-config.njk
@@ -1,0 +1,1 @@
+<!-- no template -->

--- a/tools/vf-frctl-theme/views/partials/pen/browser.njk
+++ b/tools/vf-frctl-theme/views/partials/pen/browser.njk
@@ -3,7 +3,7 @@
 
     <div class="component-info">
       {% if entity.notes %}
-      <div class="component-library-notes">
+      <div class="component-library-notes | vf-content">
       {{ frctl.docs.renderString(entity.notes, renderEnv) | async }}
       </div>
       {% else %}


### PR DESCRIPTION
This follows up on #550 and improves documentation and resolves an issues with broken links appearing in the Utilities section on the VF Core index of components.

This should mostly address #546

Also kills `_vf-variables.shame.scss` which we seem to no longer need 🎉 