### PR TITLE
Enable scheduling for renovate

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -16,6 +16,8 @@ pullRequestOpened: >
 
   Before your PR can be merged in, it will need to be reviewed.
 
+  - [ ] a detailed outline on what this PR is expected to do
+
   - [ ] add relevant labels to this PR
 
   - [ ] `package.json` is updated accordingly
@@ -23,5 +25,3 @@ pullRequestOpened: >
   - [ ] `README.md` is filled out with required documentation
 
   - [ ] any `.scss` files correctly documented
-
-  - [ ] a detailed outlin on what this PR is expected to do

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
   "major": {
     "automerge": false
   },
+  "schedule": [
+    "before 10am every monday"
+  ]
+  timezone: "Europe/Berlin",
   "packageRules": [{
     "sourceUrlPrefixes": ["https://github.com/visual-framework/vf-core"],
     "groupName": "Visual Framework core components"

--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,8 @@
   },
   "schedule": [
     "before 10am every monday"
-  ]
-  timezone: "Europe/Berlin",
+  ],
+  "timezone": "Europe/Berlin",
   "packageRules": [{
     "sourceUrlPrefixes": ["https://github.com/visual-framework/vf-core"],
     "groupName": "Visual Framework core components"


### PR DESCRIPTION
This optimises our renovate workflow to have less noise, as discussed in #713:

- àutomerge` doesn't work as PRs need approval
- our code doesn't run live so we don't need updates 24 hours a day
- restricts updates to come on Monday morning
   - https://docs.renovatebot.com/configuration-options/#timezone
   - https://docs.renovatebot.com/configuration-options/#schedule

In all, we still make sure we're not using anything to out of date with less PR noise. 