### PR TITLE
bug: fix-font-css-import

### DIFF
--- a/components/vf-font-plex-mono/vf-font-plex-mono.scss
+++ b/components/vf-font-plex-mono/vf-font-plex-mono.scss
@@ -10,7 +10,7 @@
  */
 
 $font-prefix: '../assets/vf-font-plex-mono/assets' !default;
-@import 'assets/scss/ibm-plex.scss';
+@import 'vf-font-plex-mono/assets/scss/ibm-plex.scss';
 
 .vf-font-plex-mono {
   @include set-type(text-body--1,$vf-font-family--monospace, $custom-margin-bottom: 0);

--- a/components/vf-font-plex-sans/vf-font-plex-sans.scss
+++ b/components/vf-font-plex-sans/vf-font-plex-sans.scss
@@ -10,7 +10,7 @@
  */
 
 $font-prefix: '../assets/vf-font-plex-sans/assets' !default;
-@import 'assets/scss/ibm-plex.scss';
+@import 'vf-font-plex-sans/assets/scss/ibm-plex.scss';
 
 .vf-font-plex-sans {
   @include set-type(text-body--3,$vf-font-family--sans-serif, $custom-margin-bottom: 0);


### PR DESCRIPTION
Sass was getting confused and accidently importing the Plex Sans sass in Plex Mono. This wasn't evident before #587 as we weren't actually using the mono font Sass.