### PR TITLE
The one where the vf-box component gets a makeover

### DIFF
--- a/components/vf-badge/vf-badge.config.yml
+++ b/components/vf-badge/vf-badge.config.yml
@@ -44,5 +44,5 @@ variants:
       theme: tertiary
   - name: link
     context:
-      badge_href: http://www.metallica.com
+      badge_href: "JavaScript:Void(0);"
       text: beta

--- a/components/vf-box/CHANGELOG.md
+++ b/components/vf-box/CHANGELOG.md
@@ -6,3 +6,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 # 1.0.0 (2019-12-17)
 
 * Initial stable release
+
+# 1.1.0 (2020-01-17)
+
+* Deprecates `vf-box--inlay` and `vf-box--factoid`
+* Introduces component–level theming variants

--- a/components/vf-box/CHANGELOG.md
+++ b/components/vf-box/CHANGELOG.md
@@ -3,11 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 1.0.0 (2019-12-17)
-
-* Initial stable release
-
-# 1.1.0 (2020-01-17)
+## 1.1.0
 
 * Deprecates `vf-box--inlay` and `vf-box--factoid`
 * Introduces component–level theming variants
+
+## 1.0.0 (2019-12-17)
+
+* Initial stable release
+

--- a/components/vf-box/README.md
+++ b/components/vf-box/README.md
@@ -4,6 +4,48 @@
 
 ## About
 
