### PR TITLE
bug: vf-tree-scss-missing-import

### DIFF
--- a/components/vf-tree/vf-tree.scss
+++ b/components/vf-tree/vf-tree.scss
@@ -1,5 +1,6 @@
 // vf-tree
 
+@import 'package.variables.scss';
 // Debug information from component's `package.json`:
 // ---
 /*!


### PR DESCRIPTION
Missing its `@import 'package.variables.scss';`

This blocks correct generation of the component-level css