### PR TITLE
BUG: rennovate-sourceurl

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "major": {
     "automerge": false
   },
-  "sourceUrlPrefixes": [
-    "https://github.com/visual-framework/vf-core"
-  ]
+  "packageRules": [{
+    "sourceUrlPrefixes": ["https://github.com/visual-framework/vf-core"],
+    "groupName": "Visual Framework core components"
+  }]
 }


### PR DESCRIPTION
bug: `sourceUrlPrefixes` should be inside a `packageRules`. Strictly I'm not sure if this is needed for how we're doing a monorepo, but it's probably worth keeping in as we learn more about lerna+rennovate

Fixes: #645