### PR TITLE
Bug: use embl.org over dev.beta.embl.org

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # This script runs on gitlab.ebi.ac.uk
 # https://gitlab.ebi.ac.uk/emblorg/vf-core-mirror
 # We do it to deploy the pattern library for view
-# http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/
+# http://www.embl.org/guidelines/visual-framework/dev-docs/
 # https://dev.assets.emblstatic.net/vf/develop/
 # https://dev.assets.emblstatic.net/vf/{tag}/ (eg v2.1.2 / v2.1.3-alpha.3)
 # https://dev.assets.emblstatic.net/vf/{minor}/ (eg v2.1)

--- a/components/ebi-vf1-integration/README.md
+++ b/components/ebi-vf1-integration/README.md
@@ -15,7 +15,7 @@ Enable its use by:
 
 ### Option 1
 
-Use the global VF 2.0 CSS along side your existing VF 1.x CSS; see: https://dev.beta.embl.org/guidelines/design/patterns/
+Use the global VF 2.0 CSS along side your existing VF 1.x CSS; see: https://www.embl.org/guidelines/design/patterns/
 
 ### Option 2
 

--- a/components/embl-breadcrumbs-lookup/package.json
+++ b/components/embl-breadcrumbs-lookup/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-beta.3",
   "name": "@visual-framework/embl-breadcrumbs-lookup",
   "description": "embl-breadcrumbs-lookup component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "build/embl-breadcrumbs-lookup.css",

--- a/components/embl-content-hub-loader/embl-content-hub-loader.njk
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.njk
@@ -1,5 +1,5 @@
 <div class="embl-content-hub-loader">
   <p>Below we do a sample import from the ContentHub:</p>
-  <link rel="import" href="https://dev.beta.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=575&pattern=node-body&source=contenthub" data-target="self" data-embl-js-content-hub-loader>
+  <link rel="import" href="https://www.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=575&pattern=node-body&source=contenthub" data-target="self" data-embl-js-content-hub-loader>
 
 </div>

--- a/components/embl-content-meta-properties/package.json
+++ b/components/embl-content-meta-properties/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "@visual-framework/embl-content-meta-properties",
   "description": "embl-content-meta-properties component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "embl-content-meta-properties.css",

--- a/components/embl-favicon/embl-favicon.njk
+++ b/components/embl-favicon/embl-favicon.njk
@@ -1,7 +1,7 @@
-<link rel="apple-touch-icon" sizes="180x180" href="https://dev.beta.embl.org/guidelines/design/assets/embl-favicon/assets/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dev.beta.embl.org/guidelines/design/assets/embl-favicon/assets//favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dev.beta.embl.org/guidelines/design/assets/embl-favicon/assets/favicon-16x16.png">
-<link rel="manifest" href="https://dev.beta.embl.org/guidelines/design/assets/embl-favicon/assets/site.webmanifest">
-<link rel="mask-icon" href="https://dev.beta.embl.org/guidelines/design/assets/embl-favicon/assets/safari-pinned-tab.svg" color="#ffffff">
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets//favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/favicon-16x16.png">
+<link rel="manifest" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/site.webmanifest">
+<link rel="mask-icon" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/safari-pinned-tab.svg" color="#ffffff">
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="theme-color" content="#ffffff">

--- a/components/embl-grid/package.json
+++ b/components/embl-grid/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.2",
   "name": "@visual-framework/embl-grid",
   "description": "embl-grid component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "embl-grid.css",

--- a/components/embl-logo/package.json
+++ b/components/embl-logo/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.2",
   "name": "@visual-framework/embl-logo",
   "description": "embl-logo component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "embl-logo.css",

--- a/components/vf-boilerplate-page/vf-boilerplate-page.njk
+++ b/components/vf-boilerplate-page/vf-boilerplate-page.njk
@@ -29,7 +29,7 @@
           <h3 class="vf-text vf-text-heading--4">
             Don't need to customise the EMBL Design Language for Websites?
           </h3>
-          <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the component library</a>.</p>
+          <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="http://www.embl.org/guidelines/visual-framework/dev-docs/" class="vf-link">consult the component library</a>.</p>
           {% codeblock 'html' -%}
 <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
 <script src="https://dev.assets.emblstatic.net/vf/develop/scripts/scripts.js"></script>

--- a/components/vf-form/vf-form__checkbox/package.json
+++ b/components/vf-form/vf-form__checkbox/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.8",
   "name": "@visual-framework/vf-form__checkbox",
   "description": "vf-form__checkbox component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-form__checkbox.css",

--- a/components/vf-form/vf-form__helper/package.json
+++ b/components/vf-form/vf-form__helper/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.8",
   "name": "@visual-framework/vf-form__helper",
   "description": "vf-form__helper component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-form__helper.css",

--- a/components/vf-form/vf-form__input/package.json
+++ b/components/vf-form/vf-form__input/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.10",
   "name": "@visual-framework/vf-form__input",
   "description": "vf-form__input component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-form__input.css",

--- a/components/vf-form/vf-form__item/package.json
+++ b/components/vf-form/vf-form__item/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.9",
   "name": "@visual-framework/vf-form__item",
   "description": "vf-form__item component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-form__item.css",

--- a/components/vf-form/vf-form__label/package.json
+++ b/components/vf-form/vf-form__label/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.9",
   "name": "@visual-framework/vf-form__label",
   "description": "vf-form__label component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-form__label.css",

--- a/components/vf-form/vf-form__radio/package.json
+++ b/components/vf-form/vf-form__radio/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.8",
   "name": "@visual-framework/vf-form__radio",
   "description": "vf-form__radio component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-form__radio.css",

--- a/components/vf-form/vf-form__select/package.json
+++ b/components/vf-form/vf-form__select/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.8",
   "name": "@visual-framework/vf-form__select",
   "description": "vf-form__select component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-form__select.css",

--- a/components/vf-form/vf-form__textarea/package.json
+++ b/components/vf-form/vf-form__textarea/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.9",
   "name": "@visual-framework/vf-form__textarea",
   "description": "vf-form__textarea component",
-  "homepage": "http://dev.beta.embl.org/guidelines/visual-framework/dev-docs/",
+  "homepage": "http://www.embl.org/guidelines/visual-framework/dev-docs/",
   "author": "VF",
   "license": "Apache 2.0",
   "style": "vf-form__textarea.css",


### PR DESCRIPTION
dev.beta is now out and www.embl.org is in.

This is currently breaking favicon in some places so good to get it in.