### PR TITLE
Bug: Unset EBI link style on hover for links

### DIFF
--- a/components/ebi-vf1-integration/ebi-vf1-integration.scss
+++ b/components/ebi-vf1-integration/ebi-vf1-integration.scss
@@ -74,6 +74,7 @@ body.ebi-vf1-integration,
   
   a:hover {
     text-decoration: unset;
+    border-bottom-style: unset;
   }  
   
   // EBI Global header and local masthead


### PR DESCRIPTION
Fixes an issue as seen on the header here on hover http://ebiwd.gitdocs.ebi.ac.uk/ebi-academy-terrified/

It's a more general issue that's worth getting on all `a:hover`

This might all need a refactor once we make links not underlined 😭