### PR TITLE
The one where the vf-section-header goes all blue

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.1.0
+
+* adds ability for section header to have sub-heading and text.
+* :visited styles so they're blue.
+* removes cursor: pointer and display: block from --is-link.
+* moves transform out of todo.
+* fixes transition-property to animation works.
+* adds last-of-type to vf-section-header__text to remove any margin.
+
 # 1.0.1 (2020-01-24)
 
 * Tweaks link mixin, adds `@mixin inline-link--dark-mode`

--- a/components/vf-section-header/vf-section-header.scss
+++ b/components/vf-section-header/vf-section-header.scss
@@ -14,16 +14,18 @@
 
   & + .vf-section-header__subheading,
   & + .vf-section-header__content {
-    @include margin--block(top, map-get($vf-spacing-map, vf-spacing--lg));
+    margin-top: map-get($vf-spacing-map, vf-spacing--lg);
   }
 }
 .vf-section-header__heading--is-link {
   @include inline-link($vf-link--visited-color: map-get($vf-colors-map, vf-color--blue));
+  cursor: pointer;
+  display: block;
 
   .vf-section-header__icon {
     fill: currentColor;
-    margin-left: 8px;
-    transform: translateY(4px);
+    margin-left: map-get($vf-spacing-map, vf-spacing--sm);
+    transform: translateY(map-get($vf-spacing-map, vf-spacing--xs));
     // @todo: some sort of centralised and reusable docs, tokens, guidance on animations
     transition-duration: 125ms;
     transition-property: transform;
@@ -33,7 +35,7 @@
   &:hover,
   &:focus {
     .vf-section-header__icon {
-      transform: translateX(4px) translateY(4px);
+      transform: translateX(map-get($vf-spacing-map, vf-spacing--xs)) translateY(map-get($vf-spacing-map, vf-spacing--xs));
     }
   }
 }
@@ -46,13 +48,19 @@
   @include set-type(text-body--2, $custom-margin-bottom: 8px);
 
   &:last-of-type {
-    margin-bottom: 0;
+    @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--0));
   }
 
   .vf-section-header__heading + & {
-    @include margin--block(top, map-get($vf-spacing-map, vf-spacing--lg));
+    margin-top: 24px;
   }
   .vf-section-header__subheading + & {
-    @include margin--block(top, map-get($vf-spacing-map, vf-spacing--md));
+    margin-top: 16px;
+  }
+  .vf-section-header__heading + & {
+    margin-top: map-get($vf-spacing-map, vf-spacing--lg);
+  }
+  .vf-section-header__subheading + & {
+    margin-top: map-get($vf-spacing-map, vf-spacing--md);
   }
 }

--- a/components/vf-section-header/vf-section-header.scss
+++ b/components/vf-section-header/vf-section-header.scss
@@ -18,18 +18,15 @@
   }
 }
 .vf-section-header__heading--is-link {
-  @include inline-link;
-  color: set-color(vf-color--blue);
-  cursor: pointer;
-  display: block;
+  @include inline-link($vf-link--visited-color: map-get($vf-colors-map, vf-color--blue));
 
   .vf-section-header__icon {
     fill: currentColor;
     margin-left: 8px;
-    // @todo: some sort of centralised and reusable docs, tokens, guidance on animations
     transform: translateY(4px);
+    // @todo: some sort of centralised and reusable docs, tokens, guidance on animations
     transition-duration: 125ms;
-    transition-property: transformX;
+    transition-property: transform;
     transition-timing-function: cubic-bezier(.45, .05, .55, .95);
   }
 
@@ -47,6 +44,11 @@
 
 .vf-section-header__text {
   @include set-type(text-body--2, $custom-margin-bottom: 8px);
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+
   .vf-section-header__heading + & {
     margin-top: 24px;
   }

--- a/components/vf-section-header/vf-section-header.scss
+++ b/components/vf-section-header/vf-section-header.scss
@@ -14,7 +14,7 @@
 
   & + .vf-section-header__subheading,
   & + .vf-section-header__content {
-    margin-top: 24px;
+    @include margin--block(top, map-get($vf-spacing-map, vf-spacing--lg));
   }
 }
 .vf-section-header__heading--is-link {
@@ -50,9 +50,9 @@
   }
 
   .vf-section-header__heading + & {
-    margin-top: 24px;
+    @include margin--block(top, map-get($vf-spacing-map, vf-spacing--lg));
   }
   .vf-section-header__subheading + & {
-    margin-top: 16px;
+    @include margin--block(top, map-get($vf-spacing-map, vf-spacing--md));
   }
 }

--- a/components/vf-section-header/vf-section-header.scss
+++ b/components/vf-section-header/vf-section-header.scss
@@ -37,6 +37,10 @@
     .vf-section-header__icon {
       transform: translateX(map-get($vf-spacing-map, vf-spacing--xs)) translateY(map-get($vf-spacing-map, vf-spacing--xs));
     }
+
+    &:visited {
+      color: map-get($vf-colors-map, vf-color--blue--dark);
+    }
   }
 }
 


### PR DESCRIPTION
Because of Safari not respecting `currentColor` for an SVG that's inside a `:visited` `<a>` tag and because it looks 'odd' for components. We have made a stylistic change to the `:visited` state. Plus some other little nice-to-haves.

- :visited styles so they're blue
- removes cursor: pointer and display: block from --is-link
- moves transform out of todo
- fixes transition-property to animation works
- adds last-of-type to vf-section-header__text to remove any margin