### PR TITLE
ENHANCEMENT: Do not optimise SVGs on `watch`

### DIFF
--- a/tools/gulp-tasks/vf-assets.js
+++ b/tools/gulp-tasks/vf-assets.js
@@ -8,6 +8,9 @@
 module.exports = function(gulp, path, componentPath, buildDestionation) {
   const svgmin = require('gulp-svgmin');
 
+  // Utility task to minify SVGs
+  // After running you should check the quality differences of an SVG, and the
+  // filesize savings.
   gulp.task('vf-svg', () => {
     return gulp
       .src(componentPath + '/**/*.svg')

--- a/tools/gulp-tasks/vf-watch.js
+++ b/tools/gulp-tasks/vf-watch.js
@@ -9,7 +9,6 @@ module.exports = function(gulp, path, componentPath, reload) {
   return gulp.task('vf-watch', function(done) {
     gulp.watch([componentPath + '/**/*.scss', '!' + componentPath + '/**/package.variables.scss'], gulp.series('vf-css')).on('change', reload);
     gulp.watch(componentPath + '/**/*.js', gulp.series('vf-scripts')).on('change', reload);
-    gulp.watch(componentPath + '/**/**/assets/*.svg', gulp.series('vf-svg','vf-component-assets')).on('change', reload);
     gulp.watch([componentPath + '/**/**/assets/*', '!' + componentPath + '/**/**/assets/*.svg'], gulp.series('vf-component-assets')).on('change', reload);
   });
 


### PR DESCRIPTION
As discussed offline in Hinxton, this disables SVG optimisation on watch as:

1. Over-optimisation can degrade SVG quality (particularly around typography hinting) and should be done on an "opt-in" commit basis
2. The SVG watch often resulted in a gulp dev loop

The PR leaves `gulp vf-svg` available but it is not automatically invoked, but remains available as development tool.