### PR TITLE
Bug: design token config was broken

### DIFF
--- a/components/vf-design-tokens/vf-design-tokens.config.js
+++ b/components/vf-design-tokens/vf-design-tokens.config.js
@@ -8,13 +8,7 @@ const path = require('path');
 let fractalConfig = {
 	title: 'Reusable Design Tokens',
   label: 'Design Tokens',
-	status: 'beta',
-  variants: {
-    name: 'default',
-    context: {
-      hidden: "true" // as best i can tell this should hide the default, but it doesn't
-    }
-  }
+	status: 'beta'
 };
 
 // Only generate the tokens if the `/dist` assets have been generated


### PR DESCRIPTION
Fixes an issue caused in #557

Seems I was wrong that you can't mix/match config.yml and config.js (which is great), but for some reason the `variants` I had used in the object was blowing things up. Who knows... _javascript_ 😩