### PR TITLE
Clean up ebi-header-footer

### DIFF
--- a/components/ebi-header-footer/ebi-header-footer--embl-selector.scss
+++ b/components/ebi-header-footer/ebi-header-footer--embl-selector.scss
@@ -52,9 +52,10 @@
       .button.hover,
       .button:focus,
       .button:hover {
-        background: no-repeat 4px 50% url("https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/EMBL_EBI_Logo_white.svg");
+        background: no-repeat 5px 48% url(https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/EMBL_EBI_Logo_white.svg);
         padding-left: 95px;
-        background-size: 100px;
+        background-size: 90px;
+        max-height: 33px;
       }
     }
 

--- a/components/ebi-header-footer/ebi-header-footer--footer.scss
+++ b/components/ebi-header-footer/ebi-header-footer--footer.scss
@@ -1,11 +1,11 @@
 // ebi-header-footer--footer
 // LOCAL FOOTER
-.local-footer {
+.ebi-header-footer.local-footer {
   border-top: 2px solid var(--vf-ui-color--off-white);;
 }
 
 // GLOBAL FOOTER
-.global-footer {
+.ebi-header-footer.global-footer {
   border-top: 5px solid var(--vf-ui-color--off-white);;
   padding-top: 1.5rem;
 
@@ -13,9 +13,7 @@
     display: inline !important;
   }
 
-  .address {
+  p.address {
     margin: 1.5em 0 5px 0;
   }
-
 } 
-

--- a/components/ebi-header-footer/ebi-header-footer--form.scss
+++ b/components/ebi-header-footer/ebi-header-footer--form.scss
@@ -46,7 +46,7 @@ fieldset {
   line-height: 1;
   text-decoration: none;
   display: block;
-  padding: 0.7rem 1rem;
+  padding: 0.6rem 1rem;
 }
 
 .button {

--- a/components/ebi-header-footer/ebi-header-footer--header.scss
+++ b/components/ebi-header-footer/ebi-header-footer--header.scss
@@ -24,11 +24,17 @@ body.no-global-search .masthead-black-bar ul#global-nav.menu li.search { display
   a:focus {
     box-shadow: 0 0 2px var(--vf-color--grey--lightest)
   }
-
+  
+  .vf-content .global-masthead-interactive-banner p:not([class*='vf-']) {
+    font-size: 15px; // embl dropdown p tags shouldn't have large text
+  } 
+  
   .global-masthead-interactive-banner {
-    height: 0; overflow: hidden;
+    height: 0; 
+    overflow: hidden;
     display: none;
     background-color: #000;
+    
 
     &.active {
       display: block;
@@ -63,6 +69,8 @@ body.no-global-search .masthead-black-bar ul#global-nav.menu li.search { display
     }
 
     li {
+      font-size: 14.4px; // to closely match existing height
+
       a:before {
         font-family: 'EBI-Generic';
         display: inline-block; // safari 9 & 10 fix

--- a/components/ebi-header-footer/ebi-header-footer--layout.scss
+++ b/components/ebi-header-footer/ebi-header-footer--layout.scss
@@ -1,6 +1,6 @@
 // ebi-header-footer--footer
 .row {
-  max-width: 76.5rem;
+  max-width: $global-page-max-width;
   margin-right: auto;
   margin-left: auto;
 }
@@ -37,7 +37,7 @@ content: ' '; }
 clear: both; }
 
 .row {
-max-width: 76.5rem;
+max-width: $global-page-max-width;
 margin-right: auto;
 margin-left: auto; }
 .row::before, .row::after {

--- a/components/ebi-header-footer/ebi-header-footer--layout.scss
+++ b/components/ebi-header-footer/ebi-header-footer--layout.scss
@@ -37,7 +37,7 @@ content: ' '; }
 clear: both; }
 
 .row {
-max-width: 80rem;
+max-width: 76.5rem;
 margin-right: auto;
 margin-left: auto; }
 .row::before, .row::after {

--- a/components/ebi-header-footer/ebi-header-footer--layout.scss
+++ b/components/ebi-header-footer/ebi-header-footer--layout.scss
@@ -1,5 +1,4 @@
 // ebi-header-footer--footer
-
 .row {
   max-width: 76.5rem;
   margin-right: auto;
@@ -139,4 +138,4 @@ padding-left: 0; }
     clear: both; }
   .large-up-3 > .column:last-child, .large-up-3 > .columns:last-child {
     float: left; }
- }
+}

--- a/components/ebi-header-footer/ebi-header-footer.njk
+++ b/components/ebi-header-footer/ebi-header-footer.njk
@@ -1,7 +1,7 @@
 {%- if frctl.env.server %}
 <link rel="stylesheet" href="../raw/ebi-header-footer/ebi-header-footer.css" type="text/css" media="all" />
 {% else %}
-{# <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/assets/ebi-header-footer/ebi-header-footer.css" type="text/css" media="all" /> #}
+<link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/assets/ebi-header-footer/ebi-header-footer.css" type="text/css" media="all" />
 {% endif %}
 <link rel="stylesheet" href="https://dev.ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
 

--- a/components/ebi-header-footer/ebi-header-footer.njk
+++ b/components/ebi-header-footer/ebi-header-footer.njk
@@ -1,7 +1,7 @@
 {%- if frctl.env.server %}
 <link rel="stylesheet" href="../raw/ebi-header-footer/ebi-header-footer.css" type="text/css" media="all" />
 {% else %}
-<link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/assets/ebi-header-footer/ebi-header-footer.css" type="text/css" media="all" />
+{# <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/assets/ebi-header-footer/ebi-header-footer.css" type="text/css" media="all" /> #}
 {% endif %}
 <link rel="stylesheet" href="https://dev.ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
 
@@ -22,5 +22,3 @@ Your content here.
 </footer>
 
 <script defer="defer" src="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/script.js"></script>
-
-

--- a/components/ebi-header-footer/ebi-header-footer.scss
+++ b/components/ebi-header-footer/ebi-header-footer.scss
@@ -19,22 +19,50 @@
 @import 'ebi-header-footer.variables.scss';
 
 @import 'ebi-header-footer--header.scss';
+@import 'ebi-header-footer--footer.scss';
 
 .ebi-header-footer {
   @import 'ebi-header-footer--embl-selector.scss';
-  @import 'ebi-header-footer--footer.scss';
-  
   @import 'ebi-header-footer--layout.scss';
   @import 'ebi-header-footer--form.scss';
   @import 'ebi-header-footer--utility.scss';
 }
 
-.data-protection-banner a {
-  @include inline-link--dark-mode(
-    $vf-link--color: set-ui-color(vf-ui-color--white),
-    $vf-link--hover-color: set-ui-color(vf-ui-color--white),
-    $vf-link--visited-color: set-ui-color(vf-ui-color--white)
-  );
-  cursor: pointer; // data-protection-agree has no href and does no get a pointer by default in most browsers
+.data-protection-banner {
+
+  background-color: #373a36 !important;
+ 
+  .row {
+    @media (min-width: $vf-breakpoint--sm) {
+      display: flex;
+    }
+    max-width: 76.5em;
+    margin: 0 auto;
+
+    .columns {
+      margin: 0 0.5rem 0.5rem;
+    }
+
+    @media (min-width: $vf-breakpoint--sm) {
+      .medium-8 {
+        flex: 5;
+      }
+      .medium-4 {
+        flex: 2;
+        text-align: right;
+      }
+    }
+
+  }
+
+  a {
+    @include inline-link--dark-mode(
+      $vf-link--color: set-ui-color(vf-ui-color--white),
+      $vf-link--hover-color: set-ui-color(vf-ui-color--white),
+      $vf-link--visited-color: set-ui-color(vf-ui-color--white)
+    );
+    cursor: pointer; // data-protection-agree has no href and does no get a pointer by default in most browsers
+  }
+  
 }
 

--- a/components/ebi-header-footer/ebi-header-footer.scss
+++ b/components/ebi-header-footer/ebi-header-footer.scss
@@ -30,7 +30,7 @@
 
 .data-protection-banner {
 
-  background-color: #373a36 !important;
+  background-color: set-color(color-grey-darkest);
  
   .row {
     @media (min-width: $vf-breakpoint--sm) {

--- a/components/ebi-header-footer/ebi-header-footer.scss
+++ b/components/ebi-header-footer/ebi-header-footer.scss
@@ -31,12 +31,12 @@
 .data-protection-banner {
 
   background-color: set-color(color-grey-darkest);
- 
+
   .row {
     @media (min-width: $vf-breakpoint--sm) {
       display: flex;
     }
-    max-width: 76.5em;
+    max-width: $global-page-max-width;
     margin: 0 auto;
 
     .columns {

--- a/components/ebi-header-footer/ebi-header-footer.scss
+++ b/components/ebi-header-footer/ebi-header-footer.scss
@@ -30,7 +30,7 @@
 }
 
 .data-protection-banner a {
-  @include inline-link(
+  @include inline-link--dark-mode(
     $vf-link--color: set-ui-color(vf-ui-color--white),
     $vf-link--hover-color: set-ui-color(vf-ui-color--white),
     $vf-link--visited-color: set-ui-color(vf-ui-color--white)

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -177,5 +177,3 @@ html, button {
 
 // If you have any locoal overrides, put them in:
 @import 'vf-local-overrides/vf-local-overrides.scss';
-@import 'ebi-header-footer/ebi-header-footer.scss';
-

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -177,3 +177,5 @@ html, button {
 
 // If you have any locoal overrides, put them in:
 @import 'vf-local-overrides/vf-local-overrides.scss';
+@import 'ebi-header-footer/ebi-header-footer.scss';
+


### PR DESCRIPTION
Changes to other vf components need to be considered in the ebi-header-footer compatibility code. Mostly changes around base font size and the removal of underlines on fonts.

Currently:

![image](https://user-images.githubusercontent.com/928100/75446902-9c2eb900-5968-11ea-8a71-d6c3a7ac445a.png)

Revised:

![image](https://user-images.githubusercontent.com/928100/75449648-9e474680-596d-11ea-943f-4bd43b7fbdd5.png)


Ping @esanzgar