### PR TITLE
Component/vf tree enhancements

### DIFF
--- a/components/vf-tree/README.md
+++ b/components/vf-tree/README.md
@@ -2,6 +2,14 @@
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-tree.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-tree)
 
+A collapsable tree list suited for list displays or deep navigation structures.
+
+There are several paramaters availabl when using the Nunjucks template:
+
+- `expanded: true` Control if the entire tree is expanded/collpased
+- `sublist` if an object of `title`s the item will be shown as a group
+- `artiveTrail: true` Highlights a tree as an active path and if it is a sublist, opens it
+
 ## Install
 
 This repository is distributed with [npm][npm]. After [installing npm][install-npm], you can install `vf-tree` with this command.

--- a/components/vf-tree/vf-tree.config.yml
+++ b/components/vf-tree/vf-tree.config.yml
@@ -44,6 +44,7 @@ variants:
 
   - name: open
     context:
+      collapsed: false
       vf_tree_list:
         - title: Course Overview
           sublist: false
@@ -66,6 +67,7 @@ variants:
   - name: one level
     label: open one level
     context:
+      collapsed: false
       vf_tree_list:
         - title: Course Overview
           sublist: false
@@ -94,6 +96,7 @@ variants:
   - name: two level
     label: open two level
     context:
+      collapsed: false
       vf_tree_list:
         - title: Course Overview
           sublist: false

--- a/components/vf-tree/vf-tree.config.yml
+++ b/components/vf-tree/vf-tree.config.yml
@@ -14,21 +14,37 @@ variants:
         - title: Course Overview
           sublist: false
         - title: What is bioinformatics?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: The role of public databases
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: What makes a good bioinformatics database?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Tips on managing and sharing data?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Where do I submit my data?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Using ontologies to provide controlled vocabularies
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Summary
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Get help and support
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
   - name: open 1
     label: Level 1
     context:
@@ -37,32 +53,51 @@ variants:
         - title: Course Overview
           sublist: false
         - title: What is bioinformatics?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: The role of public databases
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: What makes a good bioinformatics database?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Tips on managing and sharing data?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Where do I submit my data?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Using ontologies to provide controlled vocabularies
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Summary
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Get help and support
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
   - name: open 2
     label: Level 2
     context:
       collapsed: false
       vf_tree_list:
         - title: Course Overview
-          sublist: false
         - title: What is bioinformatics?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: The role of public databases
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: What makes a good bioinformatics database?
           expanded: true
           currentParent: true
@@ -72,15 +107,25 @@ variants:
             - title: Minimum information standards
             - title: Controlled vocabularies
         - title: Tips on managing and sharing data?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Where do I submit my data?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Using ontologies to provide controlled vocabularies
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Summary
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Get help and support
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
   - name: open 3
     label: Level 3
     context:
@@ -89,9 +134,13 @@ variants:
         - title: Course Overview
           sublist: false
         - title: What is bioinformatics?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: The role of public databases
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: What makes a good bioinformatics database?
           expanded: true
           currentParent: true
@@ -108,12 +157,22 @@ variants:
                 - title: Thesaurus
                 - title: Gene Ontology
         - title: Tips on managing and sharing data?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Where do I submit my data?
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Using ontologies to provide controlled vocabularies
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Summary
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems
         - title: Get help and support
-          sublist: true
+          expanded: false
+          sublist:
+            - title: Subitems

--- a/components/vf-tree/vf-tree.config.yml
+++ b/components/vf-tree/vf-tree.config.yml
@@ -7,7 +7,7 @@ context:
   tree_example_href: 'JavaScript:Void(0);'
 variants:
   - name: default
-    label: closed
+    label: Closed
     context:
       collapsed: true
       vf_tree_list:
@@ -18,19 +18,7 @@ variants:
         - title: The role of public databases
           sublist: true
         - title: What makes a good bioinformatics database?
-          expanded: true
-          currentParent: true
-          sublist:
-            - title: Primary and secondary databases
-            - title: Describing data consistently
-            - title: Minimum information standards
-            - title: Controlled vocabularies
-              sublist:
-                - title: Non-heirarchial list
-                  currentChild: true
-                - title: Taxonomy
-                - title: Thesaurus
-                - title: Gene Ontology
+          sublist: true
         - title: Tips on managing and sharing data?
           sublist: true
         - title: Where do I submit my data?
