### PR TITLE
the one where we update the vf-button component

### DIFF
--- a/components/_previews/_preview.njk
+++ b/components/_previews/_preview.njk
@@ -15,6 +15,11 @@
   {% if _config.project.environment.production %}
   <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
   {% endif %}
+  <style>
+    .vf-component__container {
+      margin: 2em 0;
+    }
+  </style>
 </head>
 <body class="vf-body">
   <div class="vf-grid">

--- a/components/vf-banner/vf-banner.js
+++ b/components/vf-banner/vf-banner.js
@@ -13,7 +13,7 @@
 //       This website uses cookies, and the limiting processing of your personal data to function. By using the site you are agreeing to this as outlined in our <a class="vf-link" href="JavaScript:Void(0);">Privacy Notice</a> and <a class="vf-link" href="JavaScript:Void(0);">Terms Of Use</a>.
 //     </p>
 //
-//     <button class="vf-button vf-text-button--secondary">
+//     <button class="vf-button vf-button--secondary">
 //       {{vf-data-protection-banner__link}}
 //     </button>
 //   </div>
@@ -170,7 +170,7 @@ function vfBannerInsert(banner,bannerId,scope) {
   // if there is a vfJsBannerButtonText and banner is blocking or dismissible,
   // add a button so user can close the banner
   if (banner.vfJsBannerButtonText && (banner.vfJsBannerState === 'blocking' || banner.vfJsBannerState === 'dismissible')) {
-    generatedBannerHtml += '<button class="vf-button vf-text-button--secondary" data-vf-js-banner-close>'+banner.vfJsBannerButtonText+'</button>';
+    generatedBannerHtml += '<button class="vf-button vf-button--secondary" data-vf-js-banner-close>'+banner.vfJsBannerButtonText+'</button>';
   }
 
   generatedBannerHtml += '</div>';

--- a/components/vf-button/CHANGELOG.md
+++ b/components/vf-button/CHANGELOG.md
@@ -2,3 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 1.0.0-beta.7
+
+- Some vf-button classes have been deprecated. [#568](https://github.com/visual-framework/vf-core/pull/568)

--- a/components/vf-button/vf-button.config.yml
+++ b/components/vf-button/vf-button.config.yml
@@ -5,10 +5,7 @@ context:
   component-type: element
 variants:
   - name: default
-    hidden: true
-    context:
-      text: alpha
-  - name: primary
+    label: Primary
     context:
       text: a primary button
       theme: primary

--- a/components/vf-button/vf-button.config.yml
+++ b/components/vf-button/vf-button.config.yml
@@ -21,7 +21,7 @@ variants:
     context:
       text: a small button
       theme: primary
-      size: 2
+      size: sm
   - name: regular
     context:
       text: a regular button
@@ -30,7 +30,7 @@ variants:
     context:
       text: a large button
       theme: primary
-      size: 1
+      size: lg
   - name: pill
     context:
       text: a pill style

--- a/components/vf-button/vf-button.njk
+++ b/components/vf-button/vf-button.njk
@@ -30,7 +30,7 @@ class="vf-button
 {% endif -%}
 {# If you want a size #}
 {%- if size %}
-  vf-text-button--{{size}}
+  vf-button--{{size}}
 {% endif -%}
 {# You want a snowflake of a classname for something, here you go #}
 {%- if override_class %} | {{override_class}}{% endif -%}

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -91,3 +91,47 @@
 
   padding: 16px;
 }
+
+// Begin deprecated classes and styles
+html:not(.vf-disable-deprecated) {
+
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in vf-button v2.0
+  .vf-text-button--secondary {
+    @include button-link($vf-link--color: set-color(vf-color--green), $vf-link--hover-color: set-color(vf-color--green--dark));
+  
+    box-shadow: 0px 6px 0px 0px set-color(vf-color--green--dark);
+    margin-bottom: 6px; // because we're using box-shadow we need to 'create the space' again
+  
+    &:hover {
+      box-shadow: 0px 2px 0px 0px set-color(vf-color--green--dark);
+    }
+  }
+
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in vf-button v2.0
+  .vf--button--outline.vf-text--button--secondary {
+    @include button-link--ghost( $vf-link--color: set-color(vf-color--green) );
+  }
+
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in vf-button v2.0
+  .vf-text-button--2 {
+    @include set-type(text-button--2);
+    padding: 8px;
+  
+    &.vf-text-button--rounded {
+      border-radius: 8px;
+    }
+  }
+
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in vf-button v2.0
+  .vf-text-button--1 {
+    @include set-type(text-button--1);
+  
+    padding: 16px;
+  }
+  
+}
+// End deprecated

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -59,11 +59,11 @@
   }
 
   &.vf-button--secondary {
-    @include button-link--ghost( $vf-link--color: set-color(vf-color--green) )
+    @include button-link--ghost( $vf-link--color: set-color(vf-color--green) );
   }
 
   &.vf-button--tertiary {
-    @include button-link--ghost( $vf-link--color: set-color(vf-color--grey--dark) )
+    @include button-link--ghost( $vf-link--color: set-color(vf-color--grey--dark) );
   }
 }
 

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -10,22 +10,27 @@
   margin: 0;
   padding: 12px;
   text-decoration: none;
-  transition: .01s ease-in-out;
+  transition: all 100ms ease-in-out;
+
+  &:hover {
+    @include vf-slide-on-hover(4px, 'down');
+    transition: all 100ms ease-in-out;
+  }
 }
 
 .vf-button--primary {
-  @include button-link($vf-link--color, $vf-link--hover-color);
+  @include button-link();
 
   box-shadow: 0px 6px 0px 0px $vf-link--hover-color;
   margin-bottom: 6px; // because we're using box-shadow we need to 'create the space' again
 
   &:hover {
     box-shadow: 0px 2px 0px 0px $vf-link--hover-color;
-    @include vf-slide-on-hover(4px, 'down');
+
   }
 }
 