+The `vf-box` container is an element to be used when ...
+
+### Options
+
+#### Is Link
+
+If you require the `vf-box` to link to a page you can do this by:
+
+- changing the `<div>` to an `<a href="">`.
+- adding `vf-box--is-link` to the classes being used.
+- if you are using `.njk` you only need to add a `box_href` to the data.
+
+#### Themes
+
+The `vf-box` component allows for global and component–level theming so that it is customisable to your needs.
+
+To make use of the component–level theming you will need to add a theme classname to the component.
+
+The theme classnames available are:
+
+- `vf-box-theme--primary`
+- `vf-box-theme--secondary`
+- `vf-box-theme--tertiary`
+- `vf-box-theme--quaternary`
+- `vf-box-theme--quinary`
+
+#### Design Variants
+
+ There are currently **no** design variants for this component.
+
+### Deprecated Variants
+
+Since `v1.1.0` the following components are considered depracted and should not be used in new projects:
+
+- `vf-box--inlay`
+- `vf-box--factoid`
+
+To update your existing usage of these variants to use the component–level theming you can swap:
+
+- `vf-box--inlay` for `vf-box-theme--quinary`
+- `vf-box--factoid` for `vf-box-theme--primary`
+
 ## Install
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-box` with this command.

--- a/components/vf-box/vf-box--factoid.scss
+++ b/components/vf-box/vf-box--factoid.scss
@@ -1,10 +1,17 @@
-.vf-box--factoid {
-  background-color: set-color(vf-color--green);
-  border-color: set-color(vf-color--green);
-}
+// Begin deprecated classes and styles
+html:not(.vf-disable-deprecated) {
 
-.vf-box--factoid,
-.vf-box--factoid .vf-box__text,
-.vf-box--factoid .vf-box__heading {
-  color: set-ui-color(vf-ui-color--white);
+  // Deprecated in 1.2.0
+  // Will be removed in v2.0
+  .vf-box--factoid {
+    background-color: set-color(vf-color--green);
+    border-color: set-color(vf-color--green);
+  }
+
+  .vf-box--factoid,
+  .vf-box--factoid .vf-box__text,
+  .vf-box--factoid .vf-box__heading {
+    color: set-ui-color(vf-ui-color--white);
+  }
+
 }

--- a/components/vf-box/vf-box--factoid.scss
+++ b/components/vf-box/vf-box--factoid.scss
@@ -1,7 +1,7 @@
 // Begin deprecated classes and styles
 html:not(.vf-disable-deprecated) {
 
-  // Deprecated in 1.2.0
+  // Deprecated in 1.1.0
   // Will be removed in v2.0
   .vf-box--factoid {
     background-color: set-color(vf-color--green);

--- a/components/vf-box/vf-box--inlay.scss
+++ b/components/vf-box/vf-box--inlay.scss
@@ -1,7 +1,7 @@
 // Begin deprecated classes and styles
 html:not(.vf-disable-deprecated) {
 
-  // Deprecated in 1.2.0
+  // Deprecated in 1.1.0
   // Will be removed in v2.0
   .vf-box--inlay {
     background-color: set-ui-color(vf-ui-color--grey);

--- a/components/vf-box/vf-box--inlay.scss
+++ b/components/vf-box/vf-box--inlay.scss
@@ -1,5 +1,12 @@
-.vf-box--inlay {
-  background-color: set-ui-color(vf-ui-color--grey);
-  border-color: set-ui-color(vf-ui-color--grey);
-  color: set-ui-color(vf-ui-color--black);
+// Begin deprecated classes and styles
+html:not(.vf-disable-deprecated) {
+
+  // Deprecated in 1.2.0
+  // Will be removed in v2.0
+  .vf-box--inlay {
+    background-color: set-ui-color(vf-ui-color--grey);
+    border-color: set-ui-color(vf-ui-color--grey);
+    color: set-ui-color(vf-ui-color--black);
+  }
+
 }

--- a/components/vf-box/vf-box.config.yml
+++ b/components/vf-box/vf-box.config.yml
@@ -5,16 +5,102 @@ context:
   component-type: block
 variants:
   - name: default
+    hidden: true
     context:
-      heading: Did You Know?
-      text: This is some more content that would be in the box.
+      box:
+        box_href: "JavaScript:Void(0);"
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+  - name: is a link
+    context:
+      box:
+        box_href: "JavaScript:Void(0);"
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box--is-link
+  - name: easy
+    hidden: true
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box--easy
+  - name: normal
+    hidden: true
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box--normal
+  - name: medium
+    hidden: true
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box--medium
+  - name: hard
+    hidden: true
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box--hard
+  - name: extreme
+    hidden: true
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box--extreme
+  - name: intense
+    hidden: true
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box--intense
+  - name: primary
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box-theme--primary
+  - name: secondary
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box-theme--secondary
+  - name: tertiary
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box-theme--tertiary
+  - name: quaternary
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box-theme--quaternary
+  - name: quinary
+    context:
+      box:
+        box_heading: Did You Know?
+        box_text: This is some more content that would be in the box.
+        box_modifier: vf-box-theme--quinary
   - name: factoid
     context:
-      heading: Did You Know?
-      text: Invasive cancer is the leading cause of death in the developed world and the second leading in the developing world.
-      class: vf-box--factoid
+      box:
+        box_heading: Did You Know?
+        box_text: Invasive cancer is the leading cause of death in the developed world and the second leading in the developing world.
+        box_modifier: vf-box--factoid
+        deprecated_text: vf-box--factoid is now deprecated, please use `vf-box--theme--primary`
   - name: inlay
     context:
-      heading: About the Häring Group
-      text: The Sharpe group brings together an interdisciplinary team of biologists, physicists and computer scientists to build a multi-scale computer simulation of a paradigm of organogenesis – mammalian limb development.
-      class: vf-box--inlay
+      box:
+        box_heading: About the Häring Group
+        box_text: The Sharpe group brings together an interdisciplinary team of biologists, physicists and computer scientists to build a multi-scale computer simulation of a paradigm of organogenesis – mammalian limb development.
+        box_modifier: vf-box--inlay
+        deprecated_text: vf-box--inlay is now deprecated, please use `vf-box--theme--quaternary`

--- a/components/vf-box/vf-box.njk
+++ b/components/vf-box/vf-box.njk
@@ -1,4 +1,4 @@
-{% if box.deprecated_text %}<!-- {{ box.deprecated_text }} -->{% endif %}
+{% if box.deprecated_text %}<!-- {{ box.deprecated_text }} -->{% endif -%}
 
 {# if we're being passed "context" from a parent template, use it as "box" #}
 {%- if context %}
@@ -21,12 +21,11 @@
 
   {# Here is where we are adding any modifier #}
   class="vf-box
-  {%- if box.box_href %} vf-box--is-link{% endif %}
+  {%- if box.box_href %} vf-box--is-link{% endif -%}
   {%- if box.box_modifier %} {{box.box_modifier}}{% endif -%}
 
   {# You want a snowflake of a classname for something, here you go #}
-  {%- if box.override_class %} | {{box.override_class}}{% endif %}
-
+  {%- if box.override_class %} | {{box.override_class}}{% endif -%}
 ">
   <h3 class="vf-box__heading">{{- box.box_heading -}}</h3>
   <p class="vf-box__text">{{- box.box_text -}}</p>

--- a/components/vf-box/vf-box.njk
+++ b/components/vf-box/vf-box.njk
@@ -1,16 +1,33 @@
-<div
+{% if box.deprecated_text %}<!-- {{ box.deprecated_text }} -->{% endif %}
 
-{# You're using an ID? Really?? That'll go here #}
-{%- if id %} id="{{-id-}}"{% endif %}
+{# if we're being passed "context" from a parent template, use it as "box" #}
+{%- if context %}
+  {% set box = context %}
+{% endif %}
 
-{# Here is where we are adding the vf-text--body modifier #}
-class="vf-box
-{%- if class %} {{class}}{% endif -%}
+{% if box.box_href %}
+  {% set tags = 'a' %}
+{% else %}
+  {% set tags = 'div' %}
+{% endif %}
+<{{tags}}
+{# If there's an href put it here #}
+{%- if tags == 'a' %}
+ href="{{ box.box_href if box.box_href else '#' }}"
+{%- endif %}
 
-{# You want a snowflake of a classname for something, here you go #}
-{%- if override_class %} | {{override_class}}{% endif -%}
+  {# You're using an ID? Really?? That'll go here #}
+  {%- if box.id %} id="{{-box.id-}}"{% endif %}
+
+  {# Here is where we are adding any modifier #}
+  class="vf-box
+  {%- if box.box_href %} vf-box--is-link{% endif %}
+  {%- if box.box_modifier %} {{box.box_modifier}}{% endif -%}
+
+  {# You want a snowflake of a classname for something, here you go #}
+  {%- if box.override_class %} | {{box.override_class}}{% endif %}
 
 ">
-  <h3 class="vf-box__heading">{{- heading -}}</h3>
-  <p class="vf-box__text">{{- text -}}</p>
-</div>
+  <h3 class="vf-box__heading">{{- box.box_heading -}}</h3>
+  <p class="vf-box__text">{{- box.box_text -}}</p>
+</{{tags}}>

--- a/components/vf-box/vf-box.scss
+++ b/components/vf-box/vf-box.scss
@@ -12,10 +12,17 @@
 @import 'vf-box.variables.scss';
 
 .vf-box {
-  background-color: set-color(vf-color--grey--dark);
-  border-color: set-color(vf-color--grey--dark);
+  --box-text-color: var( --vf-box-theme-color--foreground, var(--vf-theme-color--foreground, #{set-ui-color(vf-ui-color--black)}));
+  --box-background-color: var(--vf-box-theme-color--background, var(--vf-theme-color--background, #{set-ui-color(vf-ui-color--white)}));
+  --box-border-color: var(--vf-box-theme-color--border, var(--vf-theme-color--border, #{set-ui-color(vf-ui-color--white)}));
+  background-color: set-ui-color(vf-ui-color--white);
+  background-color: var(--box-background-color);
+  border-color: set-ui-color(vf-ui-color--white);
+  border-color: var(--box-border-color);
   box-sizing: border-box;
-  color: set-ui-color(vf-ui-color--white);
+  color: set-ui-color(vf-ui-color--black);
+  color: var(--box-text-color);
+  display: block;
   margin-bottom: $vf-box-outer-spacing;
   padding: 24px 16px;
   width: 100%;
@@ -23,6 +30,20 @@
   // the last element within the component shouldn't have a bottom margin
   & :last-child {
     margin-bottom: 0;
+  }
+}
+
+.vf-box--is-link {
+  text-decoration: none;
+  transition-duration: 250ms;
+  transition-property: box-shadow;
+  transition-timing-function: ease-in-out;
+
+  &:hover {
+    box-shadow: 0 0 4px 4px rgba(0, 0, 0, .2);
+    transition-duration: 250ms;
+    transition-property: box-shadow;
+    transition-timing-function: ease-in-out;
   }
 }
 
@@ -48,22 +69,34 @@
   padding: 32px;
 }
 
-.vf-box--primary {
-  background-color: set-color(vf-color--blue--dark);
-  border-color: set-color(vf-color--blue--dark);
-  color: set-ui-color(vf-ui-color--white);
+.vf-box-theme--primary {
+  --vf-box-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
+  --vf-box-theme-color--border: #{set-color(vf-color--green)};
+  --vf-box-theme-color--background: #{set-color(vf-color--green)};
 }
 
-.vf-box--secondary {
-  background-color: set-color(vf-color--green);
-  border-color: set-color(vf-color--green);
-  color: set-ui-color(vf-ui-color--white);
+.vf-box-theme--secondary {
+  --vf-box-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
+  --vf-box-theme-color--border: #{set-color(vf-color--blue)};
+  --vf-box-theme-color--background: #{set-color(vf-color--blue)};
 }
 
-.vf-box--tertiary {
-  background-color: set-color(vf-color--grey--dark);
-  border-color: set-color(vf-color--grey--dark);
-  color: set-ui-color(vf-ui-color--white);
+.vf-box-theme--tertiary {
+  --vf-box-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
+  --vf-box-theme-color--border: #{set-color(vf-color--grey)};
+  --vf-box-theme-color--background: #{set-color(vf-color--grey)};
+}
+
+.vf-box-theme--quaternary {
+  --vf-box-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
+  --vf-box-theme-color--border: #{set-color(vf-color--yellow)};
+  --vf-box-theme-color--background: #{set-color(vf-color--yellow)};
+}
+
+.vf-box-theme--quinary {
+  --vf-box-theme-color--background: #{set-ui-color(vf-ui-color--grey)};
+  --vf-box-theme-color--border: #{set-ui-color(vf-ui-color--grey)};
+  --vf-box-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
 }
 
 .vf-box--rounded {
@@ -74,5 +107,4 @@
   background-color: transparent;
   border-style: solid;
   border-width: 2px;
-  color: set-ui-color(vf-ui-color--black);
 }

--- a/components/vf-button/vf-button.config.yml
+++ b/components/vf-button/vf-button.config.yml
@@ -49,5 +49,5 @@ variants:
   - name: link
     context:
       text: a link variant
-      button_href: https://example.com/
+      button_href: "JavaScript:Void(0);"
       theme: primary

--- a/components/vf-card-container/vf-card-container.config.yml
+++ b/components/vf-card-container/vf-card-container.config.yml
@@ -15,7 +15,7 @@ context:
   component-type: container
   modifier: vf-u-background-color--grey--lightest
   section_title: Missions
-  href: www.test.com
+  href: "JavaScript:Void(0);"
   # section__subheading: To promote molecular biology across Europe
   vf_section__content:
     - To promote molecular biology across Europe
@@ -23,19 +23,19 @@ context:
   vf_cards:
     - card_type: easy
       card_title: One card
-      card_href: http://www.hello.com
+      card_href: "JavaScript:Void(0);"
       modifier: vf-card--easy
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
     - card_type: normal
       card_title: A card here
-      card_href: http://www.hello.com
+      card_href: "JavaScript:Void(0);"
       modifier: vf-card--normal
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
     - card_type: normal--primary
       card_title: Another card
-      card_href: http://www.hello.com
+      card_href: "JavaScript:Void(0);"
       modifier: vf-card--normal vf-card-theme--primary
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -18,79 +18,79 @@ variants:
   - name: easy
     label: Easy
     hidden: false
-    context: 
-      card: 
+    context:
+      card:
         card_title: A Easy Card Title 1
-        card_href: http://www.hello.com
+        card_href: "JavaScript:Void(0);"
         modifier: vf-card--easy
         card_image: ../../assets/vf-card/assets/vf-card-example.png
         card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal
     label: Normal
     hidden: false
-    context: 
-      card: 
+    context:
+      card:
         card_title: A Normal Card Title 1
-        card_href: http://www.hello.com
+        card_href: "JavaScript:Void(0);"
         modifier: vf-card--normal
         card_image: ../../assets/vf-card/assets/vf-card-example.png
         card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal--primary
     label: Normal (primary)
-    context: 
-      card: 
+    context:
+      card:
         card_title: Normal Card with primary accent
-        card_href: http://www.hello.com
+        card_href: "JavaScript:Void(0);"
         modifier: vf-card--normal vf-card-theme--primary
         card_image: ../../assets/vf-card/assets/vf-card-example.png
         card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal--secondary
     label: Normal (secondary)
-    context: 
-      card: 
+    context:
+      card:
         modifier: vf-card--normal vf-card-theme--secondary
-        card_title: A Normal Card with secondary accent 
+        card_title: A Normal Card with secondary accent
         card_image: ../../assets/vf-card/assets/vf-card-example.png
         card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal--tertiary
     label: Normal (tertiary)
-    context: 
-      card: 
+    context:
+      card:
         modifier: vf-card--normal vf-card-theme--tertiary
         card_title: A Normal Card with tertiary accent
         card_image: ../../assets/vf-card/assets/vf-card-example.png
         card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal--quaternary
     label: Normal (quaternary)
-    context: 
-      card: 
+    context:
+      card:
         modifier: vf-card--normal vf-card-theme--quaternary
         card_title: A Normal Card with quaternary accent
         card_image: ../../assets/vf-card/assets/vf-card-example.png
         card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: medium
     label: Medium
-    context: 
-      card: 
-        card_title: A Medium Card 
-        card_href: http://www.hello.com
+    context:
+      card:
+        card_title: A Medium Card
+        card_href: "JavaScript:Void(0);"
         modifier: vf-card--medium
         card_image: ../../assets/vf-card/assets/vf-card-example.png
         card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: medium--primairy
     label: Medium (primary)
-    context: 
-      card: 
+    context:
+      card:
         card_title: A Medium Card with primairy accent
-        card_href: http://www.hello.com
+        card_href: "JavaScript:Void(0);"
         modifier: vf-card--medium vf-card-theme--primary
         card_image: ../../assets/vf-card/assets/vf-card-example.png
         card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: medium--secondary
     label: Medium (secondary)
     hidden: false
-    context: 
-      card: 
+    context:
+      card:
         modifier: vf-card--medium vf-card-theme--secondary
         card_title: A Medium Card with secondary accent
         card_image: ../../assets/vf-card/assets/vf-card-example.png
@@ -98,8 +98,8 @@ variants:
   - name: medium--tertiary
     label: Medium (tertiary)
     hidden: false
-    context: 
-      card: 
+    context:
+      card:
         modifier: vf-card--medium vf-card-theme--tertiary
         card_title: A Medium Card with tertiary accent
         card_image: ../../assets/vf-card/assets/vf-card-example.png
@@ -107,8 +107,8 @@ variants:
   - name: medium--quaternary
     label: Medium (quaternary)
     hidden: false
-    context: 
-      card: 
+    context:
+      card:
         modifier: vf-card--medium vf-card-theme--quaternary
         card_title: A Medium Card with quaternary accent
         card_image: ../../assets/vf-card/assets/vf-card-example.png
@@ -123,7 +123,3 @@ variants:
   # image: ../../assets/vf-component-name/assets/vf-component-name.png
   # - note on paths: be sure to prefix with `../../`
   # - Why? https://github.com/visual-framework/vf-core/issues/364
-
-
-
-

--- a/components/vf-link/vf-link.config.yml
+++ b/components/vf-link/vf-link.config.yml
@@ -9,5 +9,5 @@ variants:
   - name: default
     hidden: true;
     context:
-      link_href: "#"
+      link_href: "JavaScript:Void(0);"
       text: "A default link"


### PR DESCRIPTION
The updates to `vf-box` allow it to be used like `vf-card` without an image, if needed.

- adds `vf-box-theme--` options
- adds in `.yml` for `vf-box--` design variants ((easy, normal, medium, hard, extreme, intense) they don't exist yet)
- updates `vf-box` styles to be black text on white background
- adds option for `vf-box` to be a link
- deprecates `vf-box--inlay` and `vf-box--factoid`
- adds some documentation

- sneakily adds in an update to all `href` in `.yml` to point to `JavaScript:Void(0);` for consistency.