### PR TITLE
enhancment: use prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "note:lerna:test": "we use the `--canary` flag to simplify testing, correct versions can be selected when running `lerna:publish`", 
     "lerna:publish": "lerna publish --no-git-tag-version --no-push && git reset --hard && lerna publish --no-git-tag-version --no-push --skip-npm --ignore-scripts",
     "note:lerna:publish": "it's a known issue that you need to supply the version twice, we're working a solution for this", 
-    "preversion": "gulp vf-core:prepare-deploy"
+    "prepublishOnly": "gulp vf-core:prepare-deploy"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This ensures we run checks before `npm publish` executes.

https://docs.npmjs.com/misc/scripts