### PR TITLE
the one where link colours get a new lick of paint

### DIFF
--- a/components/vf-design-tokens/dist/sass/vf-links.variables.scss
+++ b/components/vf-design-tokens/dist/sass/vf-links.variables.scss
@@ -6,5 +6,7 @@
 $vf-link--color: #3b6fb6;
 $vf-link--disabled-color: #d0d0ce;
 $vf-link--hover-color: #193f90;
-$vf-link--visited-color: #54585a;
+$vf-link--visited-color: #734595;
 $vf-link--decoration: underline;
+$vf-link--dark-mode--hover-color: #a8d2ff;
+$vf-link--dark-mode--visited-color: #cba3d8;

--- a/components/vf-design-tokens/src/core.palette.alias.yml
+++ b/components/vf-design-tokens/src/core.palette.alias.yml
@@ -53,7 +53,10 @@ aliases:
   vf-color--bright-green--light: '#E2E868'
 
 
+  # EMBL Link Colours
 
+  vf-color--link--dark-mode--hover: '#a8d2ff'
+  vf-color--link--dark-mode--visited: '#cba3d8'
 
   # VF Core Colours
 

--- a/components/vf-design-tokens/src/variables/vf-links.yml
+++ b/components/vf-design-tokens/src/variables/vf-links.yml
@@ -15,8 +15,14 @@ props:
     value: "{!vf-color--blue--dark}"
     type: color
   vf-link--visited-color:
-    value: "{!vf-color--grey--dark}"
+    value: "{!vf-color--purple}"
     type: color
   vf-link--decoration:
     value: underline
     type: style
+  vf-link--dark-mode--hover-color:
+    value: "{!vf-color--link--dark-mode--hover}"
+    type: color
+  vf-link--dark-mode--visited-color:
+    value: "{!vf-color--link--dark-mode--visited}"
+    type: color

