### PR TITLE
ENHANCEMENT - Require vf-sass-config, vf-design-tokens

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ build
 .gitlab-ci.yml
 temp
 backstop_data
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@frctl/fractal": "^1.2.0-beta.3",
     "@frctl/nunjucks": "^2.0.1",
+    "@visual-framework/vf-design-tokens": "^1.0.0-beta.6",
+    "@visual-framework/vf-sass-config": "^1.0.0-beta.6",
     "chalk": "^2.4.2",
     "fast-glob": "^3.0.4",
     "gulp": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,6 +1042,16 @@
     "@types/events" "*"
     "@types/node" "*"
 
+"@visual-framework/vf-design-tokens@^1.0.0-beta.6":
+  version "1.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@visual-framework/vf-design-tokens/-/vf-design-tokens-1.0.0-beta.6.tgz#9f560d24b48b88403ac4b870898127326fcce13a"
+  integrity sha512-trG+8xlchViNaLhBJGGGWNzOZzB1VsxLCeQYOYDAa+L0nAzgl6g/YfZVdO5TMZaBF1jOEKx95r1AKpFXRf4pPQ==
+
+"@visual-framework/vf-sass-config@^1.0.0-beta.6":
+  version "1.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@visual-framework/vf-sass-config/-/vf-sass-config-1.0.0-beta.6.tgz#b53bdf9299cd7bac42988531b95e739b550aab7c"
+  integrity sha512-YWrKMFTI5JrzsFYtUalBuSePCT8LmgtskLYcbbK6d+VEHymO9yFPlRprphbPNSHUMmnFEl/MUf3AQlDzilcHrw==
+
 "@yarnpkg/lockfile@^1.0.2":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"


### PR DESCRIPTION
You can't do anything useful with vf-core without these two components, so it saves a couple of `yarn add`s and removes a common miss-configuration step. -- For developing vf-core, this won't mean anything practical, however it does help when using it as a dependency.

Also .npmignore-ing yarn.lock makes vf-core a lighter dependency by reducing the number of duplicate similar-version npm packages install, and this ensures that the required vf components are minimums, that is: default to vf-sass-config@v1.0.1, but newer is ok too