### PR TITLE
Deprecated: some vf-button classes

### DIFF
--- a/components/vf-button/CHANGELOG.md
+++ b/components/vf-button/CHANGELOG.md
@@ -2,3 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 1.0.0-beta.7
+
+- Some vf-button classes have been deprecated. [#568](https://github.com/visual-framework/vf-core/pull/568)

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -91,3 +91,47 @@
 
   padding: 16px;
 }
+
+// Begin deprecated classes and styles
+html:not(.vf-disable-deprecated) {
+
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in vf-button v2.0
+  .vf-text-button--secondary {
+    @include button-link($vf-link--color: set-color(vf-color--green), $vf-link--hover-color: set-color(vf-color--green--dark));
+  
+    box-shadow: 0px 6px 0px 0px set-color(vf-color--green--dark);
+    margin-bottom: 6px; // because we're using box-shadow we need to 'create the space' again
+  
+    &:hover {
+      box-shadow: 0px 2px 0px 0px set-color(vf-color--green--dark);
+    }
+  }
+
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in vf-button v2.0
+  .vf--button--outline.vf-text--button--secondary {
+    @include button-link--ghost( $vf-link--color: set-color(vf-color--green) );
+  }
+
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in vf-button v2.0
+  .vf-text-button--2 {
+    @include set-type(text-button--2);
+    padding: 8px;
+  
+    &.vf-text-button--rounded {
+      border-radius: 8px;
+    }
+  }
+
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in vf-button v2.0
+  .vf-text-button--1 {
+    @include set-type(text-button--1);
+  
+    padding: 16px;
+  }
+  
+}
+// End deprecated

--- a/components/vf-deprecated/README.md
+++ b/components/vf-deprecated/README.md
@@ -5,4 +5,4 @@
 This component demonstrates a deprecated component.
 
 - See the contents of `vf-deprecated.config.yml`
-- [See the documentation]({{ '../../docs/contributing/deprecating-components' | path }}).
+- [See the documentation](https://visual-framework.github.io/vf-welcome/developing/components/deprecating-components/).

--- a/components/vf-deprecated/vf-deprecated.scss
+++ b/components/vf-deprecated/vf-deprecated.scss
@@ -9,10 +9,14 @@
 
 // @import 'vf-deprecated.variables.scss';
 
+// Begin deprecated classes and styles
 html:not(.vf-disable-deprecated) {
 
+  // Deprecated in 1.0.0-beta.7
+  // Will be removed in v2.0
   .vf-deprecated::before {
     content: 'CSS `:before` content and custom rules that can be conditionally disabled with a parent `.vf-disable-deprecated` selector.';
   }
 
 }
+// End deprecated 

--- a/components/vf-deprecated/vf-deprecated.scss
+++ b/components/vf-deprecated/vf-deprecated.scss
@@ -1,12 +1,5 @@
 // vf-deprecated
 
-// **Thinking about deleting this file?**
-// If your component needs no CSS/Sass, we still recommend leaving the
-// scss files in place. As this is primarily a CSS framework, it is better to
-// leave the empty files so you know a file wasn't accidently omitted.
-// If you don't have any Sass, you can trim this block down to:
-// "This page was intentionally left blank"
-
 // @import 'vf-deprecated.variables.scss';
 
 // Begin deprecated classes and styles


### PR DESCRIPTION
This supplements #568 so that the class names changes won't break existing sites and instead deprecates the changes, noting when the deprecated code will be removed.