--- a/components/vf-link/vf-link--disabled.scss
+++ b/components/vf-link/vf-link--disabled.scss
@@ -1,3 +1,8 @@
 .vf-link--disabled {
-  @include vf-disabled($vf-link--disabled-color);
+  @include vf-disabled(#54585a);
+}
+.vf-u-background-color--grey--dark {
+  .vf-link--disabled {
+    @include vf-disabled(#fff);
+  }
 }

--- a/components/vf-link/vf-link--example.njk
+++ b/components/vf-link/vf-link--example.njk
@@ -1,0 +1,65 @@
+
+<div class="vf-grid vf-u-padding--lg">
+<!-- Default -->
+<a href="JavaScript:Void(0);" class="vf-link ">A default link</a>
+<!-- Default Hover -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--hover">A default:hover link</a>
+<!-- Default Visited -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--visited">A default:visited link</a>
+<!-- Default Disabled -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--disabled" disabled>A disabled default link</a>
+</div>
+<div class="vf-grid vf-u-background-color--grey--dark vf-u-padding--lg">
+<!-- Default -->
+<a href="JavaScript:Void(0);" class="vf-link ">A default link</a>
+<!-- Default Hover -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--hover">A default:hover link</a>
+<!-- Default Visited -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--visited">A default:visited link</a>
+<!-- Default Disabled -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--disabled" disabled>A disabled default link</a>
+</div>
+<div class="vf-grid vf-u-padding--lg">
+<!-- Primary -->
+<a href="JavaScript:Void(0);" class="vf-link ">A primary link</a>
+<!-- Primary Hover -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--hover">A primary:hover link</a>
+<!-- Primary Visited -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--visited">A primary:visited link</a>
+<!-- Primary Disabled -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--disabled" disabled>A disabled primary link</a>
+</div>
+<div class="vf-grid vf-u-background-color--grey--dark vf-u-padding--lg">
+<!-- Primary -->
+<a href="JavaScript:Void(0);" class="vf-link ">A primary link</a>
+<!-- Primary Hover -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--hover">A primary:hover link</a>
+<!-- Primary Visited -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--visited">A primary:visited link</a>
+<!-- Primary Disabled -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--disabled" disabled>A disabled primary link</a>
+</div>
+<div class="vf-grid vf-u-padding--lg">
+<!-- Secondary -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--secondary ">A secondary link</a>
+<!-- Secondary Hover -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--secondary--hover">A secondary:hover link</a>
+<!-- Secondary Visited -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--secondary--visited">A secondary:visited link</a>
+<!-- Secondary Disabled -->
+<a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--disabled" disabled>A disabled secondary link</a>
+<!-- Example -->
+<a href="" class="vf-link "></a>
+</div>
+<div class="vf-grid vf-u-background-color--grey--dark vf-u-padding--lg">
+  <!-- Secondary -->
+  <a href="JavaScript:Void(0);" class="vf-link vf-link--secondary ">A secondary link</a>
+  <!-- Secondary Hover -->
+  <a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--secondary--hover">A secondary:hover link</a>
+  <!-- Secondary Visited -->
+  <a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--secondary--visited">A secondary:visited link</a>
+  <!-- Secondary Disabled -->
+  <a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--disabled" disabled>A disabled secondary link</a>
+  <!-- Example -->
+  <a href="JavaScript:Void(0);" class="vf-link "></a>
+</div>

--- a/components/vf-link/vf-link--secondary.scss
+++ b/components/vf-link/vf-link--secondary.scss
@@ -2,13 +2,27 @@
 @import 'vf-link.variables.scss';
 
 .vf-link--secondary {
-  @include inline-link($vf-link---secondary-color, $vf-link---secondary-color--hover, $vf-link---secondary-color--visited, $vf-include-normalisations: true);
+  @include inline-link(set-color(vf-color--grey--dark), set-color(vf-color--grey--dark), set-color(vf-color--purple), $vf-include-normalisations: true);
 }
 
 .vf-link--secondary--visited {
-  color: $vf-link---secondary-color--visited;
+  color: set-color(vf-color--purple);
 }
 
 .vf-link--secondary--hover {
-  color: $vf-link---secondary-color--hover;
+  color: set-color(vf-color--grey--dark);
+}
+
+.vf-u-background-color--grey--dark {
+  .vf-link--secondary {
+    @include inline-link(set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), $vf-link--dark-mode--visited-color, $vf-include-normalisations: true);
+  }
+
+  .vf-link--secondary--visited {
+    color: $vf-link--dark-mode--visited-color;
+  }
+
+  .vf-link--secondary--hover {
+    color: set-ui-color(vf-ui-color--white);
+  }
 }

--- a/components/vf-link/vf-link.config.yml
+++ b/components/vf-link/vf-link.config.yml
@@ -1,69 +1,13 @@
 title: Visual Framework Link
 label: Link
 status: live
+collated: true
+preview: '@preview--nogrid'
 context:
   component-type: element
 variants:
   - name: default
+    hidden: true;
     context:
       link_href: "#"
-      id: "harsh"
       text: "A default link"
-  - name: default-hover
-    context:
-      link_href: "#"
-      style: ["hover"]
-      text: "A default:hover link"
-  - name: default-visited
-    context:
-      link_href: "#"
-      style: ["visited"]
-      text: "A default:visited link"
-  - name: default-disabled
-    context:
-      link_href: "#"
-      style: ["disabled"]
-      text: "A disabled default link"
-  - name: primary
-    context:
-      link_href: "#"
-      id: "harsh"
-      text: "A primary link"
-  - name: primary-hover
-    context:
-      link_href: "#"
-      style: ["hover"]
-      text: "A primary:hover link"
-  - name: primary-visited
-    context:
-      link_href: "#"
-      style: ["visited"]
-      text: "A primary:visited link"
-  - name: primary-disabled
-    context:
-      link_href: "#"
-      style: ["disabled"]
-      text: "A disabled primary link"
-  - name: secondary
-    context:
-      link_href: "#"
-      text: A secondary link
-      theme: secondary
-  - name: secondary-hover
-    context:
-      link_href: "#"
-      text: A secondary:hover link
-      theme: secondary
-      style: ["hover"]
-  - name: secondary-visited
-    context:
-      link_href: "#"
-      text: A secondary:visited link
-      theme: secondary
-      style: ["visited"]
-  - name: secondary-disabled
-    context:
-      link_href: "#"
-      text: A disabled secondary link
-      theme: secondary
-      style: ["disabled"]

--- a/components/vf-link/vf-link.scss
+++ b/components/vf-link/vf-link.scss
@@ -20,3 +20,17 @@
 .vf-link--hover {
   color: $vf-link--hover-color;
 }
+
+.vf-u-background-color--grey--dark {
+  .vf-link {
+    @include inline-link($vf-link--dark-mode--hover-color, $vf-link--dark-mode--hover-color, $vf-link--dark-mode--visited-color, $vf-include-normalisations: true);
+  }
+
+  .vf-link--visited {
+    color: $vf-link--dark-mode--visited-color;
+  }
+
+  .vf-link--hover {
+    color: $vf-link--dark-mode--hover-color;
+  }
+}

--- a/components/vf-link/vf-link.variables.scss
+++ b/components/vf-link/vf-link.variables.scss
@@ -1,5 +1,3 @@
-$vf-link--hover-color: lighten(saturate(adjust-hue($vf-link--color, 5), 32.54), 10.78);
-
-$vf-link---secondary-color: set-color(vf-color--grey) !default;
-$vf-link---secondary-color--hover: $vf-link--hover-color !default;
+$vf-link---secondary-color: set-ui-color(vf-ui-color--white) !default;
+$vf-link---secondary-color--hover: set-ui-color(vf-ui-color--white) !default;
 $vf-link---secondary-color--visited: set-color(vf-color--grey--lightest) !default;

--- a/components/vf-sass-config/mixins/_links.scss
+++ b/components/vf-sass-config/mixins/_links.scss
@@ -1,7 +1,7 @@
 // Styling for inline links
 
 @mixin inline-link(
-  $vf-link--color: $vf-link--color,
+  $vf-link--color: map-get($vf-colors-map, vf-color--blue),
   $vf-link--hover-color: $vf-link--hover-color,
   $vf-link--visited-color: $vf-link--visited-color,
   $vf-include-normalisations: $vf-include-normalisations) {
@@ -9,7 +9,7 @@
   /// @todo Add documentation about how/when/where to expect, use $vf-include-normalisations
   @if $vf-include-normalisations == true {
     border-bottom: none;
-    text-decoration: underline;
+    text-decoration: none;
   }
 
   color: $vf-link--color;
@@ -19,12 +19,53 @@
 
     @if $vf-include-normalisations == true {
       border-bottom: none;
+    }
+
+    &:hover {
+      color: $vf-link--visited-color;
       text-decoration: underline;
     }
   }
 
   &:hover {
     color: $vf-link--hover-color;
+
+    @if $vf-include-normalisations == true {
+      border-bottom: none;
+      text-decoration: underline;
+    }
+  }
+}
+
+@mixin inline-link--dark-mode(
+  $vf-link--color: map-get($vf-colors-map, vf-color--blue),
+  $vf-link--hover-color: $vf-link--hover-color,
+  $vf-link--visited-color: $vf-link--visited-color,
+  $vf-include-normalisations: $vf-include-normalisations) {
+
+  /// @todo Add documentation about how/when/where to expect, use $vf-include-normalisations
+  @if $vf-include-normalisations == true {
+    border-bottom: none;
+    text-decoration: none;
+  }
+
+  color: $vf-link--dark-mode--hover-color;
+
+  &:visited {
+    color: $vf-link--dark-mode--visited-color;
+
+    @if $vf-include-normalisations == true {
+      border-bottom: none;
+    }
+
+    &:hover {
+      color: $vf-link--dark-mode--visited-color;
+      text-decoration: underline;
+    }
+  }
+
+  &:hover {
+    color: $vf-link--dark-mode--hover-color;
 
     @if $vf-include-normalisations == true {
       border-bottom: none;


### PR DESCRIPTION
This PR:

- adds two new design tokens for use when links are on a dark background
- updates the link colours in the design tokens to match current design
- updates the Sass mixin for `@include inline-link` to incorporate the new colours
- adds an additional Sass mixin `@include inline-link--dark-mode` for dark background and dark mode
- updates the CSS for `vf-link`
- removes the .yml for examples for `vf-link`
- creates a `vf-link--examples` `.njk` file to show all style options on dark and light background. 

I've gone through the component library and looked at the dummy group pages to see if there would be any conflict - all current uses of links on dark background make use of their own component based colour choices. 

Nothing would break - but these components (like `vf-footer`) need updating with the new Sass mixin for "dark mode" 