### PR TITLE
Enhancement: embl-content-hub-loader handle no results

### DIFF
--- a/components/embl-content-hub-loader/CHANGELOG.md
+++ b/components/embl-content-hub-loader/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+## 1.0.2 
 
-# 1.0.0 (2019-12-17)
+* adds features for when no content is returned. Supply "no content found" text or hide a region.
+
+## 1.0.1 (2019)
+
+* adds CSS for times when the `*-content-hub-html` is a direct child of `vf-body`.
+
+## 1.0.0 (2019-12-17)
 
 * Initial stable release
 
-
-# 1.0.1 (2019)
-
-* adds CSS for times when the `*-content-hub-html` is a direct child of `vf-body`.

--- a/components/embl-content-hub-loader/README.md
+++ b/components/embl-content-hub-loader/README.md
@@ -8,6 +8,34 @@ Use this component to remotely load markup and content from the central EMBL Con
 
 Currently this is done as HTML imports (see the code example) + some JS. In the future other methods will be support (such as JSON).
 
+### Supported patterns 
+
+See the [introductory text on the contentHub](https://content.embl.org/).
+
+### Standard HTML import
+
+Load a content and pattern through the contentHub:
+
+```html
+<link rel="import" href="https://www.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=580&pattern=node-body&source=contenthub" data-target="self" data-embl-js-content-hub-loader>
+```
+
+### Options
+
+There are optional features specified by data attributes, looks like:
+
+```html
+<link rel="import" href="https://www.embl.org/api/v1/pattern.html?source=contenthub&pattern=embl-person-publications&limit=100&sort-field-value[changed]=DESC&orcid=0000-0002-2524-5026&source=contenthub" data-target="publications-block" data-embl-js-content-hub-loader-no-content="No publications were found." data-embl-js-content-hub-loader-no-content-hide=".publications-container" data-embl-js-content-hub-loader>
+```
+
+Breakdown:
+
+- `data-target="publications-block"`: pass the class of an element to insert text into
+- `data-embl-js-content-hub-loader-no-content="No publications were found."`: String to use if no results found, can also pass `true` to use default no match text
+- `data-embl-js-content-hub-loader-no-content-hide=".publications-container"`: If no results, hide an element that matches this selector selector 
+- `data-inject-class="vf-grid vf-grid__col-2" data-inject-class-target="ul"`: Inject class(es) to a an element inside the returned content
+
+
 ## Install
 
 This repository is distributed with [npm][npm]. After [installing npm][install-npm], you can install `primer-buttons` with this command.

--- a/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
@@ -104,7 +104,34 @@ function emblContentHubFetch() {
       exportedContent = exportedContent.firstElementChild;
       exportedContent.classList.add('vf-content-hub-html');
       exportedContent.classList.add('vf-content-hub-html__derived-div');
-    }
+    } else if (exportedContent.childNodes.length == 3) {
+      // if there are three or fewer child nodes this is likely a no-results reply
+      // We'll still inject the content from the contentHub along with any passed "no matches" text
+      var noContentMessage = targetLink.getAttribute('data-embl-js-content-hub-loader-no-content');
+
+      if (noContentMessage == 'true') {
+        // use a default
+        noContentMessage = 'No content was found found for this query.';
+      } 
+
+      var noContentMessageElement = document.createElement('div');
+      noContentMessageElement.classList.add('vf-text');
+      noContentMessageElement.classList.add('embl-content-hub-html__no-content-found');
+      noContentMessageElement.innerHTML = noContentMessage;
+      exportedContent.appendChild(noContentMessageElement.firstChild);
+
+      // if data-embl-js-content-hub-loader-no-content-hide is true or has a class, hide accordingly
+      var noContentHideBehavior = targetLink.getAttribute('data-embl-js-content-hub-loader-no-content-hide');
+      if (noContentHideBehavior) {
+        if (noContentHideBehavior == 'true') {
+          // if true, just hide the response
+          exportedContent.classList.add('vf-u-display-none');
+        } else {
+          // otherwise hide any element specified
+          document.querySelector(noContentHideBehavior).classList.add('vf-u-display-none');
+        }
+      } // END noContentHideBehavior
+    } // END exportedContent.childElementCount
 
     var contentID = emblContentHubGenerateID(position);
 


### PR DESCRIPTION
Adds features to handle no-result responses from contentHub:

- `data-embl-js-content-hub-loader-no-content="No publications were found."`: String to use if no results found, can also pass `true` to use default no match text
- `data-embl-js-content-hub-loader-no-content-hide=".publications-container"`: If no results, hide an element that matches this selector selector