### PR TITLE
CHORE: update-publishing-notes

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -9,12 +9,13 @@ and allows for the creation of CSS, JS and usable Nunjucks templates.
 
 See also: [Guide on versions in `vf-core`](https://visual-framework.github.io/vf-welcome/developing/guidelines/versioning/)
 
-1. Select the `develop` branch
-1. Update the version 
+1. select the `develop` branch
+    - reminder: [we don't use `master`](https://github.com/visual-framework/vf-core/blob/master/README.md)
+1. update the version 
     - https://docs.npmjs.com/cli/version
     - `npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]` 
 1. PR `develop` to `master`
-1. Publish to npm
+1. publish to npm
     - `npm publish`
 
 ## Components inside `vf-core`
@@ -24,12 +25,10 @@ to npm with [Lerna](https://github.com/lerna/lerna#about).
 
 See also: [Guide on updating a component versions](https://visual-framework.github.io/vf-welcome/developing/components/updating-a-component/)
 
-While we do not add tags as part of the "release" for component, Lerna needs a named tag to function.
-
 ### Component pre-release workflow
 
 1. select the `develop` branch
-    - this should be at least as up to date as `master`
+    - reminder: [we don't use `master`](https://github.com/visual-framework/vf-core/blob/master/README.md)
 1. see a list of changed packages
     - `lerna changed`
 1. test publish 
@@ -38,8 +37,11 @@ While we do not add tags as part of the "release" for component, Lerna needs a n
     - `yarn run lerna:publish`
 1. commit changes to the `develop` branch
     - commit message in a format of: `Component release YYYYMMDD-01`
-1. add a tag `git tag -a components.YYYYMMDD-01 -m 'Snapshot of components for lerna'`
-1. push the tag `git push origin --tags`
+1. add a tag 
+    - `git tag -a components.YYYYMMDD-01 -m 'Snapshot of components for lerna'`
+    - Why like this? We do not add tags per individual component version, Lerna needs a named tag to see what has changed. This way we get one tag per release "bundle" avoiding tag spamming in the release history. 
+1. push the tag 
+    - `git push origin --tags`
 
 ### Appendix of useful Lerna commands
 


### PR DESCRIPTION
For #698 (STRATEGIC - Don't use master) and follows #703 (CHORE - Make stub master branch)