### PR TITLE
Fix vf-content blockquote spacing

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -24,6 +24,6 @@ pullRequestOpened: >
 
   - [ ] `README.md` is filled out with required documentation
 
-  - [ ] `CHNAGELOG.md` is updated
+  - [ ] `CHANGELOG.md` is updated
 
   - [ ] any `.scss` files correctly documented

--- a/components/vf-content/CHANGELOG.md
+++ b/components/vf-content/CHANGELOG.md
@@ -1,16 +1,18 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+## 1.0.8
 
-# 1.0.3 (2020-01-24)
+* Add support for cite, figcaption
+* Improve spacing on blockquote
 
-* Lerna version bump
-
-# 1.0.1 (2019-12-18)
+## 1.0.3 (2020-01-24)
 
 * Lerna version bump
 
-# 1.0.0 (2019-12-17)
+## 1.0.1 (2019-12-18)
+
+* Lerna version bump
+
+## 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-content/vf-content.njk
+++ b/components/vf-content/vf-content.njk
@@ -60,4 +60,10 @@
   <blockquote>
     <p>We are a group of user experience specialists in an international scientific organisation</p><p>Our aim is to help teams design services to meet the needs of their users</p><p>We believe in openness , transparency, working collaboratively and iteratively, continuously learning and sharing knowledge throughout the organisation</p><p><cite>EMBl-EBI Web Development UX Team Mission</cite></p>
   </blockquote>
+
+  <figure>
+    <img src="https://news.embl.de/wp-content/uploads/2019/11/Anastasia-Vlasiuk.jpg" alt="Anastasia Vlasiuk in the lab">
+    <figcaption>Anastasiia Vlasiuk, PhD student in the Asari group, recording the visual responses of an isolated retina. PHOTO: Marietta Schupp/EMBL</figcaption>
+  </figure>
+
 </div>

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -122,6 +122,18 @@
 
   blockquote:not([class*='vf-']) {
     @include blockquote;
+
+    p:last-of-type:not([class*='vf-']) {
+      margin-bottom: 0;
+    }
+  }
+
+  figcaption:not([class*='vf-']),
+  cite:not([class*='vf-']) {
+    // matches @mixin figure, but that is not directly usable here as it requires css classes
+    @include set-type(text-body--5);
+    color: map-get($vf-colors-map, vf-color--grey);
+    font-style: italic;
   }
 }
 


### PR DESCRIPTION
- Fix vf-content blockquote spacing on last p tag 
- Also adds support for styling of figcaption and cite

These were most visible on the WP News site, but apply everywhere vf-content is used with these elements.