### PR TITLE
enhancement: embl-breadcrumb-lookup

### DIFF
--- a/components/embl-breadcrumbs-lookup/CHANGELOG.md
+++ b/components/embl-breadcrumbs-lookup/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## 1.0.0-beta.2 
 
+- Prefers "EMBL.org profile" matches to taxonomy entries
+- If no related breadcrumbs are found, the label will be hidden
+- Do not display "notSet" as a breadcrumb
+- If a non-primairy breadcrumb value is "notSet", a value will be inferred from the primairy breadcrumb's respective who, what or where
 - If no match is found a search is performed
 - Handle non-26 character names (Spaßß => spass) for URLs
 - If no match is found generate a "smart URL" for people
-- Also switches to use the production contentHub
+- Switches to use the production contentHub
 
 ## 1.0.0-alpha.3 (2019-07-25)
 

--- a/components/embl-breadcrumbs-lookup/README.md
+++ b/components/embl-breadcrumbs-lookup/README.md
@@ -7,3 +7,8 @@ This requires and builds atop the `vf-breadcrumbs` and
 
 This component reads meta properties and then performs a lookup to the EMBL contentHub.
 Returned are appropriate primary and secondary breadcrumbs.
+
+Notes:
+
+- If a non-primairy breadcrumb value is "notSet", a value will be inferred from the primairy breadcrumb's respective who, what or where
+- If no match is found a search is performed

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -207,14 +207,36 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
 
     var termObject;
 
-    Array.prototype.forEach.call(Object.keys(emblTaxonomy.terms), (termId) => {
-      let term = emblTaxonomy.terms[termId];
-      if (term.name === termName) {
-        termObject = term;
-        return; //exit
-      }
-    });
+    // scan through all terms and find a match, if any
+    function scanTaxonomyForTerm(termName) {
+      // We prefer profiles
+      Array.prototype.forEach.call(Object.keys(emblTaxonomy.terms), (termId) => {
+        let term = emblTaxonomy.terms[termId];
+        if (term.type == 'profile') {
+          if (term.name_display === termName) {
+            termObject = term;
+            return; //exit
+          }
+        }
+      }); 
 
+      // If no profile found, match any entry in taxonomy
+      if (typeof termObject === undefined) {
+        Array.prototype.forEach.call(Object.keys(emblTaxonomy.terms), (termId) => {
+          let term = emblTaxonomy.terms[termId];
+          if (term.type != 'profile') { 
+            if (term.name_display === termName) {
+              termObject = term;
+              return; //exit
+            }
+          }
+        }); 
+      }
+    }
+
+    scanTaxonomyForTerm(termName);
+
+    // Validation and protection
     // we never want to return undefined
     if (termObject == undefined || termObject == null) {
       // console.warn('embl-js-breadcumbs-lookup: No matching breadcrumb found for `' + termName + '`; Will formulate a URL.');

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -188,6 +188,10 @@ function emblBreadcrumbRemoveDiacritics(str) {
     str = str.replace(defaultDiacriticsRemovalMap[i].letters, defaultDiacriticsRemovalMap[i].base);
   }
 
+  // remove all commas, apostrophes, etc
+  // @todo, this should be done by an optional paramater
+  str = str.replace(/[^a-zA-Z0-9 ]/, ""); 
+
   return str;
 }
 

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -44,6 +44,12 @@ function emblBreadcrumbsLookup(metaProperties) {
       relatedLabel.innerHTML = 'Related:';
       relatedLabel.classList.add('vf-breadcrumbs__heading');
 
+  // If no related terms were found, hide the related label
+  // we only hide it as we could add related terms later
+  if (emblBreadcrumbRelated.childNodes.length == 0) {
+    relatedLabel.classList.add('vf-u-display-none');
+  }
+
   // now that we've processed all the meta properties, insert our rendered breadcrumbs
   emblBreadcrumbTarget[0].innerHTML = emblBreadcrumbPrimary.outerHTML + relatedLabel.outerHTML + emblBreadcrumbRelated.outerHTML;
 }
