### PR TITLE
ENHANCEMENT: allow component CSS  to proceed

### DIFF
--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -248,7 +248,9 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
         includePaths: sassPaths,
         outputStyle: 'expanded'
       })
-      .on('error', sass.logError))
+      .on('error', function(e){
+        console.log('Couldn\'t find a component dependency, the per-component CSS won\'t be generated for this', e.message);
+      }))
       .pipe(autoprefixer(autoprefixerOptions))
       .pipe(rename(file_name))
       .pipe(gulp.dest(option.dir));


### PR DESCRIPTION
Not really a bug, but something that is obnoxious particularly in sites that consume vf-core.

Currently if a component's index.scss's dependency isn't present the generation of the the `vf-component.css` fails, which makes sense -- however it crashes the gulp task for all the other components, this allows them to still be made.

That is: if `vf-component-1/index.scss` doesn't build, this will allow the build to continue for `vf-component-2/index.scss`