### PR TITLE
Bug: Fix Fractal config path

### DIFF
--- a/tools/gulp-tasks/vf-fractal.js
+++ b/tools/gulp-tasks/vf-fractal.js
@@ -1,18 +1,20 @@
 'use strict';
 
+// const resolve = require('path').resolve
+
 /**
  * Expose vf-fractal gulp tasks as a JS module
  * This makes dependency management a bit cleaner
  */
 
-module.exports = function(gulp, path, componentPath, buildDestionation) {
-  const fractalConfig = path.resolve('.', 'fractal.js') ;
+module.exports = function(gulp, path) {
 
   // start fractal in a desired mode, and await it to return the environment
   let startFractal = function(mode) {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve, ) {
+      const fractalConfig = path.resolve(__dirname, '../../fractal.js').replace(/\\/g, '/');
       require(fractalConfig).initialize(mode, fractalReadyCallback);
-  
+
       function fractalReadyCallback(fractal) {
         global.fractal = fractal; // "save" fractal so the templates and nunjucks environments are available 
         resolve();


### PR DESCRIPTION
In #613 David noticed there was something off with the Fractal config path.

This PR fixes the behaviour to be as intended: for vf-core to always use the vf-core's `fractal.js` config (client projects aren't expected to bring their own Fractal config).

This fixes that bug, but also raises a couple things:

- Option A: Should `vf-build` be only used by `vf-core`? I think David's experience suggests it has value to other projects
- Option B: We support client projects using `vf-build`, but we need to add some parameter so that the correct Fractal build mode is invoked (or not at all, when it's not needed)

That's probably a separate issue/PR -- best to get this bug fixed first as although `vf-build` could be faster, it at least works with this fix.