### PR TITLE
adds simple CSS for inline links in vf-box__text

### DIFF
--- a/components/vf-box/README.md
+++ b/components/vf-box/README.md
@@ -6,6 +6,12 @@
 
 The `vf-box` container is an element to be used when ...
 
+## Usage
+
+A `vf-box` can be used in all grid systems and also inside of `vf-content`.
+
+For now `vf-box` is only designed to accept a heading and text (both have classes). The text node – `vf-box__text` can also accept a link which will inherit the text colour. 
+
 ## Options
 
 ### Is Link

--- a/components/vf-box/vf-box.scss
+++ b/components/vf-box/vf-box.scss
@@ -51,6 +51,13 @@
 
 .vf-box__text {
   @include set-type(text-body--3);
+
+  // some times there's a link inside the text in old WP posts.
+  a {
+    border-bottom: 1px solid currentColor;
+    color: currentColor;
+    text-decoration: none;
+  }
 }
 
 // The CSS below is on notice

--- a/components/vf-box/vf-box.scss
+++ b/components/vf-box/vf-box.scss
@@ -53,10 +53,14 @@
   @include set-type(text-body--3);
 
   // some times there's a link inside the text in old WP posts.
+  // the vf-box might also be inside of `vf-content`
+  .vf-content & a,
   a {
-    border-bottom: 1px solid currentColor;
     color: currentColor;
-    text-decoration: none;
+    text-decoration: underline;
+    &:hover {
+      color: currentColor;
+    }
   }
 }
 


### PR DESCRIPTION
As we could be swapping the WP [fact box] for `vf-box` we need to incorporate the need for links in the `vf-box__text`. 

This does this by making the `<a>` inherit the `currentColor` from the `<p class="vf-box__text">`.

![Screenshot 2020-03-20 at 10 37 18](https://user-images.githubusercontent.com/925197/77156284-fcf86f80-6a96-11ea-9a3f-4b03177cd5d1.png)
