### PR TITLE
the one with the quick update to the masthead component

### DIFF
--- a/components/vf-masthead/vf-masthead--inlay.njk
+++ b/components/vf-masthead/vf-masthead--inlay.njk
@@ -1,11 +1,4 @@
-<style>
-:root {
-  /* These CSS properties are theming variables. If used, add to your HTML
-     after the VF CSS for vf-masthead and before the HTML for vf-masthead. */
-  --vf-masthead__bg-image: url('{{ '../../assets/vf-masthead/assets/group-bg_2d4155.png' | path }}');
-}
-</style>
-<div data-vf-js-masthead class="vf-masthead" style="background-color: 'var(--vf-masthead__color--background', var(--vf-masthead__color--background-default)); color: var(--vf-masthead__color--foreground, var(--vf-masthead__color--foreground-default) );">
+<div data-vf-js-masthead class="vf-masthead">
   <div class="vf-masthead__inner">
     <div class="vf-masthead__title">
       <h1 class="vf-masthead__heading">
@@ -15,4 +8,3 @@
     </div>
   </div>
 </div>
-<!--/vf-masthead-->

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -1,4 +1,5 @@
-$vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
+$vf-masthead__title-text--color: set-color(vf-color--grey--darkest);
+$vf-masthead__subtitle-text--color: set-color(vf-color--grey);
 
 // vf-masthead
 
@@ -12,14 +13,14 @@ $vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
  */
 
 .vf-masthead {
-  --vf-masthead__color--foreround-default: var(--vf-ui-color--white);
-  --vf-masthead__color--background-default: var(--vf-color--green);
-
-  background-color: set-color(vf-color--green);
-  background-image: var( --vf-masthead__bg-image, none);
-  background-repeat: no-repeat;
-  background-size: cover;
-  color: set-ui-color(vf-ui-color--white);
+  // --vf-masthead__color--foreround-default: var(--vf-color--grey-darkest);
+  // --vf-masthead__color--background-default: var(--vf-color--green);
+  //
+  // background-color: set-color(vf-color--green);
+  // background-image: var( --vf-masthead__bg-image, none);
+  // background-repeat: no-repeat;
+  // background-size: cover;
+  color: set-ui-color(vf-ui-color--black);
 
   @media (min-width: $vf-breakpoint--lg) {
     padding-top: 48px;
@@ -46,7 +47,7 @@ $vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
 .vf-masthead__heading {
   @include set-type(text-heading--1, $custom-margin-bottom: 8px);
 
-  color: var(--vf-masthead__color--foreground, var(--vf-masthead__color--foreround-default) );
+  color: $vf-masthead__title-text--color;
   display: flex;
   flex-direction: column;
 }
@@ -54,15 +55,15 @@ $vf-masthead__title-text--color: set-ui-color(vf-ui-color--white);
 .vf-masthead__heading--additional {
   @include set-type(text-heading--5, $custom-margin-bottom: 0);
 
-  color: var(--vf-masthead__color--foreground, var(--vf-masthead__color--foreround-default) );
+  color: $vf-masthead__subtitle-text--color;
   position: relative;
-  top: -8px;
+  top: -4px;
 }
 
 .vf-masthead__sub-heading {
   @include set-type(text-heading--5);
 
-  color: var(--vf-masthead__color--foreground, var(--vf-masthead__color--foreround-default) );
+  color: $vf-masthead__subtitle-text--color;
 }
 
 .vf-masthead__heading__link {


### PR DESCRIPTION
with the current, new designs the masthead that holds the heading, sub-heading, and additional heading text no longer has a background colour or background image option.

This PR

- removes the inlined HTML in the component
- removes the colourisation of the component and make things dark on white.