### PR TITLE
Bug: update usage of class names for vf-utility-classes

### DIFF
--- a/components/embl-logo/embl-logo.njk
+++ b/components/embl-logo/embl-logo.njk
@@ -1,4 +1,4 @@
 <a href="{{ logo_href }}" class="embl-logo">
-  <span class="vf-sr-only" for="text">{{ logo_text}}</span>
+  <span class="vf-u-sr-only" for="text">{{ logo_text}}</span>
 </a>
 {% if deprecated_text %}<!-- {{ deprecated_text }} -->{% endif %}

--- a/components/vf-form/vf-form__input/vf-form__input.njk
+++ b/components/vf-form/vf-form__input/vf-form__input.njk
@@ -1,16 +1,16 @@
 <form action="" class="vf-form">
   <div class="vf-form__item" data-vf-js-form-floatlabel>
-    <label class="vf-form__label | vf-sr-only" for="text">Text</label>
+    <label class="vf-form__label | vf-u-sr-only" for="text">Text</label>
     <input type="text" id="text" class="vf-form__input" placeholder="Text">
   </div>
 
   <div class="vf-form__item" data-vf-js-form-floatlabel>
-    <label class="vf-form__label | vf-sr-only" for="password">Password</label>
+    <label class="vf-form__label | vf-u-sr-only" for="password">Password</label>
     <input type="password" id="password" class="vf-form__input" placeholder="Password">
   </div>
 
   <div class="vf-form__item">
-    <label class="vf-form__label | vf-sr-only" for="email">Disabled email</label>
+    <label class="vf-form__label | vf-u-sr-only" for="email">Disabled email</label>
     <input type="email" id="email" class="vf-form__input" disabled placeholder="disabled">
   </div>
 </form>

--- a/components/vf-form/vf-form__item/vf-form__item.njk
+++ b/components/vf-form/vf-form__item/vf-form__item.njk
@@ -1,5 +1,5 @@
 <div class="vf-form__item" data-vf-js-form-floatlabel>
-  <label for="text" class="vf-form__label | vf-sr-only">Form Label</label>
+  <label for="text" class="vf-form__label | vf-u-sr-only">Form Label</label>
   <input type="text" id="text" class="vf-form__input" placeholder="for item example">
   <p class="vf-form__helper">Form helper text</p>
 </div>

--- a/components/vf-form/vf-form__label/vf-form__label.njk
+++ b/components/vf-form/vf-form__label/vf-form__label.njk
@@ -1,4 +1,4 @@
 <div class="vf-form__item" data-vf-js-form-floatlabel>
-  <label for="text" class="vf-form__label | vf-sr-only">Form Label</label>
+  <label for="text" class="vf-form__label | vf-u-sr-only">Form Label</label>
   <input type="text" id="text" class="vf-form__input" placeholder="form label example">
 </div>

--- a/components/vf-form/vf-form__textarea/vf-form__textarea.njk
+++ b/components/vf-form/vf-form__textarea/vf-form__textarea.njk
@@ -1,4 +1,4 @@
 <div class="vf-form__item" data-vf-js-form-floatlabel>
-  <label class="vf-form__label | vf-sr-only" for="vf-form__textarea">Write Some More details</label>
+  <label class="vf-form__label | vf-u-sr-only" for="vf-form__textarea">Write Some More details</label>
   <textarea class="vf-form__textarea" id="vf-form__textarea" name="vf-form__textarea" rows="5" placeholder="Write Some More details"></textarea>
 </div>

--- a/components/vf-logo/vf-logo.njk
+++ b/components/vf-logo/vf-logo.njk
@@ -3,6 +3,6 @@
 {% if id %} id="{{-id-}}"{% endif %}
 class="vf-logo {%- if override_class %} | {{override_class}}{% endif -%}">
   <img class="vf-logo__image" src="{{ image }}" alt="{{ logo_text }}">
-  <span class="vf-logo__text{% if hidden_text %} vf-sr-only{% endif %}">{{logo_text}}</span>
+  <span class="vf-logo__text{% if hidden_text %} vf-u-sr-only{% endif %}">{{logo_text}}</span>
 </a>
 {% if deprecated_text %}<!-- {{ deprecated_text }} -->{% endif %}

--- a/components/vf-pagination/vf-pagination.njk
+++ b/components/vf-pagination/vf-pagination.njk
@@ -6,11 +6,11 @@
       <a
       href="{{ item.page_href }}"
       class="vf-pagination__link">
-        {{ item.page_number }}<span class="vf-sr-only"> page</span>
+        {{ item.page_number }}<span class="vf-u-sr-only"> page</span>
       </a>
       {% elseif item.item_modifier == "vf-pagination__item--is-active" %}
       <span class="vf-pagination__label" aria-current="page">
