### PR TITLE
makes changes so njk works in 11ty or WP

### DIFF
--- a/components/vf-box/vf-box.njk
+++ b/components/vf-box/vf-box.njk
@@ -1,11 +1,22 @@
-{% if box.deprecated_text %}<!-- {{ box.deprecated_text }} -->{% endif -%}
-
 {# if we're being passed "context" from a parent template, use it as "box" #}
 {%- if context %}
   {% set box = context %}
 {% endif %}
 
-{% if box.box_href %}
+{%- if box %}
+  {% set deprecated_text = box.deprecated_text %}
+  {% set box_href = box.box_href %}
+  {% set id = box.id %}
+  {% set box_modifier = box.box_modifier %}
+  {% set override_class = box.override_class %}
+  {% set box_heading = box.box_heading %}
+  {% set box_text = box.box_text %}
+  {% set box_text = box.box_text %}
+{% endif %}
+
+{% if box.deprecated_text %}<!-- {{ box.deprecated_text }} -->{% endif -%}
+
+{% if box_href %}
   {% set tags = 'a' %}
 {% else %}
   {% set tags = 'div' %}
@@ -13,20 +24,20 @@
 <{{tags}}
 {# If there's an href put it here #}
 {%- if tags == 'a' %}
- href="{{ box.box_href if box.box_href else '#' }}"
+ href="{{ box_href if box_href else '#' }}"
 {%- endif %}
 
   {# You're using an ID? Really?? That'll go here #}
-  {%- if box.id %} id="{{-box.id-}}"{% endif %}
+  {%- if id %} id="{{-id-}}"{% endif %}
 
   {# Here is where we are adding any modifier #}
   class="vf-box
-  {%- if box.box_href %} vf-box--is-link{% endif -%}
-  {%- if box.box_modifier %} {{box.box_modifier}}{% endif -%}
+  {%- if box_href %} vf-box--is-link{% endif -%}
+  {%- if box_modifier %} {{box_modifier}}{% endif -%}
 
   {# You want a snowflake of a classname for something, here you go #}
-  {%- if box.override_class %} | {{box.override_class}}{% endif -%}
+  {%- if override_class %} | {{override_class}}{% endif -%}
 ">
-  <h3 class="vf-box__heading">{{- box.box_heading -}}</h3>
-  <p class="vf-box__text">{{- box.box_text -}}</p>
+  <h3 class="vf-box__heading">{{- box_heading -}}</h3>
+  <p class="vf-box__text">{{- box_text -}}</p>
 </{{tags}}>

--- a/components/vf-card/vf-card.njk
+++ b/components/vf-card/vf-card.njk
@@ -3,7 +3,17 @@
   {% set card = context %}
 {% endif %}
 
-{% if card.card_href %}
+{%- if card %}
+  {% set card_href = card.card_href %}
+  {% set id = card.id %}
+  {% set modifier = card.modifier %}
+  {% set override_class = card.override_class %}
+  {% set card_image = card.card_image %}
+  {% set card_title = card.card_title %}
+  {% set card_text = card.card_text %}
+{% endif %}
+
+{% if card_href %}
   {% set tags = 'a' %}
 {% else %}
   {% set tags = 'div' %}
@@ -14,27 +24,27 @@
 <{{tags}}
 {# If there's an href put it here #}
 {%- if tags == 'a' %}
- href="{{ card.card_href if card.card_href else '#' }}"
+ href="{{ card_href if card_href else '#' }}"
 {%- endif %}
 
   {# You're using an ID? Really?? That'll go here #}
-  {%- if card.id %} id="{{-card.id-}}"{% endif %}
+  {%- if id %} id="{{-id-}}"{% endif %}
 
   {# Here is where we are adding any modifier #}
   class="vf-card
-  {%- if card.card_href %} vf-card--is-link{% endif %}
-  {%- if card.modifier %} {{card.modifier}}{% endif -%}
+  {%- if card_href %} vf-card--is-link{% endif %}
+  {%- if modifier %} {{modifier}}{% endif -%}
 
   {# You want a snowflake of a classname for something, here you go #}
-  {%- if card.override_class %} | {{card.override_class}}{% endif %}
+  {%- if override_class %} | {{override_class}}{% endif %}
 ">
-  <img src="{{ card.card_image }}" alt="" class="vf-card__image">
+  <img src="{{ card_image }}" alt="" class="vf-card__image">
   <div class="vf-card__content">
     <h3 class="vf-card__title">
-      {{ card.card_title }}
+      {{ card_title }}
     </h3>
     <p class="vf-card__text">
-      {{ card.card_text }}
+      {{ card_text }}
     </p>
   </div>
 </{{tags}}>


### PR DESCRIPTION
This should make things a little more portable when we have texted components or sub components that rely on the parent to determine what the data could be.

We check to see if the context knows it is a sub-component and if so sets the keys to be prefixed to the correct component type.

I've tested this in the `vf-core` where one component has nested data and the other does not and it seems to work.

👆 it's not easy explaining this :sob:

This should close #804 
