### PR TITLE
bug: favicon paths

### DIFF
--- a/components/vf-favicon/CHANGELOG.md
+++ b/components/vf-favicon/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 1.0.0 (2019-12-17)
+## 1.0.1
+
+* Fixes default path of favicons
+* Improves docs
+
+## 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-favicon/README.md
+++ b/components/vf-favicon/README.md
@@ -4,6 +4,21 @@
 
 ## About
 
+A template to specify favicons for your site:
+
+```
+{% render '@vf-favicon', {
+    apple_touch_icon: "../../assets/vf-favicon/assets/apple-touch-icon.png",
+    icon_32: "../../assets/vf-favicon/assets/favicon-32x32.png",
+    icon_16: "../../assets/vf-favicon/assets/favicon-16x16.png",
+    manifest: "../../assets/vf-favicon/assets/site.webmanifest",
+    icon_mask: "../../assets/vf-favicon/assets/safari-pinned-tab.svg",
+    color_mask: "#ffffff",
+    color_msapplication: "#ffffff",
+    color_theme: "#ffffff"
+} %}
+```
+
 ## Install
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-favicon` with this command.
@@ -11,6 +26,5 @@ This component is distributed with npm. After [installing npm](https://www.npmjs
 ```
 $ yarn add --dev @visual-framework/vf-favicon
 ```
-
 
 _Make sure you import Sass requirements along with the modules._

--- a/components/vf-favicon/README.md
+++ b/components/vf-favicon/README.md
@@ -7,6 +7,23 @@
 A template to specify favicons for your site:
 
 ```
+{% raw %}
+{% render '@vf-favicon', {
+    apple_touch_icon: "../../assets/vf-favicon/assets/apple-touch-icon.png",
+    icon_32: "../../assets/vf-favicon/assets/favicon-32x32.png",
+    icon_16: "../../assets/vf-favicon/assets/favicon-16x16.png",
+    manifest: "../../assets/vf-favicon/assets/site.webmanifest",
+    icon_mask: "../../assets/vf-favicon/assets/safari-pinned-tab.svg",
+    color_mask: "#ffffff",
+    color_msapplication: "#ffffff",
+    color_theme: "#ffffff"
+} %}
+{% endraw %}
+```
+
+Yields: 
+
+```
 {% render '@vf-favicon', {
     apple_touch_icon: "../../assets/vf-favicon/assets/apple-touch-icon.png",
     icon_32: "../../assets/vf-favicon/assets/favicon-32x32.png",

--- a/components/vf-favicon/vf-favicon.config.yml
+++ b/components/vf-favicon/vf-favicon.config.yml
@@ -6,11 +6,11 @@ context:
 variants:
   - name: default
     context:
-      apple_touch_icon: https://dev.assets.emblstatic.net/vf/assets/vf-favicon/assets/apple-touch-icon.png
-      icon_32: https://dev.assets.emblstatic.net/vf/assets/vf-favicon/assets/favicon-32x32.png
-      icon_16: https://dev.assets.emblstatic.net/vf/assets/vf-favicon/assets/favicon-16x16.png
-      manifest: https://dev.assets.emblstatic.net/vf/assets/vf-favicon/assets/site.webmanifest
-      icon_mask: https://dev.assets.emblstatic.net/vf/assets/vf-favicon/assets/safari-pinned-tab.svg
+      apple_touch_icon: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/apple-touch-icon.png
+      icon_32: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/favicon-32x32.png
+      icon_16: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/favicon-16x16.png
+      manifest: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/site.webmanifest
+      icon_mask: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/safari-pinned-tab.svg
       color_mask: '#ffffff'
       color_msapplication: '#ffffff'
       color_theme: '#ffffff'


### PR DESCRIPTION
Favicons were hard wired to the old emblstatic deploy path. Instead, they should use the develop branch. 