### PR TITLE
Add vf-u-text--break

### DIFF
--- a/components/vf-utility-classes/CHANGELOG.md
+++ b/components/vf-utility-classes/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.1 
+
+* Adds .vf-u-text--break
+
 # 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-utility-classes/vf-u-text.scss
+++ b/components/vf-utility-classes/vf-u-text.scss
@@ -2,6 +2,10 @@
   white-space: nowrap;
 }
 
+.vf-u-text--break {
+  word-break: break-all;
+}
+
 .vf-u-text--et-al {
   position: relative;
 

--- a/components/vf-utility-classes/vf-utility-classes.njk
+++ b/components/vf-utility-classes/vf-utility-classes.njk
@@ -15,11 +15,17 @@
 
 <span class="vf-u-sr-only">Like this text</span>
 
-### No-wrap.
+### No wrap
 
-- `.vf-u-text--no-wrap` keep text together, as much as possible
+- `.vf-u-text--nowrap` keep text together, as much as possible
 
-I'm some words that can break awkwardly but keep the <span class="vf-u-text--no-wrap">Company Name</span> together.
+I'm some words that can break awkwardly but keep the <span class="vf-u-text--nowrap">Company Name</span> together.
+
+### Break text
+
+- `.vf-u-text--break` break long strings of text
+
+Here's some long text that would otherwise run off the side of the page <span class="vf-u-text--break">evock2OTIhUP5N9ZgsNCzgYrfFuKd3ktVLTYnVTfX1NPpzjxmYC0RwLiOxwqi7n7VLWgRFUiTa7UK77exxWkpbJwLoERCAU5L0Z8ebvYpjKCtCboKgAxYx4CxmlsP3U66rabF3nxA6sNDhZnYWW6zr1QfR7J7nzKhQG9P2oSnOFNoK7xPr6hgxpePl3Jq9Ml2n5eAeV6evock2OTIhUP5N9ZgsNCzgYrfFuKd3ktVLTYnVTfX1NPpzjxmYC0RwLiOxwqi7n7VLWgRFUiTa7UK77exxWkpbJwLoERCAU5L0Z8ebvYpjKCtCboKgAxYx4CxmlsP3U66rabF3nxA6sNDhZnYWW6zr1QfR7J7nzKhQG9P2oSnOFNoK7xPr6hgxpePl3Jq9Ml2n5eAeV6</span>.
 
 ### Text-colours
 


### PR DESCRIPTION
As found on the new EMBL.org redirect pages, it would be really good to have a utility class to break verrrrrrrrrrrrrrry long urls

https://gitlab.ebi.ac.uk/emblorg/static-html-pages/commit/ae1a6eb543983e240ad4b295f86971fd626187eb

Also fixes the documentation example on `.vf-u-text--nowrap` which had an incorrect additional hyphen. 