@@ -238,7 +244,10 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
       }
     }
 
-    scanTaxonomyForTerm(termName);
+    // don't scan for junk matches 
+    if (termName != 'notSet' && termName != '') {
+      scanTaxonomyForTerm(termName);
+    }
 
     // Validation and protection
     // we never want to return undefined

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -231,7 +231,7 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
       }); 
 
       // If no profile found, match any entry in taxonomy
-      if (typeof termObject === undefined) {
+      if (typeof termObject === 'undefined') {
         Array.prototype.forEach.call(Object.keys(emblTaxonomy.terms), (termId) => {
           let term = emblTaxonomy.terms[termId];
           if (term.type != 'profile') { 
@@ -256,8 +256,14 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
       
       termObject = {};
 
-      // if we're linking to people
-      if (facet == 'who') {
+      
+      if (termName == "notSet") {
+        // if a term has not been passed
+        // No matches? Then don't show anything.
+        termName = '';
+
+      } else if (facet == 'who') {
+        // if we're linking to people generate a person URL
         termObject.url = 'https://www.embl.org/people/person/'+emblBreadcrumbRemoveDiacritics(termName).replace(/[\W_]+/g,' ').replace(/\s+/g, '-').toLowerCase();
       } else {
         termObject.url = 'https://www.embl.org/search/#stq='+termName+'&taxonomyFacet='+facet+'&origin=breadcrumbTermNotFound'; // if no link specified, do a search
@@ -342,6 +348,10 @@ function emblBreadcrumbAppend(breadcrumbTarget,termName,facet,type) {
    * @param {string} [breadcrumbUrl] - a fully formed URL, or 'null' to not make a link
    */
   function formatBreadcrumb(termName,breadcrumbUrl) {
+    if (termName == '') {
+      // if no term, do nothing
+      return '';
+    }
     var newBreadcrumb = '<li class="vf-breadcrumbs__item">';
     if (breadcrumbUrl && breadcrumbUrl !== 'null' && breadcrumbUrl !== '#no_url_specified') {
       newBreadcrumb += '<a href="'+breadcrumbUrl+'" class="vf-breadcrumbs__link">' + termName + '</a>';

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.njk
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.njk
@@ -1,4 +1,20 @@
 {% render "@embl-content-meta-properties", {"meta_who": "James Sharpe", "meta_what": "Sharpe Group", "meta_where": "EMBL Barcelona", "meta_active": "what"} %}
 <nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
   <div class="vf-list vf-list--inline | vf-breadcrumbs__list | embl-breadcrumbs-lookup--ghosting"></div>
-</nav>
+</nav> 
+
+{# {% render "@embl-content-meta-properties", {"meta_who": "Christian Löw", "meta_what": "Löw", "meta_where": "EMBL Barcelona", "meta_active": "what"} %}
+<nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
+  <div class="vf-list vf-list--inline | vf-breadcrumbs__list | embl-breadcrumbs-lookup--ghosting"></div>
+</nav> #}
+
+{# {% render "@embl-content-meta-properties", {"meta_who": "Terry O'Connor",  "meta_active": "who"} %}
+<nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
+  <div class="vf-list vf-list--inline | vf-breadcrumbs__list | embl-breadcrumbs-lookup--ghosting"></div>
+</nav> #}
+ 
+
+{# {% render "@embl-content-meta-properties", {"meta_who": "Cian O´Luanaigh", "meta_what": "Communications", "meta_where": "EMBL Heidelberg", "meta_active": "what" } %}
+<nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
+  <div class="vf-list vf-list--inline | vf-breadcrumbs__list | embl-breadcrumbs-lookup--ghosting"></div>
+</nav> #}


### PR DESCRIPTION
Enables "prefered" matches for EMBL profile entries.

todos:
- ~Prefer what=what, who=who, where=where matches~ moved to #773
- ~Support UUID if found~ moved to #773
- [x] Handle cases when other terms are notSet