### PR TITLE
Bug: fix nunjucks compilation loop

### DIFF
--- a/tools/gulp-tasks/vf-watch.js
+++ b/tools/gulp-tasks/vf-watch.js
@@ -9,8 +9,11 @@ module.exports = function(gulp, path, componentPath, reload) {
   return gulp.task('vf-watch', function(done) {
     gulp.watch([componentPath + '/**/*.scss', '!' + componentPath + '/**/package.variables.scss'], gulp.series('vf-css')).on('change', reload);
     gulp.watch([componentPath + '/**/*.js', '!' + componentPath + '/**/*.precompiled.js'], gulp.series('vf-scripts')).on('change', reload);
-    gulp.watch([componentPath + '/**/*.njk'], gulp.series('vf-templates-precompile'));
+    gulp.watch([componentPath + '/**/*.njk'], {
+      usePolling: true // uses fs.watchFile(), otherwise this gets stuck in a loop
+    }, gulp.series('vf-templates-precompile'));
     gulp.watch([componentPath + '/**/**/assets/*'], gulp.series('vf-component-assets')).on('change', reload);
+
   });
 
 };

--- a/tools/gulp-tasks/vf-watch.js
+++ b/tools/gulp-tasks/vf-watch.js
@@ -13,7 +13,5 @@ module.exports = function(gulp, path, componentPath, reload) {
       usePolling: true // uses fs.watchFile(), otherwise this gets stuck in a loop
     }, gulp.series('vf-templates-precompile'));
     gulp.watch([componentPath + '/**/**/assets/*'], gulp.series('vf-component-assets')).on('change', reload);
-
   });
-
 };


### PR DESCRIPTION
The Nunjucks precompilation watch task can get stuck in a loop due to some strange behaviour around the file being read, renamed and written differently.

`usePolling` provides a more accurate behaviour.

This resolves an issue that breaks `gulp dev` in vf-eleventy. 