@@ -41,8 +29,8 @@ variants:
           sublist: true
         - title: Get help and support
           sublist: true
-
-  - name: open
+  - name: open 1
+    label: Level 1
     context:
       collapsed: false
       vf_tree_list:
@@ -64,8 +52,8 @@ variants:
           sublist: true
         - title: Get help and support
           sublist: true
-  - name: one level
-    label: open one level
+  - name: open 2
+    label: Level 2
     context:
       collapsed: false
       vf_tree_list:
@@ -93,8 +81,8 @@ variants:
           sublist: true
         - title: Get help and support
           sublist: true
-  - name: two level
-    label: open two level
+  - name: open 3
+    label: Level 3
     context:
       collapsed: false
       vf_tree_list:

--- a/components/vf-tree/vf-tree.config.yml
+++ b/components/vf-tree/vf-tree.config.yml
@@ -100,10 +100,10 @@ variants:
             - title: Describing data consistently
             - title: Minimum information standards
             - title: Controlled vocabularies
+              expanded: true
               sublist:
                 - title: Non-heirarchial list
                   currentChild: true
-                  expanded: true
                 - title: Taxonomy
                 - title: Thesaurus
                 - title: Gene Ontology

--- a/components/vf-tree/vf-tree.config.yml
+++ b/components/vf-tree/vf-tree.config.yml
@@ -9,7 +9,7 @@ variants:
   - name: default
     label: Closed
     context:
-      collapsed: true
+      expanded: false
       vf_tree_list:
         - title: Course Overview
           sublist: false
@@ -48,7 +48,7 @@ variants:
   - name: open 1
     label: Level 1
     context:
-      collapsed: false
+      expanded: true
       vf_tree_list:
         - title: Course Overview
           sublist: false
@@ -87,7 +87,7 @@ variants:
   - name: open 2
     label: Level 2
     context:
-      collapsed: false
+      expanded: true
       vf_tree_list:
         - title: Course Overview
         - title: What is bioinformatics?
@@ -129,7 +129,7 @@ variants:
   - name: open 3
     label: Level 3
     context:
-      collapsed: false
+      expanded: true
       vf_tree_list:
         - title: Course Overview
           sublist: false

--- a/components/vf-tree/vf-tree.config.yml
+++ b/components/vf-tree/vf-tree.config.yml
@@ -100,7 +100,7 @@ variants:
             - title: Subitems
         - title: What makes a good bioinformatics database?
           expanded: true
-          currentParent: true
+          artiveTrail: true
           sublist:
             - title: Primary and secondary databases
             - title: Describing data consistently
@@ -143,7 +143,7 @@ variants:
             - title: Subitems
         - title: What makes a good bioinformatics database?
           expanded: true
-          currentParent: true
+          artiveTrail: true
           sublist:
             - title: Primary and secondary databases
             - title: Describing data consistently
@@ -152,7 +152,7 @@ variants:
               expanded: true
               sublist:
                 - title: Non-heirarchial list
-                  currentChild: true
+                  artiveTrail: true
                 - title: Taxonomy
                 - title: Thesaurus
                 - title: Gene Ontology

--- a/components/vf-tree/vf-tree.njk
+++ b/components/vf-tree/vf-tree.njk
@@ -1,3 +1,23 @@
+{% set vfTreeButton %}
+<button href="{{ tree_example_href }}" class="vf-button vf-tree__button">
+  <svg width="8" height="13" xmlns="http://www.w3.org/2000/svg"><g stroke="" stroke-width="1.6" fill="none" fill-rule="evenodd" stroke-linecap="square"><path d="M1.417 1.275L6 6.326M6 6.105l-4.583 5.61"/></g></svg>
+</button>
+{% endset %}
+
+{% macro vfTreeList(list, currentDepth=1) %}
+  <ul class="vf-tree__list {% if currentDepth > 1 %}vf-tree__list--additional{% endif %} vf-tree__list--{{ currentDepth }} | vf-list" aria-role="{% if currentDepth == 1 %}tree{% else %}group{% endif %}">
+  {% for item in list %}
+    <li class="vf-tree__item {%- if item.artiveTrail == true %} vf-tree__item--selected{% endif -%}{% if item.expanded == true %} | vf-tree__item--expanded{% endif -%}" aria-role="treeitem">
+      <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.artiveTrail == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
+      {% if item.sublist %}{{ vfTreeButton }}{% endif %}
+      {% if item.sublist and item.expanded %}
+        {{ vfTreeList(item.sublist, currentDepth+1) }}
+      {% endif %}
+    </li>
+  {% endfor %}
+  </ul>
+{% endmacro %}
+
 <div class="vf-tree{% if expanded === false %} vf-tree--collapsed{% endif %}" {% if expanded === false %}data-vf-tree--collapsed="true"{% endif %}>
   <span class="vf-show-hide">
     <button class="vf-button | vf-show-hide__button">
