### PR TITLE
makes the button transition slower to aid the issue in Safari

### DIFF
--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -36,7 +36,9 @@ $button-hover-fix: -5px -5px rgba(0, 0, 0, 0);
   text-align: center;
   text-decoration: none;
   transform: translate(0, 0);
-  transition: all linear 125ms;
+  transition: all linear 125ms; // Ideally we want this to be 50ms but there's an issue in Webkit/Safari on box-shadow animations
+                                // additionally we can't do a pseude :before/:after as we need to support <button> elements
+                                // https://github.com/visual-framework/vf-core/pull/632
 
 
   // Hover and Focus Styles

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -16,10 +16,11 @@ $button-hover-fix: -5px -5px rgba(0, 0, 0, 0);
   --vf-button__color__background--default: var(--vf-color--grey);
   --vf-button__color__background--default-dark: var(--vf-color--grey--darkest);
   --vf-button__color__border--default-visited: var(--vf-color--grey--lightest);
-  
+
   @include set-type(text-button--1);
 
   appearance: none;
+  backface-visibility: hidden;
   background-color: set-ui-color(vf-ui-color--black);
   background-color: var(--vf-button-background-color, var(--vf-button__color__background--default));
   border: 4px solid set-ui-color(vf-ui-color--black);
@@ -34,75 +35,23 @@ $button-hover-fix: -5px -5px rgba(0, 0, 0, 0);
   position: relative;
   text-align: center;
   text-decoration: none;
-  // transform: translate(0, 0);
-  // transform-style: preserve-3d;
-  transition: all linear 50ms;
+  transform: translate(0, 0);
+  transition: all linear 125ms;
 
-  // &::before {
-  //   background-color: set-ui-color(vf-ui-color--black);
-  //   background-color: var(--vf-button-shadow-background-color, var(--vf-button__color__background--default-dark));
-  //   border: 4px solid set-ui-color(vf-ui-color--black);
-  //   border: 4px solid var(--vf-button-shadow-border-color, var(--vf-button__color__background--default-dark));
-  //   content: '';
-  //   height: 100%;
-  //   left: 0;
-  //   position: absolute;
-  //   top: 0;
-  //   transform: translateX(4px) translateY(4px) translateZ(-1px);
-  //   transition: all linear 50ms;
-  //   width: 100%;
-  // }
-
-  // Visited Styles
-  // &:visited {
-  //   border-bottom-color: var(--vf-button-border-color--visited, var(--vf-button__color__border--default-visited) );
-  //   // &::after {
-  //   //   background-color: var(--vf-button-border-color--visited, var(--vf-button__color__border--default-visited) );
-  //   //   bottom: -4px;
-  //   //   content: '';
-  //   //   height: 4px;
-  //   //   left: -4px;
-  //   //   position: absolute;
-  //   //   transition: all linear 50ms;
-  //   //   width: calc(100% + 8px);
-  //   // }
-  //   // &:hover {
-  //   //   &::after {
-  //   //     background-color: var(--vf-button-shadow-border-color, var(--vf-button__color__background--default-dark));
-  //   //     transition: all linear 50ms;
-  //   //   }
-  //   // }
-  //   &:hover {
-  //     border-bottom-color: var(--vf-button-shadow-border-color, var(--vf-button__color__background--default-dark));
-  //   }
-  // }
 
   // Hover and Focus Styles
   &:focus,
   &:hover {
     box-shadow: 4px 4px 0 var(--vf-button-shadow-background-color, var(--vf-button__color__background--default-dark)), 2px 2px 4px rgba(set-ui-color(vf-ui-color--black), .25), $button-hover-fix;
     color: set-ui-color(vf-ui-color--white);
-    transform: translate(4px, 4px) translateZ(1px);
-    // transition: all linear 50ms;
-
-    // &::before {
-    //   box-shadow: 2px 2px 4px rgba(set-ui-color(vf-ui-color--black), .25);
-    //   transform: translateX(0) translateY(0) translateZ(-1px);
-    //   transition: all linear 50ms;
-    // }
+    transform: translate(4px, 4px);
+    transition: all linear 125ms;
   }
 
   // Active Styles
   &:active {
     box-shadow: 0px 0px 0 var(--vf-button-shadow-background-color, var(--vf-button__color__background--default-dark)), 2px 2px 2px rgba(set-ui-color(vf-ui-color--black), .125), $button-hover-fix;
     transform: translate(8px, 8px) translateZ(1px);
-    // transition: all linear 25ms;
-
-    // &::before {
-    //   box-shadow: 2px 2px 2px rgba(set-ui-color(vf-ui-color--black), .125);
-    //   transform: translateX(-4px) translateY(-4px) translateZ(-1px);
-    //   transition: all linear 25ms;
-    // }
   }
 }
 
@@ -162,10 +111,6 @@ a.vf-button {
 
 .vf-button--rounded {
   border-radius: $vf-radius--md;
-
-  // &::before {
-  //   border-radius: $vf-radius--md;
-  // }
 }
 
 .vf-button--sm {


### PR DESCRIPTION
this tries to slowdown the Safari but we've encountered in #626 

It also removes a load of CSS that had been commented out, because it is no longer required.

We should keep #626 open, in the hope webkit fixes the underlying rendering issues