### PR TITLE
FEATURE: Make compiled CSS available as an "asset"

### DIFF
--- a/tools/gulp-tasks/_gulp_rollup.js
+++ b/tools/gulp-tasks/_gulp_rollup.js
@@ -28,7 +28,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   // -----------------------------------------------------------------------------
 
   gulp.task('vf-dev', gulp.series(
-    'vf-clean', 'vf-component-assets', ['vf-css', 'vf-scripts'], 'vf-fractal:start', ['vf-lint:scss-soft-fail', 'vf-watch']
+    'vf-clean', ['vf-css', 'vf-scripts'], 'vf-component-assets', 'vf-fractal:start', ['vf-lint:scss-soft-fail', 'vf-watch']
   ));
 
   gulp.task('vf-prepush-test', gulp.parallel(

--- a/tools/gulp-tasks/vf-assets.js
+++ b/tools/gulp-tasks/vf-assets.js
@@ -15,11 +15,23 @@ module.exports = function(gulp, path, componentPath, buildDestionation) {
       .pipe(gulp.dest(componentPath));
   });
 
-  gulp.task('vf-component-assets', function() {
+  // make each component's `./assets` directory available
+  gulp.task('vf-component-assets:directory', function() {
     return gulp
       .src([componentPath + '/vf-core-components/**/assets/**/*', componentPath + '/**/assets/**/*'])
       .pipe(gulp.dest(buildDestionation + '/assets'));
   });
+
+  // make each component's `./vf-component.css` compiled CSS available
+  gulp.task('vf-component-assets:compiled-css', function() {
+    return gulp
+      .src([componentPath + '/vf-core-components/**/*.css', componentPath + '/**/*.css'])
+      .pipe(gulp.dest(buildDestionation + '/assets'));
+  });
+
+  gulp.task('vf-component-assets', gulp.parallel(
+    'vf-component-assets:directory', 'vf-component-assets:compiled-css'
+  ));
 
   return gulp;
 };


### PR DESCRIPTION
This PR collectes the per-component `index.scss -> vf-component.css` as an asset to be made available alongside any SVGs, JPGs, etc.

![image](https://user-images.githubusercontent.com/928100/64951784-fd614500-d87e-11e9-8ba1-83f6119d43de.png)

Useful for debugging and for edge cases around including one CSS file.