-        <span class="vf-sr-only">Page </span>{{ item.page_number }}
+        <span class="vf-u-sr-only">Page </span>{{ item.page_number }}
       </span>
       {% else %}
       <span class="vf-pagination__label">{{ item.page_number }}</span>

--- a/components/vf-sass-utilities/README.md
+++ b/components/vf-sass-utilities/README.md
@@ -1,7 +1,7 @@
 
 # Sass Utilities component
 
-<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="#"new</a> component.</h2>
+<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="https://www.npmjs.com/package/@visual-framework/vf-utility-classes">vf-utility-classes</a> component.</h2>
 
 The utility classes here have been moved to the `vf-utility-classes` component.
 

--- a/components/vf-sass-utilities/_vf-screen-reader.scss
+++ b/components/vf-sass-utilities/_vf-screen-reader.scss
@@ -1,4 +1,4 @@
-.vf-js {
+html.vf-js:not(.vf-disable-deprecated) {
   // Some things should only be show to screen readers
   .vf-sr-only {
     position: absolute;

--- a/components/vf-sass-utilities/vf-sass-utilities.scss
+++ b/components/vf-sass-utilities/vf-sass-utilities.scss
@@ -11,7 +11,9 @@ html:not(.vf-disable-deprecated) {
 
   @import 'vf-sass-utilities.variables.scss';
 
-  @import 'vf-screen-reader.scss';
   @import 'vf-et-al.scss';
   @import 'vf-no-wrap.scss';
 }
+
+// vf-no-js expects to be on the html root element 
+@import 'vf-screen-reader.scss';

--- a/components/vf-search/vf-search--inline.njk
+++ b/components/vf-search/vf-search--inline.njk
@@ -1,6 +1,6 @@
 <form action="" class="vf-form | vf-search vf-search--inline">
   <div class="vf-form__item | vf-search__item">
-    <label class="vf-form__label vf-sr-only | vf-search__label" for="text">Search</label>
+    <label class="vf-form__label vf-u-sr-only | vf-search__label" for="text">Search</label>
     <input type="text" id="text" class="vf-form__input | vf-search__input">
   </div>
   <button type="submit" class="vf-search__button | vf-button vf-button--primary">Search</button>

--- a/components/vf-search/vf-search.njk
+++ b/components/vf-search/vf-search.njk
@@ -1,6 +1,6 @@
 <form action="" class="vf-form | vf-search">
   <div class="vf-form__item | vf-search__item">
-    <label class="vf-form__label vf-sr-only | vf-search__label" for="text">{{ label }}</label>
+    <label class="vf-form__label vf-u-sr-only | vf-search__label" for="text">{{ label }}</label>
     <input type="text" id="text" class="vf-form__input | vf-search__input">
   </div>
   <button type="submit" class="vf-search__button | vf-button vf-button--primary"> {{ button }}</button>

--- a/components/vf-summary/README.md
+++ b/components/vf-summary/README.md
@@ -8,7 +8,7 @@
 
 The `vf-summary--publication` can be nested inside a vf-box where it takes the vf-box colours.
 
-If the `vf-summary__author` list is truncated to a certain number of authors you will need to add vf-et-al to the `<p>` - `<p class="vf-summary__author | vf-et-al">` - for it to add et al to the end of the list.
+If the `vf-summary__author` list is truncated to a certain number of authors you will need to add vf-u-text--et-al to the `<p>` - `<p class="vf-summary__author | vf-u-text--et-al">` - for it to add et al to the end of the list.
 
 ## Install
 

--- a/components/vf-utility-classes/vf-utility-classes.njk
+++ b/components/vf-utility-classes/vf-utility-classes.njk
@@ -5,21 +5,21 @@
 
 ### Et al.
 
-- `.vf-et-al` for use in publications lists and similar
+- `.vf-u-text--et-al` for use in publications lists and similar
 
-<span class="vf-et-al">Jon Smith, Jane Johnson, </span>
+<span class="vf-u-text--et-al">Jon Smith, Jane Johnson, </span>
 
 ### Screenreader text
 
-- `.vf-sr-only` some things should only be shown to screen readers
+- `.vf-u-sr-only` some things should only be shown to screen readers
 
-<span class="vf-sr-only">Like this text</span>
+<span class="vf-u-sr-only">Like this text</span>
 
 ### No-wrap.
 
-- `.vf-no-wrap` keep text together, as much as possible
+- `.vf-u-text--no-wrap` keep text together, as much as possible
 
-I'm some words that can break awkwardly but keep the <span class="vf-no-wrap">Company Name</span> together.
+I'm some words that can break awkwardly but keep the <span class="vf-u-text--no-wrap">Company Name</span> together.
 
 ### Text-colours
 


### PR DESCRIPTION
Bug: the vf-utility-classes picked up the now-deprecated vf-sass-utilities and changed the class names, but this wasn't reflected in the docs and other component templates.