### PR TITLE
Suggestion: Hide is-a-link and use in some examples

### DIFF
--- a/components/vf-box/vf-box.config.yml
+++ b/components/vf-box/vf-box.config.yml
@@ -12,6 +12,7 @@ variants:
         box_heading: Did You Know?
         box_text: This is some more content that would be in the box.
   - name: is a link
+    hidden: true
     context:
       box:
         box_href: "JavaScript:Void(0);"
@@ -28,6 +29,7 @@ variants:
   - name: normal
     context:
       box:
+        box_href: "JavaScript:Void(0);"
         box_heading: Did You Know?
         box_text: This is some more content that would be in the box.
         box_modifier: vf-box--normal
@@ -60,6 +62,7 @@ variants:
     hidden: true
     context:
       box:
+        box_href: "JavaScript:Void(0);"
         box_heading: Did You Know?
         box_text: This is some more content that would be in the box.
         box_modifier: vf-box--normal vf-box-theme--quinary
@@ -78,6 +81,7 @@ variants:
   - name: medium (secondary)
     context:
       box:
+        box_href: "JavaScript:Void(0);"
         box_heading: Did You Know?
         box_text: This is some more content that would be in the box.
         box_modifier: vf-box--medium vf-box-theme--secondary


### PR DESCRIPTION
Since it's a utility-class-like variant, do we need to show it? And might be good to demonstrate it's use.