### PR TITLE
BUG: Correct font demos and monospace mixin

### DIFF
--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -41,7 +41,7 @@
 @import 'vf-utility-mixins.scss';
 
 /* All Visual Framework Font components */
-// @import 'vf-font-plex-mono/vf-font-plex-mono.scss';
+@import 'vf-font-plex-mono/vf-font-plex-mono.scss';
 @import 'vf-font-plex-sans/vf-font-plex-sans.scss';
 
 html, button {

--- a/components/vf-font-plex-mono/README.md
+++ b/components/vf-font-plex-mono/README.md
@@ -4,6 +4,8 @@
 
 ## About
 
+Makes `IBM Plex Mono` font-family with a weight of 400 available to your Sass/CSS and other higher-level components.
+
 ## Install
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-font-plex-mono` with this command.

--- a/components/vf-font-plex-mono/vf-font-plex-mono.config.yml
+++ b/components/vf-font-plex-mono/vf-font-plex-mono.config.yml
@@ -2,4 +2,8 @@ title: Plex Mono Font
 label: Plex Mono Font
 status: beta
 context:
-  component-type: block
+  component-type: utility
+variants:
+  - name: default
+    context:
+      text: I'm vf-font-plex-mono.

--- a/components/vf-font-plex-mono/vf-font-plex-mono.njk
+++ b/components/vf-font-plex-mono/vf-font-plex-mono.njk
@@ -1,15 +1,1 @@
-<div class="vf-activity">
-  <p class="vf-activity__date">Tuesday 20th February 2018</p>
-  <ul class="vf-activity__list | vf-list">
-    <li class="vf-activity__item">
-      <strong>Sonia Furtado Neves</strong> published <a href="JavaScript:Void(0);">'The Future of Training'</a> on <a href="JavaScript:Void(0);">EMBL News</a>.
-    </li>
-    <li class="vf-activity__item">
-      <strong>Sonia Furtado Neves</strong> published <a href="JavaScript:Void(0);">'The Future of Training'</a> on <a href="JavaScript:Void(0);">EMBL News</a>.
-    </li>
-    <li class="vf-activity__item">
-      <strong>Mark Boulton</strong> updated <a href="JavaScript:Void(0);">Digital Strategy</a> on <a href="JavaScript:Void(0);">Gitlab</a> to version 1.1, with the comment:
-      <blockquote class="vf-activity__blockquote | vf-blockquote">Additional detail added to social section.</blockquote>
-    </li>
-  </ul>
-</div>
+<div class="vf-font-plex-mono">{{ text }}</div>

--- a/components/vf-font-plex-mono/vf-font-plex-mono.scss
+++ b/components/vf-font-plex-mono/vf-font-plex-mono.scss
@@ -10,4 +10,8 @@
  */
 
 $font-prefix: '../assets/vf-font-plex-mono/assets' !default;
-@import 'assets/scss/ibm-plex.scss'
+@import 'assets/scss/ibm-plex.scss';
+
+.vf-font-plex-mono {
+  @include set-type(text-body--1,$vf-font-family--monospace, $custom-margin-bottom: 0);
+}

--- a/components/vf-font-plex-sans/README.md
+++ b/components/vf-font-plex-sans/README.md
@@ -4,6 +4,8 @@
 
 ## About
 
+Makes `IBM Plex Sans` font-family in various weights and italic available to your Sass/CSS and other higher-level components.
+
 ## Install
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-font-plex-sans` with this command.

--- a/components/vf-font-plex-sans/vf-font-plex-sans.config.yml
+++ b/components/vf-font-plex-sans/vf-font-plex-sans.config.yml
@@ -2,4 +2,8 @@ title: Plex Sans Font
 label: Plex Sans Font
 status: beta
 context:
-  component-type: block
+  component-type: utility
+variants:
+  - name: default
+    context:
+      text: I'm vf-font-plex-sans.

--- a/components/vf-font-plex-sans/vf-font-plex-sans.njk
+++ b/components/vf-font-plex-sans/vf-font-plex-sans.njk
@@ -1,15 +1,1 @@
-<div class="vf-activity">
-  <p class="vf-activity__date">Tuesday 20th February 2018</p>
-  <ul class="vf-activity__list | vf-list">
-    <li class="vf-activity__item">
-      <strong>Sonia Furtado Neves</strong> published <a href="JavaScript:Void(0);">'The Future of Training'</a> on <a href="JavaScript:Void(0);">EMBL News</a>.
-    </li>
-    <li class="vf-activity__item">
-      <strong>Sonia Furtado Neves</strong> published <a href="JavaScript:Void(0);">'The Future of Training'</a> on <a href="JavaScript:Void(0);">EMBL News</a>.
-    </li>
-    <li class="vf-activity__item">
-      <strong>Mark Boulton</strong> updated <a href="JavaScript:Void(0);">Digital Strategy</a> on <a href="JavaScript:Void(0);">Gitlab</a> to version 1.1, with the comment:
-      <blockquote class="vf-activity__blockquote | vf-blockquote">Additional detail added to social section.</blockquote>
-    </li>
-  </ul>
-</div>
+<div class="vf-font-plex-sans">{{ text }}</div>

--- a/components/vf-font-plex-sans/vf-font-plex-sans.scss
+++ b/components/vf-font-plex-sans/vf-font-plex-sans.scss
@@ -10,4 +10,8 @@
  */
 
 $font-prefix: '../assets/vf-font-plex-sans/assets' !default;
-@import 'assets/scss/ibm-plex.scss'
+@import 'assets/scss/ibm-plex.scss';
+
+.vf-font-plex-sans {
+  @include set-type(text-body--3,$vf-font-family--sans-serif, $custom-margin-bottom: 0);
+}

--- a/components/vf-sass-config/mixins/_typography.scss
+++ b/components/vf-sass-config/mixins/_typography.scss
@@ -39,6 +39,7 @@
   }
   @else {
 
+    font-family: $vf-font-family--monospace;
     $map-font-family: $vf-fonts--monospace;
     font-size: map-deep-get($map-font-family, $font-size, font-size);
     @if map-deep-get($map-font-family, $font-size, font-weight) == 400 {


### PR DESCRIPTION
@esanzgar noted that the NJK templates for `vf-font-plex-sans` and `vf-font-plex-mono` weren't actually showing the fonts, rather they seem to accidentally have the `vf-activity` njk template.

This addresses that. It also addresses:

- Monospace component wasn't in vf-rollup, so it wasn't included in https://dev.assets.emblstatic.net/vf/develop/css/styles.css
-  an issue in the `_typography.scss` mixin where the `font-family` prop wasn't being set (gif to follow).

![Kapture 2019-10-02 at 11 16 25](https://user-images.githubusercontent.com/928100/66033458-980c8580-e507-11e9-8489-68bea3fce96d.gif)
