### PR TITLE
fixes issue with vf-grid in production

### DIFF
--- a/components/vf-grid/README.md
+++ b/components/vf-grid/README.md
@@ -12,6 +12,8 @@ You can define the number of columns with a modifier class.
 
 ***Do Not Use*** with any component that uses the `<table>` HTML element as this breaks built-in browser accessibility for screen readers etc.
 
+Currently (16/03/20) The `vf-grid` is expecting to be a parent of `vf-body`. It does, however, work inside `embl-grid` now as we have added CSS to make it respect the boundaries so that it doesn't break. 
+
 ## Install
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-grid` with this command.

--- a/components/vf-grid/vf-grid.scss
+++ b/components/vf-grid/vf-grid.scss
@@ -55,8 +55,17 @@
       grid-auto-flow: column
     }
   }
+  // This rule seems to break things more than it fixes.
+  // @media (max-width: 1299px) {
+  //   .vf-grid {
+  //     grid-column: 1 / -1;
+  //   }
+  // }
+
+  // This is needed for when the vf-grid is nested inside an embl-grid, like the news
+  // home page.
   @media (max-width: 1299px) {
-    .vf-grid {
+    .embl-grid .vf-grid {
       grid-column: 1 / -1;
     }
   }


### PR DESCRIPTION
there's a little bug in places where `vf-grid` causes the `vf-body` component to not be the correct sizes expected.

removing this line from `vf-grid` seems to fix this and not break in places it is used.

```
@media (max-width: 1299px) {
  .vf-grid {
    grid-column: 1 / -1;
  }
}
```

however, this breaks if the `vf-grid` is inside an `embl-grid` like it is on the news homepage - https://wwwdev.embl.org/news/

so the CSS is commented out, and then repeated underneath but scored to `embl-grid`.

This shows that we need to take a look at the original ideas of the grid systems and work towards making a cleaner initial 'page layout' which doesn't rely on us adding a classname or adding CSS to an element. 