-.vf-text-button--secondary {
+.vf-button--secondary {
   @include button-link($vf-link--color: set-color(vf-color--green), $vf-link--hover-color: set-color(vf-color--green--dark));
 
   box-shadow: 0px 6px 0px 0px set-color(vf-color--green--dark);
@@ -33,7 +38,6 @@
 
   &:hover {
     box-shadow: 0px 2px 0px 0px set-color(vf-color--green--dark);
-    @include vf-slide-on-hover(4px, 'down');
   }
 }
 
@@ -45,7 +49,6 @@
 
   &:hover {
     box-shadow: 0px 2px 0px 0px set-color(vf-color--grey);
-    @include vf-slide-on-hover(4px, 'down');
   }
 }
 
@@ -55,12 +58,12 @@
     @include button-link--ghost;
   }
 
-  &.vf-text-button--secondary {
-    @include button-link--ghost($vf-link--color: set-color(vf-color--green), $vf-link--hover-color: set-color(vf-color--green--dark));
+  &.vf-button--secondary {
+    @include button-link--ghost( $vf-link--color: set-color(vf-color--green) )
   }
 
   &.vf-button--tertiary {
-    @include button-link--ghost($vf-link--color: set-color(vf-color--grey--dark), $vf-link--hover-color: set-color(vf-color--grey));
+    @include button-link--ghost( $vf-link--color: set-color(vf-color--grey--dark) )
   }
 }
 
@@ -72,18 +75,18 @@
   border-radius: $vf-radius--md;
 }
 
