### PR TITLE
Bug: watch should ignore precompiled templates

### DIFF
--- a/tools/gulp-tasks/vf-watch.js
+++ b/tools/gulp-tasks/vf-watch.js
@@ -8,7 +8,7 @@
 module.exports = function(gulp, path, componentPath, reload) {
   return gulp.task('vf-watch', function(done) {
     gulp.watch([componentPath + '/**/*.scss', '!' + componentPath + '/**/package.variables.scss'], gulp.series('vf-css')).on('change', reload);
-    gulp.watch(componentPath + '/**/*.js', gulp.series('vf-scripts')).on('change', reload);
+    gulp.watch([componentPath + '/**/*.js', '!' + componentPath + '/**/*.precompiled.js'], gulp.series('vf-scripts')).on('change', reload);
     gulp.watch([componentPath + '/**/*.njk'], gulp.series('vf-templates-precompile'));
     gulp.watch([componentPath + '/**/**/assets/*'], gulp.series('vf-component-assets')).on('change', reload);
   });


### PR DESCRIPTION
Sometimes the updating of NJK precompiled templates would cause a `watch` loop.