### PR TITLE
bug: vf-figure path handling

### DIFF
--- a/components/vf-figure/CHANGELOG.md
+++ b/components/vf-figure/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+## 1.0.0-beta.2
 
-# 1.0.0-alpha.8 (2019-10-23)
-
-**Note:** Version bump only for package @visual-framework/vf-figure
-
-
-
-
-
-# 1.0.0-alpha.7 (2019-09-30)
-
-**Note:** Version bump only for package @visual-framework/vf-figure
+* removes the `| path` from the njk template which made it non-usable outside of Fractal

--- a/components/vf-figure/vf-figure.config.yml
+++ b/components/vf-figure/vf-figure.config.yml
@@ -7,4 +7,4 @@ context:
 
   text: Version, 1982, Adenovirus with 217 dots
   alttext: hello alt text
-  imageUrl: "/assets/vf-figure/assets/figure-example.png"
+  imageUrl: "../../assets/vf-figure/assets/figure-example.png"

--- a/components/vf-figure/vf-figure.njk
+++ b/components/vf-figure/vf-figure.njk
@@ -1,8 +1,7 @@
-<figure
-{# You're using an ID? Really?? That'll go here #}
-{% if id %} id="{{-id-}}"{% endif %}
+<figure {# You're using an ID? Really?? That'll go here -#}
+{%- if id -%} id="{{-id-}}" {%- endif -%}
 class="vf-figure
 {%- if override_class %} | {{override_class}}{% endif -%}">
-  <img class="vf-figure__image" src="{{imageUrl | path}}" alt="{{alttext}}">
+  <img class="vf-figure__image" src="{{imageUrl}}" alt="{{alttext}}">
   <figcaption class="vf-figure__caption">{{- html | safe if html else text -}}</figcaption>
 </figure>


### PR DESCRIPTION
This removes the ` | path` from the njk template which made it non-usable outside of fractal (it now follow the docs made sense this pattern was last updated).

Also eats extra white space.