-.vf-text-button--2 {
+.vf-button--sm {
   @include set-type(text-button--2);
 
   padding: 8px;
   // @include padding(all, map-get($vf-spacing-map, vf-spacing--sm));
 
-  &.vf-text-button--rounded {
+  &.vf-button--rounded {
     border-radius: 8px;
   }
 }
 
-.vf-text-button--1 {
+.vf-button--lg {
   @include set-type(text-button--1);
 
   padding: 16px;

--- a/components/vf-deprecated/README.md
+++ b/components/vf-deprecated/README.md
@@ -5,4 +5,4 @@
 This component demonstrates a deprecated component.
 
 - See the contents of `vf-deprecated.config.yml`
-- [See the documentation]({{ '../../docs/contributing/deprecating-components' | path }}).
+- [See the documentation](https://visual-framework.github.io/vf-welcome/developing/components/deprecating-components/).

--- a/components/vf-deprecated/vf-deprecated.scss
+++ b/components/vf-deprecated/vf-deprecated.scss
@@ -1,18 +1,15 @@
 // vf-deprecated
 
-// **Thinking about deleting this file?**
-// If your component needs no CSS/Sass, we still recommend leaving the
-// scss files in place. As this is primarily a CSS framework, it is better to
-// leave the empty files so you know a file wasn't accidently omitted.
-// If you don't have any Sass, you can trim this block down to:
-// "This page was intentionally left blank"
-
 // @import 'vf-deprecated.variables.scss';
 
+// Begin deprecated classes and styles
 html:not(.vf-disable-deprecated) {
 
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in v2.0
   .vf-deprecated::before {
     content: 'CSS `:before` content and custom rules that can be conditionally disabled with a parent `.vf-disable-deprecated` selector.';
   }
 
 }
+// End deprecated 

--- a/components/vf-sass-config/mixins/_links.scss
+++ b/components/vf-sass-config/mixins/_links.scss
@@ -37,7 +37,8 @@
 @mixin button-link(
   $vf-link--color: $vf-link--color,
   $vf-link--hover-color: $vf-link--hover-color,
-  $vf-link--visited-color: $vf-link--visited-color) {
+  $vf-link--visited-color: $vf-link--visited-color
+  ) {
 
   background-color: $vf-link--color;
   border: 2px solid $vf-link--color;
@@ -65,11 +66,6 @@
 
   &:visited {
     background-color: $vf-link--visited-color;
-    color: map-get($vf-ui-colors-map, vf-ui-color--white);
-  }
-
-  &:hover {
-    background-color: $vf-link--hover-color;
     color: map-get($vf-ui-colors-map, vf-ui-color--white);
   }
 }

--- a/components/vf-tabs/vf-tabs.scss
+++ b/components/vf-tabs/vf-tabs.scss
@@ -15,19 +15,29 @@ $vf-tabs__list--active-border--color: set-ui-color(vf-ui-color--white);
   padding: 0 0 0px 16px;
   position: relative;
 
-  @media (min-width: $vf-breakpoint--xl) {
-    &::before,
-    &::after {
-      border-bottom: 1px solid $vf-tabs__list-border--color;
-      bottom: -1px;
-      content: '';
-      height: 1px;
-      position: absolute;
-      transform: translateX(-50%);
-      width: 100vw;
-      z-index: 5150;
-    }
-  }
+  // @media (min-width: $vf-breakpoint--xl) {
+  //   &::before {
+  //     border-bottom: 1px solid $vf-tabs__list-border--color;
+  //     bottom: -1px;
+  //     content: '';
+  //     height: 1px;
+  //     position: absolute;
+  //     transform: translateX(-50%);
+  //     width: 100vw;
+  //     z-index: 5150;
+  //   }
+  //
+  //   &::after {
+  //     border-bottom: 1px solid $vf-tabs__list-border--color;
+  //     bottom: -1px;
+  //     content: '';
+  //     height: 1px;
+  //     position: absolute;
+  //     transform: translateX(-50%);
+  //     width: 100vw;
+  //     z-index: 5150;
+  //   }
+  // }
 }
 
 .vf-tabs__item,

--- a/components/vf-tabs/vf-tabs.scss
+++ b/components/vf-tabs/vf-tabs.scss
@@ -13,6 +13,21 @@ $vf-tabs__list--active-border--color: set-ui-color(vf-ui-color--white);
   border-bottom: 1px solid $vf-tabs__list-border--color;
   margin: 0;
   padding: 0 0 0px 16px;
+  position: relative;
+
+  @media (min-width: $vf-breakpoint--xl) {
+    &::before,
+    &::after {
+      border-bottom: 1px solid $vf-tabs__list-border--color;
+      bottom: -1px;
+      content: '';
+      height: 1px;
+      position: absolute;
+      transform: translateX(-50%);
+      width: 100vw;
+      z-index: 5150;
+    }
+  }
 }
 
 .vf-tabs__item,


### PR DESCRIPTION
This PR works on a few things in the `vf-button` component:

- fixes the secondary colours not coming through
- removes background colour on hover of `vf-button--outline` variants
- adds a 150ms transition on hover state so it's a little smoother
- changes the `vf-text-button--1` to `vf-button--sm` etc as ¯\_(ツ)_/¯ why `vf-text-button--1` was there

ancillary things

- removes the `default` button from the component library view - as it's not really a thing
- adds some margin to the top and bottom of components when using the default preview
- makes `vf-tabs` fullwidth with its border as it looks 'odd' on a page that's not `vf-inlay`ed.

