### PR TITLE
Enhancement: improve build process this

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ build:
   script:
     - npm install
     - npm install -g gulp-cli
-    - gulp vf-build
+    - vf-core:prepare-deploy
   artifacts:
     paths:
       - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ build:
   script:
     - npm install
     - npm install -g gulp-cli
-    - vf-core:prepare-deploy
+    - gulp vf-core:prepare-deploy
   artifacts:
     paths:
       - build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ stages:
 before_script:
   - yarn install
   - yarn global add gulp-cli
-  - gulp vf-build
+  - gulp vf-core:prepare-deploy
   - "curl https://www.projectwallace.com/webhooks/v1/imports?token=$WALLACE_TOKEN -fsS --retry 3 -X POST -H 'Content-Type: text/css' -d @build/css/styles.css"
 
 percy:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,3 +14,23 @@ const {componentPath, componentDirectories, buildDestionation} = require('./tool
 // Not familiar with JS Modules? Don't fret, it can be a lot like wrapping code in a function; here's
 // a nice quick start: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#Exporting_module_features
 require('./tools/gulp-tasks/_gulp_rollup.js')(gulp, path, componentPath, componentDirectories, buildDestionation);
+
+
+// The below gulp taks are intended for use only by vf-core
+// ---
+
+// Copy prepared files for deployment
+// Intended for use directly by vf-core
+gulp.task('vf-core:deploy-move-build-files', function() {
+  console.info('Copying `/temp/build-files` assets.');
+  return gulp.src(buildDestionation + '/**/*')
+    .pipe(gulp.dest('./build')); // hard-coded as this is used only by vf-core directly
+});
+
+// Runs vf-build and does an 
+gulp.task('vf-core:prepare-deploy',
+  gulp.series(
+    'vf-build',
+    'vf-core:deploy-move-build-files',
+  )
+);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,12 +16,13 @@ const {componentPath, componentDirectories, buildDestionation} = require('./tool
 require('./tools/gulp-tasks/_gulp_rollup.js')(gulp, path, componentPath, componentDirectories, buildDestionation);
 
 
-// The below gulp taks are intended for use only by vf-core
+// The below gulp tasks are intended for use only by vf-core
 // ---
 
 // Copy prepared files for deployment
 // Intended for use directly by vf-core
 gulp.task('vf-core:deploy-move-build-files', function() {
+  // vf-core copy some assets into /temp as to de-conflict fractal asset writing
   console.info('Copying `/temp/build-files` assets.');
   return gulp.src(buildDestionation + '/**/*')
     .pipe(gulp.dest('./build')); // hard-coded as this is used only by vf-core directly

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",
-    "preversion": "gulp vf-build"
+    "preversion": "gulp vf-core:prepare-deploy"
   },
   "repository": {
     "type": "git",

--- a/tools/gulp-tasks/vf-assets.js
+++ b/tools/gulp-tasks/vf-assets.js
@@ -32,8 +32,15 @@ module.exports = function(gulp, path, componentPath, buildDestionation) {
       .pipe(gulp.dest(buildDestionation + '/assets'));
   });
 
+  // make each component's `./*.js` files available
+  gulp.task('vf-component-assets:js', function() {
+    return gulp
+      .src([componentPath + '/vf-core-components/**/*.js', componentPath + '/**/*.js'])
+      .pipe(gulp.dest(buildDestionation + '/assets'));
+  });
+
   gulp.task('vf-component-assets', gulp.parallel(
-    'vf-component-assets:directory', 'vf-component-assets:compiled-css'
+    'vf-component-assets:directory', 'vf-component-assets:compiled-css', 'vf-component-assets:js'
   ));
 
   return gulp;

--- a/tools/gulp-tasks/vf-build.js
+++ b/tools/gulp-tasks/vf-build.js
@@ -7,13 +7,6 @@
 
 module.exports = function(gulp, buildDestionation) {
 
-  // Copy compiled css/js and other assets
-  gulp.task('vf-build:copy-assets', function() {
-    console.info('Copying `/temp/build-files` assets.');
-    return gulp.src(buildDestionation + '/**/*')
-      .pipe(gulp.dest('./build'));
-  });
-
   // Support for client projects using vf-build
   // but we need to see which Fractal build mode to invoke (or not at all, when it's not needed)
   let gulpFractalBuildTask;
@@ -39,7 +32,7 @@ module.exports = function(gulp, buildDestionation) {
     done();
   });
 
-  // Rollup all-in-one build as a static site for CI
+  // Rollup all-in-one build all VF tasks as static assets
   gulp.task('vf-build',
     gulp.series(
       'vf-clean',
@@ -48,8 +41,7 @@ module.exports = function(gulp, buildDestionation) {
         'vf-css:generate-component-css',
         gulp.series('vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
         gulp.series(gulpFractalBuildTask, 'vf-templates-precompile')
-      ),
-      'vf-build:copy-assets'
+      )
   ));
 
   return gulp;


### PR DESCRIPTION
This does two things spurred on by not-quite-right features (https://github.com/visual-framework/vf-wp/pull/76) in beta.5 and a related need @dbushell spotted for `vf-wp` to copy JS assets: 

- Enhancement: Separate out logice of vf-build task … 64aeafc 
    some vf-build tasks should only be done by vf-core, this moves those tasks out of the reach of the `require('../node_modules/@visual-framework/vf-core/tools/gulp-tasks/_gulp_rollup.js')(`
- Enhancement: capture component JS assets … d01bb5c
  A new gulp task `vf-component-assets:js`  to grab JS files from components and deploy them in the `{build}/assets` url
