### PR TITLE
FEATURE - precompiled nunjucks templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ backstop_data/html_report/
 bitmaps_test/
 temp
 package.variables.scss
+*.precompiled.js

--- a/fractal.js
+++ b/fractal.js
@@ -161,13 +161,14 @@ module.exports = {
 
     // To build the fractal object in memory
     if (mode == 'dataobject') {
-      fractal.set('project.environment.local', 'true');
+      fractal.set('project.environment.production', 'true');
       const server = fractal.web.server();
 
       server.start().then(function(){
-        console.log('The Fractal component data has been generated.')
+        console.log('The Fractal component data has been generated.');
         callback(fractal);
         server.stop();
+        fractal.unwatch(); // exit fractal
       });
       
     }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "prettier-stylelint": "^0.4.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "echo \"Error: no test specified\" && exit 0",
+    "preversion": "gulp vf-build"
   },
   "repository": {
     "type": "git",

--- a/tools/gulp-tasks/_gulp_rollup.js
+++ b/tools/gulp-tasks/_gulp_rollup.js
@@ -29,7 +29,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   // -----------------------------------------------------------------------------
 
   gulp.task('vf-dev', gulp.series(
-    'vf-clean', ['vf-css', 'vf-scripts'], 'vf-component-assets', 'vf-fractal:start', ['vf-lint:scss-soft-fail', 'vf-watch']
+    'vf-clean', ['vf-css', 'vf-scripts'], 'vf-component-assets', 'vf-fractal:start', ['vf-lint:scss-soft-fail', 'vf-templates-precompile', 'vf-watch']
   ));
 
   gulp.task('vf-prepush-test', gulp.parallel(

--- a/tools/gulp-tasks/_gulp_rollup.js
+++ b/tools/gulp-tasks/_gulp_rollup.js
@@ -21,8 +21,9 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   require(path.resolve('.', __dirname + '/vf-scripts.js'))(gulp, path, componentPath, componentDirectories, buildDestionation);
   require(path.resolve('.', __dirname + '/vf-fractal.js'))(gulp, path, componentPath, buildDestionation);
   require(path.resolve('.', __dirname + '/vf-watch.js'))(gulp, path, componentPath, reload);
+  require(path.resolve('.', __dirname + '/vf-templates-precompile.js'))(gulp, path, componentPath);
   require(path.resolve('.', __dirname + '/vf-build.js'))(gulp, buildDestionation);
-
+  
   // -----------------------------------------------------------------------------
   // Main tasks
   // -----------------------------------------------------------------------------

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -22,11 +22,11 @@ module.exports = function(gulp, buildDestionation) {
       gulp.parallel (
         'vf-css:generate-component-css',
         gulp.series('vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
-        'vf-fractal:build'
+        'vf-fractal:build',
+        'vf-templates-precompile'
       ),
       'vf-build:copy-assets'
   ));
-
 
   return gulp;
 };

--- a/tools/gulp-tasks/vf-fractal.js
+++ b/tools/gulp-tasks/vf-fractal.js
@@ -8,18 +8,30 @@
 module.exports = function(gulp, path, componentPath, buildDestionation) {
   const fractalConfig = path.resolve('.', 'fractal.js') ;
 
+  // start fractal in a desired mode, and await it to return the environment
+  let startFractal = function(mode) {
+    return new Promise(function(resolve, reject) {
+      require(fractalConfig).initialize(mode, fractalReadyCallback);
+  
+      function fractalReadyCallback(fractal) {
+        global.fractal = fractal; // "save" fractal so the templates and nunjucks environments are available 
+        resolve();
+      }
+    });
+  }
+
   gulp.task('vf-fractal:start', function(done) {
-    const fractal = require(fractalConfig).initialize('server',fractalReadyCallback);
-    function fractalReadyCallback() {
-      done();
-    }
+    startFractal('server').then(done);
   });
 
   gulp.task('vf-fractal:build', function(done) {
-    const fractal = require(fractalConfig).initialize('build',fractalReadyCallback);
-    function fractalReadyCallback() {
-      done();
-    }
+    global.vfOpenBrowser = false;
+    startFractal('build').then(done);
+  });
+
+  gulp.task('vf-fractal:dataobject', function(done) {
+    global.vfOpenBrowser = false;
+    startFractal('dataobject').then(done);
   });
 
   return gulp;

--- a/tools/gulp-tasks/vf-templates-precompile.js
+++ b/tools/gulp-tasks/vf-templates-precompile.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * Precompile vf-core Nunjucks templates
+ */
+
+module.exports = function(gulp, path, componentPath) {
+
+  const chalk = require('chalk');
+  const fs = require('fs');
+  const nunjucks = require('nunjucks');
+  const fastglob = require('fast-glob');
+  
+  // Precompile vf-core Nunjucks templates
+  // Requires that the fractal environment be initialised first
+  gulp.task('vf-templates-precompile', function(done) {
+
+    const componentList = fastglob.sync([componentPath+'/**/*.njk',componentPath+'/**/**/*.njk'], {
+      allowEmpty: true,
+      objectMode: true
+      // absolute: false 
+      // ignore: [componentPath+'/**/index.scss',componentPath+'/**/**/index.scss',componentPath+'/vf-core-components/vf-core/components/**/*.scss']
+    });
+
+    // bail if fractal hasn't been started
+    if (typeof global.fractal === 'undefined') {
+      console.log(chalk.red('The Fractal environment has not been initialised. Exiting the gulp task and proceeding.'));
+      return done();
+    } 
+
+    // Grab the Nunjucks environment from fractal
+    const env = global.fractal.components._engine._engine;
+
+    componentList.forEach(component => {
+      component.commonName = component.name.replace('.njk','');
+      const vfPackage = `@visual-framework/${component.commonName}`;
+      const src = path.resolve(
+        __dirname,
+        component.path
+      );
+      const dest = path.resolve(
+        __dirname,
+        component.path.replace('.njk', '.precompiled.js')
+      );
+      const front = `/**\n * Precompiled Nunjucks template: ${component.name}\n */\n`;
+      if (!fs.existsSync(src)) {
+        console.log(chalk.yellow(`Missing dependency: ${component.name}`));
+        return;
+      }
+      // console.log(chalk.green(`Precompiling: ${component.commonName}`));
+      const js = (() => {
+        try {
+          return nunjucks.precompile(src, {
+            env: env,
+            name: component.commonName
+          });
+        } catch (err) {
+          console.log(chalk.red(err));
+        }
+      })();
+      if (!js) {
+        return;
+      }
+      fs.writeFileSync(dest, front + js);
+    });
+
+    done();
+
+  });
+
+  // A standalong command to start fractal and build the templates
+  gulp.task('vf-templates-precompile:test', gulp.series(
+    'vf-fractal:dataobject', 'vf-templates-precompile'
+  ));
+  
+  return gulp;
+};
+

--- a/tools/gulp-tasks/vf-watch.js
+++ b/tools/gulp-tasks/vf-watch.js
@@ -9,7 +9,8 @@ module.exports = function(gulp, path, componentPath, reload) {
   return gulp.task('vf-watch', function(done) {
     gulp.watch([componentPath + '/**/*.scss', '!' + componentPath + '/**/package.variables.scss'], gulp.series('vf-css')).on('change', reload);
     gulp.watch(componentPath + '/**/*.js', gulp.series('vf-scripts')).on('change', reload);
-    gulp.watch([componentPath + '/**/**/assets/*', '!' + componentPath + '/**/**/assets/*.svg'], gulp.series('vf-component-assets')).on('change', reload);
+    gulp.watch([componentPath + '/**/*.njk'], gulp.series('vf-templates-precompile'));
+    gulp.watch([componentPath + '/**/**/assets/*'], gulp.series('vf-component-assets')).on('change', reload);
   });
 
 };


### PR DESCRIPTION
For #577

This:

- Largely ports @dbushell 's approach from https://github.com/visual-framework/vf-wp/blob/feature/vf-gutenberg/gulp-tasks/vf-nunjucks.js
- Ensures that the VF has been built before we `lerna publish`, important for this as we're not git commiting the nunjucks templates, but this will also help ensure things are correct (like  components' Sass variables) before going onto npm 7cadeee3
- Optimises the new-ish Fractal dataobject mode 4a9b8790