### PR TITLE
Feature: move config to npm

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,48 +1,11 @@
 'use strict';
 
-const gulp = require('gulp');
-
-// -----------------------------------------------------------------------------
-// Configuration
-// -----------------------------------------------------------------------------
-
-// Pull in some optional configuration from the package.json file, a la:
-// "vfConfig": {
-//   "vfName": "My Component Library",
-//   "vfNameSpace": "myco-",
-//   "vfComponentPath": "./src/components",
-//   "vfComponentDirectories": [
-//      "vf-core-components",
-//      "../node_modules/your-optional-collection-of-dependencies"
-//     NOTE: Don't forget to symlink: `cd components` `ln -s ../node_modules/your-optional-collection-of-dependencies`
-//    ],
-//   "vfBuildDestination": "./build",
-//   "vfThemePath": "@frctl/mandelbrot"
-// },
-// all settings are optional
-// todo: this could/should become a JS module
 const fs = require('fs');
 const path = require('path');
-const config = JSON.parse(fs.readFileSync('./package.json'));
-// Load the vf-core package.json config
-let vfCoreConfig;
-if (config.name === '@visual-framework/vf-core') {
-  // if being run from within the vf-core project, use the local package.json
-  vfCoreConfig = JSON.parse(fs.readFileSync('./package.json'));
-} else {
-  // load vfCoreConfig from node_modules
-  vfCoreConfig = JSON.parse(fs.readFileSync(require.resolve('@visual-framework/vf-core/package.json')));
-}
-config.vfConfig = config.vfConfig || [];
-global.vfName = config.vfConfig.vfName || "Visual Framework 2.0";
-global.vfNamespace = config.vfConfig.vfNamespace || "vf-";
-global.vfComponentPath = config.vfConfig.vfComponentPath || path.resolve('.', __dirname + '/components');
-global.vfBuildDestination = config.vfConfig.vfBuildDestination || __dirname + '/temp/build-files';
-global.vfThemePath = config.vfConfig.vfThemePath || './tools/vf-frctl-theme';
-global.vfVersion = vfCoreConfig.version || 'not-specified';
-const componentPath = path.resolve('.', global.vfComponentPath).replace(/\\/g, '/');
-const componentDirectories = config.vfConfig.vfComponentDirectories || ['vf-core-components'];
-const buildDestionation = path.resolve('.', global.vfBuildDestination).replace(/\\/g, '/');
+const gulp = require('gulp');
+
+// Pull in some optional configuration from the package.json file, a la:
+const {componentPath, componentDirectories, buildDestionation} = require('./tools/vf-config');
 
 // Gulp tasks live in their own files, for the sake of clarity.
 // These are done as JS Modules as it makes passing paramaters simpler and avoids

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "lerna": "0.0.1",
   "packages": [
-    "components/**/**"
+    "components/**/**",
+    "tools/*"
   ],
   "version": "independent"
 }

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -9,9 +9,9 @@ module.exports = function(gulp, buildDestionation) {
 
   // Copy compiled css/js and other assets
   gulp.task('vf-build:copy-assets', function() {
+    console.info('Copying `/temp/build-files` assets.');
     return gulp.src(buildDestionation + '/**/*')
       .pipe(gulp.dest('./build'));
-      console.info('Copied `/temp/build-files` assets.');
   });
 
   // Rollup all-in-one build as a static site for CI

--- a/tools/vf-config/index.js
+++ b/tools/vf-config/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Expose vf-config as a JS module
+ * Pull in some optional configuration from the package.json file, a la:
+ * (note: all settings are optional)
+ * "vfConfig": {
+ *  "vfName": "My Component Library",
+ *  "vfNameSpace": "myco-",
+ *  "vfComponentPath": "./src/components",
+ *  "vfComponentDirectories": [
+ *     "vf-core-components",
+ *     "../node_modules/your-optional-collection-of-dependencies"
+ *    NOTE: Don't forget to symlink: `cd components` `ln -s ../node_modules/your-optional-collection-of-dependencies`
+ *   ],
+ *  "vfBuildDestination": "./build",
+ *  "vfThemePath": "@frctl/mandelbrot"
+ *},
+ */
+
+// Load the vf-core package.json config
+const config = JSON.parse(fs.readFileSync('./package.json'));
+let vfCoreConfig;
+
+if (config.name === '@visual-framework/vf-core') {
+  // if being run from within the vf-core project, use the local package.json
+  vfCoreConfig = JSON.parse(fs.readFileSync('./package.json'));
+} else {
+  // load vfCoreConfig from node_modules
+  vfCoreConfig = JSON.parse(fs.readFileSync(require.resolve('@visual-framework/vf-core/package.json')));
+}
+
+config.vfConfig = config.vfConfig || [];
+global.vfName = config.vfConfig.vfName || "Visual Framework 2.0";
+global.vfNamespace = config.vfConfig.vfNamespace || "vf-";
+global.vfComponentPath = config.vfConfig.vfComponentPath || path.resolve('.', 'components');
+global.vfBuildDestination = config.vfConfig.vfBuildDestination || 'temp/build-files';
+global.vfThemePath = config.vfConfig.vfThemePath || './tools/vf-frctl-theme';
+global.vfVersion = vfCoreConfig.version || 'not-specified';
+const componentPath = path.resolve('.', global.vfComponentPath).replace(/\\/g, '/');
+const componentDirectories = config.vfConfig.vfComponentDirectories || ['vf-core-components'];
+const buildDestionation = path.resolve('.', global.vfBuildDestination).replace(/\\/g, '/'); 
+
+module.exports = {
+  componentPath,
+  componentDirectories,
+  buildDestionation
+};
+

--- a/tools/vf-config/index.js
+++ b/tools/vf-config/index.js
@@ -40,6 +40,11 @@ global.vfComponentPath = config.vfConfig.vfComponentPath || path.resolve('.', 'c
 global.vfBuildDestination = config.vfConfig.vfBuildDestination || 'temp/build-files';
 global.vfThemePath = config.vfConfig.vfThemePath || './tools/vf-frctl-theme';
 global.vfVersion = vfCoreConfig.version || 'not-specified';
+global.vfBuildFractalMode = vfCoreConfig.vfConfig.vfBuildFractalMode || 'normal'; 
+  // in vf-build specifices to run fractal as 'normal' full build of static assets,
+  // 'dataobject' to render only to memory or
+  // 'none' to not build at all
+
 const componentPath = path.resolve('.', global.vfComponentPath).replace(/\\/g, '/');
 const componentDirectories = config.vfConfig.vfComponentDirectories || ['vf-core-components'];
 const buildDestionation = path.resolve('.', global.vfBuildDestination).replace(/\\/g, '/'); 

--- a/tools/vf-config/package.json
+++ b/tools/vf-config/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "vf-config",
+  "version": "0.0.1",
+  "description": "Pull in some optional configuration from a project's package.json for use when building Visual Framework components and templates.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/visual-framework/vf-core.git"
+  },
+  "keywords": [
+    "Visual",
+    "Framework",
+    "VF"
+  ],
+  "author": "Ken Hawkins <ken.hawkins@embl.de>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/visual-framework/vf-core/issues"
+  },
+  "homepage": "https://github.com/visual-framework/vf-core#readme"
+}


### PR DESCRIPTION
Fulfills a long overdue task, this turns the config into a npm dependency, it:

- cleans up the gulpfile.js
- reduces copy-paste hell
- allows config versions to be tied to vf-core versions

To do this I've also added the `./tools` directory to be a lerna directory.

This means we can make more parts of vf-core npm components, like the component generator.