### PR TITLE
the one where we try and remove another excess <div> element for content-hub-html

### DIFF
--- a/components/embl-content-hub-loader/CHANGELOG.md
+++ b/components/embl-content-hub-loader/CHANGELOG.md
@@ -6,3 +6,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 # 1.0.0 (2019-12-17)
 
 * Initial stable release
+
+
+# 1.0.1 (2019)
+
+* adds CSS for times when the `*-content-hub-html` is a direct child of `vf-body`.

--- a/components/embl-content-hub-loader/embl-content-hub-loader.scss
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.scss
@@ -11,7 +11,7 @@
 
 @import 'embl-content-hub-loader.variables.scss';
 
-// contentHub html caries an extra div that should be outside of the grid layout
+// contentHub html carries an extra div that should be outside of the grid layout
 .embl-grid > .vf-content-hub-html,
 .embl-grid > .embl-content-hub-html,
 .vf-grid > .vf-content-hub-html,
@@ -20,4 +20,10 @@
   // @todo: this should probably just be .embl-content-hub-html, but that requires a
   //        disruptive change in the contenthub itself and will impact many systems.
   //        that change will require coordination
+}
+// contentHub html is sometimes placed as a direct child of `vf-body` which needs a
+// different grid-column ruleset.
+.vf-body > .vf-content-hub-html,
+.vf-body > .embl-content-hub-html {
+  grid-column: main;
 }


### PR DESCRIPTION
Looking through the HTML on the static-html-pages for the new site I noticed that `vf-content-hub-html` element that houses the `vf-banner--phase` was wrapped inside a `vf-grid` element so that it didn't blow up the page.

We already have CSS for `vf-grid >` and `embl-grid >` so I think adding `vf-body >` for the `vf-content-hub-html` and `embl-content-hub-html` will benefit in these cases, and make the markup a little bit more sane. 

