### PR TITLE
Feature: add fractalBuildMode

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,6 +40,10 @@ global.vfComponentPath = config.vfConfig.vfComponentPath || path.resolve('.', __
 global.vfBuildDestination = config.vfConfig.vfBuildDestination || __dirname + '/temp/build-files';
 global.vfThemePath = config.vfConfig.vfThemePath || './tools/vf-frctl-theme';
 global.vfVersion = vfCoreConfig.version || 'not-specified';
+global.vfBuildFractalMode = vfCoreConfig.vfConfig.vfBuildFractalMode || 'normal'; 
+  // in vf-build specifices to run fractal as 'normal' full build of static assets,
+  // 'dataobject' to render only to memory or
+  // 'none' to not build at all
 const componentPath = path.resolve('.', global.vfComponentPath).replace(/\\/g, '/');
 const componentDirectories = config.vfConfig.vfComponentDirectories || ['vf-core-components'];
 const buildDestionation = path.resolve('.', global.vfBuildDestination).replace(/\\/g, '/');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "vfConfig": {
     "vfNamespace": "vf-",
     "vfName": "Visual Framework 2.0",
-    "vfHomepage": "https://visual-framework.github.io/vf-core"
+    "vfHomepage": "https://visual-framework.github.io/vf-core",
+    "vfBuildFractalMode": "normal"
   },
   "dependencies": {
     "@frctl/fractal": "^1.2.0-beta.3",

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -14,6 +14,31 @@ module.exports = function(gulp, buildDestionation) {
       console.info('Copied `/temp/build-files` assets.');
   });
 
+  // Support for client projects using vf-build
+  // but we need to see which Fractal build mode to invoke (or not at all, when it's not needed)
+  let gulpFractalBuildTask;
+  switch (global.vfBuildFractalMode) {
+    case 'dataObject':
+      // just render the objects to memory for further use
+      gulpFractalBuildTask = 'vf-fractal:dataobject';
+      break;
+    case 'none':
+      // don't invoke fractal at all
+      gulpFractalBuildTask = 'vf-build:fractaldummybuild';
+      break;
+      console.error('Fractal build mode not supplied.');
+    default:
+    case 'normal':
+      // standard full build of all static html for components
+      gulpFractalBuildTask = 'vf-fractal:build';
+      break;
+  }
+
+  gulp.task('vf-build:fractaldummybuild', function (done) {
+    // an empty task as we can't run no gulp task using this approach
+    done();
+  });
+
   // Rollup all-in-one build as a static site for CI
   gulp.task('vf-build',
     gulp.series(
@@ -22,8 +47,7 @@ module.exports = function(gulp, buildDestionation) {
       gulp.parallel (
         'vf-css:generate-component-css',
         gulp.series('vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
-        'vf-fractal:build',
-        'vf-templates-precompile'
+        gulp.series(gulpFractalBuildTask, 'vf-templates-precompile')
       ),
       'vf-build:copy-assets'
   ));


### PR DESCRIPTION
This realtes to #613, better allowing client projects to run `gulp vf-build` by allowing them to indicate how Fractal should be built.

>   // in vf-build specifices to run fractal as 'normal' full build of static assets,
>  // 'dataobject' to render only to memory or
>  // 'none' to not build at all

This should finish 613.

Next up should be to move the configuration block of text into an npm module and add documentation for it.