### PR TITLE
the one that makes the banner 'fit' better when in a page

### DIFF
--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -6,3 +6,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 # 1.0.0 (2019-12-17)
 
 * Initial stable release
+
+
+# 1.0.1
+
+* Removed default spacing of `vf-text` components inside.
+* Removes overriding variant CSS that removes padding, as it breaks the GDPR banner.
+* The spacing inside the component is now dictated by the component.
+* Adds a top and bottom margin for spacing of the `--phase` variant.

--- a/components/vf-banner/vf-banner--fixed.scss
+++ b/components/vf-banner/vf-banner--fixed.scss
@@ -4,7 +4,6 @@
   grid-template-columns: minmax(var(--page-grid-gap), auto) [main-start] minmax(288px, 76.5em) [main-end] minmax(var(--page-grid-gap), auto);
   left: 0;
   margin: 0;
-  padding: 0;
   position: fixed;
   width: 100%;
   z-index: set-layer(vf-z-index--banner);

--- a/components/vf-banner/vf-banner--phase.scss
+++ b/components/vf-banner/vf-banner--phase.scss
@@ -1,11 +1,11 @@
 .vf-banner--phase {
   background-color: $vf-phase-banner-color--background;
 
-  margin-bottom: 24px;
+  margin: 16px 0;
 
   [class*='vf-text'] {
     color: $vf-phase-banner-color--text;
-    margin: 12px 0;
+    margin: 0; // makes the text have no margin so the parent component defines the spacing
 
     & .vf-link {
       color: $vf-banner-color--link;

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -13,7 +13,7 @@
 
 .vf-banner {
   box-sizing: border-box;
-  padding: 16px 12px;
+  padding: 16px;
 
   .vf-badge {
     margin-right: 16px;

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -13,7 +13,7 @@
 
 .vf-banner {
   box-sizing: border-box;
-  padding: 0 12px;
+  padding: 16px 12px;
 
   .vf-badge {
     margin-right: 16px;
@@ -59,8 +59,6 @@
 }
 
 .vf-banner--notice {
-  @include padding--block(all, $vf-notice-banner-padding);
-
   background-color: $vf-notice-banner-color--background;
 
   .vf-text {


### PR DESCRIPTION
This PR:

- removes the margin forced on `vf-text`.
- makes the `vf-banner` have padding to make up for this margin
- removes the variant overrides for padding so all banners have the same padding
- updates changeling