@@ -6,44 +26,6 @@
   </span>
 
   <ul class="vf-tree__list | vf-list" aria-role="tree">
-    {% for item in vf_tree_list %}
-    <li class="vf-tree__item {%- if item.artiveTrail == true %} vf-tree__item--selected{% endif -%}{% if item.expanded == true %} | vf-tree__item--expanded"{% endif -%}" aria-role="treeitem">
-      <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.artiveTrail == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
-      {% if item.sublist %}
-      <button href="{{ tree_example_href }}" class="vf-button vf-tree__button">
-        <svg width="8" height="13" xmlns="http://www.w3.org/2000/svg"><g stroke="" stroke-width="1.6" fill="none" fill-rule="evenodd" stroke-linecap="square"><path d="M1.417 1.275L6 6.326M6 6.105l-4.583 5.61"/></g></svg>
-      </button>
-      {% endif %}
-      {% if item.sublist and item.expanded %}
-      <ul class="vf-tree__list vf-tree__list--additional vf-tree__list--secondary | vf-list" aria-role="group">
-        {% for item in item.sublist %}
-        <li class="vf-tree__item{%- if item.artiveTrail == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem">
-          <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.artiveTrail == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
-          {% if item.sublist and item.expanded %}
-          <ul class="vf-tree__list vf-tree__list--additional vf-tree__list--tertiary | vf-list" aria-role="treeitem">
-            {% for item in item.sublist %}
-            <li class="vf-tree__item
-            {%- if item.artiveTrail == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem">
-              <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.artiveTrail == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
-              {% if item.sublist %}
-              <ul class="vf-tree__list vf-tree__list--additional vf-tree__list--quaternary | vf-list" aria-role="treeitem">
-                {% for item in item.sublist %}
-                <li class="vf-tree__item
-                {%- if item.artiveTrail == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem"> <!-- quaternary item open -->
-                  <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.artiveTrail == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
-                </li>
-              {% endfor %}
-              </ul>
-            {% endif %}
-            </li>
-          {% endfor %}
-          </ul>
-        {% endif %}
-        </li>
-      {% endfor %}
-      </ul>
-    {% endif %}
-    </li>
-  {% endfor %}
+    {{ vfTreeList(vf_tree_list) }}
   </ul>
 </div>

--- a/components/vf-tree/vf-tree.njk
+++ b/components/vf-tree/vf-tree.njk
@@ -14,12 +14,12 @@
         <svg width="8" height="13" xmlns="http://www.w3.org/2000/svg"><g stroke="" stroke-width="1.6" fill="none" fill-rule="evenodd" stroke-linecap="square"><path d="M1.417 1.275L6 6.326M6 6.105l-4.583 5.61"/></g></svg>
       </button>
       {% endif %}
-      {% if item.sublist %}
+      {% if item.sublist and item.expanded %}
       <ul class="vf-tree__list vf-tree__list--additional vf-tree__list--secondary | vf-list" aria-role="group">
         {% for item in item.sublist %}
         <li class="vf-tree__item{%- if item.currentChild == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem">
           <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.currentChild == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
-          {% if item.sublist %}
+          {% if item.sublist and item.expanded %}
           <ul class="vf-tree__list vf-tree__list--additional vf-tree__list--tertiary | vf-list" aria-role="treeitem">
             {% for item in item.sublist %}
             <li class="vf-tree__item

--- a/components/vf-tree/vf-tree.njk
+++ b/components/vf-tree/vf-tree.njk
@@ -7,8 +7,8 @@
 
   <ul class="vf-tree__list | vf-list" aria-role="tree">
     {% for item in vf_tree_list %}
-    <li class="vf-tree__item {%- if item.currentParent == true %} vf-tree__item--selected{% endif -%}{% if item.expanded == true %} | vf-tree__item--expanded"{% endif -%}" aria-role="treeitem">
-      <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.currentParent == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
+    <li class="vf-tree__item {%- if item.artiveTrail == true %} vf-tree__item--selected{% endif -%}{% if item.expanded == true %} | vf-tree__item--expanded"{% endif -%}" aria-role="treeitem">
+      <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.artiveTrail == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
       {% if item.sublist %}
       <button href="{{ tree_example_href }}" class="vf-button vf-tree__button">
         <svg width="8" height="13" xmlns="http://www.w3.org/2000/svg"><g stroke="" stroke-width="1.6" fill="none" fill-rule="evenodd" stroke-linecap="square"><path d="M1.417 1.275L6 6.326M6 6.105l-4.583 5.61"/></g></svg>
@@ -17,20 +17,20 @@
       {% if item.sublist and item.expanded %}
       <ul class="vf-tree__list vf-tree__list--additional vf-tree__list--secondary | vf-list" aria-role="group">
         {% for item in item.sublist %}
-        <li class="vf-tree__item{%- if item.currentChild == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem">
-          <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.currentChild == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
+        <li class="vf-tree__item{%- if item.artiveTrail == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem">
+          <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.artiveTrail == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
           {% if item.sublist and item.expanded %}
           <ul class="vf-tree__list vf-tree__list--additional vf-tree__list--tertiary | vf-list" aria-role="treeitem">
             {% for item in item.sublist %}
             <li class="vf-tree__item
-            {%- if item.currentChild == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem">
-              <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.currentChild == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
+            {%- if item.artiveTrail == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem">
+              <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.artiveTrail == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
               {% if item.sublist %}
               <ul class="vf-tree__list vf-tree__list--additional vf-tree__list--quaternary | vf-list" aria-role="treeitem">
                 {% for item in item.sublist %}
                 <li class="vf-tree__item
-                {%- if item.currentChild == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem"> <!-- quaternary item open -->
-                  <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.currentChild == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
+                {%- if item.artiveTrail == true %} vf-tree__item--selected{% endif -%}" aria-role="treeitem"> <!-- quaternary item open -->
+                  <a href="{{ tree_example_href }}" class="vf-tree__link" {%- if item.artiveTrail == true %} aria-current="page"{% endif %}>{{ item.title }}</a>
                 </li>
               {% endfor %}
               </ul>

--- a/components/vf-tree/vf-tree.njk
+++ b/components/vf-tree/vf-tree.njk
@@ -1,4 +1,4 @@
-<div class="vf-tree{% if collapsed %} vf-tree--collapsed{% endif %}" {% if collapsed %}data-vf-tree--collapsed="true"{% endif %}>
+<div class="vf-tree{% if expanded === false %} vf-tree--collapsed{% endif %}" {% if expanded === false %}data-vf-tree--collapsed="true"{% endif %}>
   <span class="vf-show-hide">
     <button class="vf-button | vf-show-hide__button">
       <svg width="13" height="13" xmlns="http://www.w3.org/2000/svg"><g stroke="" stroke-width="1.6" fill="none" fill-rule="evenodd" stroke-linecap="square"><path d="M6.583 11.725L2 6.674M2 6.895l4.583-5.61"/><path d="M11.583 11.725L7 6.674M7 6.895l4.583-5.61"/></g></svg>


### PR DESCRIPTION
This PR would need to be merged into the `component/vf-tree` branch.

This doesn't really change the behaviour but rather tries to improve consistency in some places, which was probably a byproduct of some of the obstacles in development. 

I've tried to break down the changes into chunks with commit comments to make things easier to follow; here's a quick link out:

1. Add placeholders for `collapsed` … a8fd47f
Although it does nothing, I think this makes the behaviour easier to understand.
1. A bit more of a programmatic naming convention 764beab
1. Respect the expanded state a8763c5
1. Improve demo-ability of YML … ce4c47c
Rather than saying `sublist: true`, add a stub list and set it to not expanded
1. Use only `expanded` … b66e9c1
Probably simpler than using `expanded` in some places and `collapsed` in others.  Maybe should also change `.vf-tree--collapsed`?
1. In place of `currentParent` and `currentChild` use `activeTrail` 5965652
1. Optimise NJK file … 5451c77
This is probably a pre-mature optimisation, but I think it demonstrates how we can make the code tidier with the standardising of the Yaml values.
1. Protodocumentation …8d4db14
Some notes that I had made as I was going through.