### PR TITLE
Enhancement: build out notication banners

### DIFF
--- a/components/embl-notifications/CHANGELOG.md
+++ b/components/embl-notifications/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.0-alpha.2
+
+* Improved formatting support and conditional logic https://github.com/visual-framework/vf-core/pull/817
+
 ## 1.0.0-alpha.1 (2020-03-20)
 
 * Documentation and minor text formatting improvemetns

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -13,11 +13,14 @@ function emblNotificationsInject(message) {
 
   // preperation
   message.body = message.body.replace(/<[/]?[p>]+>/g, ' '); // no <p> tags allowed in inline messages, preserve a space to not colide words
-
+  // add vf-link to link
+  message.body = message.body.replace('<a href=', '<a class="vf-link" href='); // we might need a more clever regex, but this should also avoid links that aleady have a class
+  // Learn more link is conditionally shown
+  if (message.field_notification_link) {
+    message.body = `${message.body} <a class="vf-link" href="${message.field_notification_link}">Learn more</a>`;
+  }
   // @todo:
-  // - add vf-link to link
   // - support custom button text
-  // - Learn more should be conditionally shown
   if (message.field_notification_position == 'fixed') {
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--bottom', 'vf-banner--notice');
     output.dataset.vfJsBanner = true;
@@ -28,11 +31,9 @@ function emblNotificationsInject(message) {
     // output.dataset.vfJsBannerCookieVersion = "CookieVersion";
     // output.dataset.vfJsBannerExtraButton = "<a href='#'>Optional button</a><a target='_blank' href='#'>New tab button</a>";
     // output.dataset.vfJsBannerAutoAccept = false;
-
-    // <h4 class="vf-text vf-text-heading--4"><a class="vf-link" href="${message.field_notification_link}">${message.title}</a></h4>
     output.innerHTML = `
       <div class="vf-banner__content | vf-grid" data-vf-js-banner-text>
-        <p class="vf-text vf-text-body--2">${message.body} <a class="vf-link" href="${message.field_notification_link}">Learn more</a></p>
+        <p class="vf-text vf-text-body--2">${message.body}</p>
       </div>`;
 
     let target = document.body.firstChild;
@@ -73,11 +74,9 @@ function emblNotificationsInject(message) {
     // output.dataset.vfJsBannerCookieVersion = "CookieVersion";
     // output.dataset.vfJsBannerExtraButton = "<a href='#'>Optional button</a><a target='_blank' href='#'>New tab button</a>";
     // output.dataset.vfJsBannerAutoAccept = false;
-
-    // <h4 class="vf-text vf-text-heading--4"><a class="vf-link" href="${message.field_notification_link}">${message.title}</a></h4>
     output.innerHTML = `
       <div class="vf-banner__content" data-vf-js-banner-text>
-        <p class="vf-text vf-text-body--3">${message.body} <a class="vf-link" href="${message.field_notification_link}">Learn more</a></p>
+        <p class="vf-text vf-text-body--3">${message.body}</p>
       </div>`;
 
     let target = document.body.firstChild;

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -11,6 +11,10 @@ import { vfBanner } from 'vf-banner/vf-banner';
 function emblNotificationsInject(message) {
   let output = document.createElement('div');
 
+  // @todo:
+  // - add vf-link to link
+  // - support custom button text
+  // - Learn more should be conditionally shown
   if (message.field_notification_position == 'fixed') {
     message.body = message.body.replace(/<[/]?[p>]+>/g, ' '); // no <p> tags allowed in inline messages, preserve a space to not colide words
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--bottom', 'vf-banner--notice');

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -48,7 +48,7 @@ function emblNotificationsInject(message) {
     output.innerHTML = `
       <div class="vf-banner vf-banner--phase | vf-content">
         <div class="vf-banner__content">
-          <p class="vf-text-body--3">${message.body}</p>
+          <p class="vf-banner__text">${message.body}</p>
         </div>
       </div>`;
   
@@ -80,7 +80,7 @@ function emblNotificationsInject(message) {
     // output.dataset.vfJsBannerAutoAccept = false;
     output.innerHTML = `
       <div class="vf-banner__content" data-vf-js-banner-text>
-        <p class="vf-text vf-text-body--3">${message.body}</p>
+        <p class="vf-banner__text">${message.body}</p>
       </div>`;
 
     let target = document.body.firstChild;

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -11,12 +11,14 @@ import { vfBanner } from 'vf-banner/vf-banner';
 function emblNotificationsInject(message) {
   let output = document.createElement('div');
 
+  // preperation
+  message.body = message.body.replace(/<[/]?[p>]+>/g, ' '); // no <p> tags allowed in inline messages, preserve a space to not colide words
+
   // @todo:
   // - add vf-link to link
   // - support custom button text
   // - Learn more should be conditionally shown
   if (message.field_notification_position == 'fixed') {
-    message.body = message.body.replace(/<[/]?[p>]+>/g, ' '); // no <p> tags allowed in inline messages, preserve a space to not colide words
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--bottom', 'vf-banner--notice');
     output.dataset.vfJsBanner = true;
     output.dataset.vfJsBannerState = message.field_notification_presentation;
@@ -37,7 +39,6 @@ function emblNotificationsInject(message) {
     target.parentNode.prepend(output);
     vfBanner();
   } else if (message.field_notification_position == 'inline') {
-    message.body = message.body.replace(/<[/]?[p>]+>/g, ''); // no <p> tags allowed in inline messages
     output.classList.add('vf-grid'); // we wrap in vf-grid for layout
     output.innerHTML = `
       <div class="vf-banner vf-banner--phase | vf-content">
@@ -63,7 +64,6 @@ function emblNotificationsInject(message) {
     }
 
   } else if (message.field_notification_position == 'top') {
-    message.body = message.body.replace(/<[/]?[p>]+>/g, ''); // no <p> tags allowed in inline messages
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--top', 'vf-banner--phase');
     output.dataset.vfJsBanner = true;
     output.dataset.vfJsBannerState = message.field_notification_presentation;

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -19,13 +19,17 @@ function emblNotificationsInject(message) {
   if (message.field_notification_link) {
     message.body = `${message.body} <a class="vf-link" href="${message.field_notification_link}">Learn more</a>`;
   }
+  // custom button text
+  message.buttonText = message.buttonText || 'Close notice';
+  
   // @todo:
-  // - support custom button text
+  // - cookie name, version
+  // - extra button text, link
   if (message.field_notification_position == 'fixed') {
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--bottom', 'vf-banner--notice');
     output.dataset.vfJsBanner = true;
     output.dataset.vfJsBannerState = message.field_notification_presentation;
-    output.dataset.vfJsBannerButtonText = "Close notice";
+    output.dataset.vfJsBannerButtonText = message.buttonText;
     // These features are not yet supported by the notification content type in the EMBL contentHub
     // output.dataset.vfJsBannerCookieName = "CookieName";
     // output.dataset.vfJsBannerCookieVersion = "CookieVersion";
@@ -68,7 +72,7 @@ function emblNotificationsInject(message) {
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--top', 'vf-banner--phase');
     output.dataset.vfJsBanner = true;
     output.dataset.vfJsBannerState = message.field_notification_presentation;
-    output.dataset.vfJsBannerButtonText = "Close notice";
+    output.dataset.vfJsBannerButtonText = message.buttonText;
     // These features are not yet supported by the notification content type in the EMBL contentHub
     // output.dataset.vfJsBannerCookieName = "CookieName";
     // output.dataset.vfJsBannerCookieVersion = "CookieVersion";

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -20,7 +20,7 @@ function emblNotificationsInject(message) {
     message.body = `${message.body} <a class="vf-link" href="${message.field_notification_link}">Learn more</a>`;
   }
   // custom button text
-  message.buttonText = message.buttonText || 'Close notice';
+  message.field_notification_button_text = message.field_notification_button_text || 'Close notice';
   
   // @todo:
   // - cookie name, version
@@ -29,7 +29,7 @@ function emblNotificationsInject(message) {
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--bottom', 'vf-banner--notice');
     output.dataset.vfJsBanner = true;
     output.dataset.vfJsBannerState = message.field_notification_presentation;
-    output.dataset.vfJsBannerButtonText = message.buttonText;
+    output.dataset.vfJsBannerButtonText = message.field_notification_button_text;
     // These features are not yet supported by the notification content type in the EMBL contentHub
     // output.dataset.vfJsBannerCookieName = "CookieName";
     // output.dataset.vfJsBannerCookieVersion = "CookieVersion";
@@ -72,7 +72,7 @@ function emblNotificationsInject(message) {
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--top', 'vf-banner--phase');
     output.dataset.vfJsBanner = true;
     output.dataset.vfJsBannerState = message.field_notification_presentation;
-    output.dataset.vfJsBannerButtonText = message.buttonText;
+    output.dataset.vfJsBannerButtonText = message.field_notification_button_text;
     // These features are not yet supported by the notification content type in the EMBL contentHub
     // output.dataset.vfJsBannerCookieName = "CookieName";
     // output.dataset.vfJsBannerCookieVersion = "CookieVersion";

--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -3,16 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 1.0.2 
+## 1.0.4
+
+* Makes use of `vf-banner__text`
+* Use of `vf-text` is deprecated
+
+## 1.0.2 
 
 * Links in text areas of banners regain an underline.
 
-# 1.0.0 (2019-12-17)
+## 1.0.0 (2019-12-17)
 
 * Initial stable release
 
-
-# 1.0.1
+## 1.0.1
 
 * Removed default spacing of `vf-text` components inside.
 * Removes overriding variant CSS that removes padding, as it breaks the GDPR banner.

--- a/components/vf-banner/vf-banner--fixed.njk
+++ b/components/vf-banner/vf-banner--fixed.njk
@@ -8,7 +8,7 @@ data-vf-js-banner-cookie-version="{{data-protection-version}}"
 data-vf-js-banner-extra-button="<a href='#'>Optional button</a><a target='_blank' href='#'>New tab button</a>"
 data-vf-js-banner-auto-accept="false">
   <div class="vf-banner__content | vf-grid" data-vf-js-banner-text>
-    <p class="vf-text vf-text-body--2">
+    <p class="vf-banner__text vf-banner__text--lg">
       This website uses cookies, and the limiting processing of your personal data to function. By using the site you are agreeing to this as outlined in our <a class="vf-link" href="JavaScript:Void(0);">Privacy Notice</a> and <a class="vf-link" href="JavaScript:Void(0);">Terms Of Use</a>.
     </p>
   </div>

--- a/components/vf-banner/vf-banner--gdpr.scss
+++ b/components/vf-banner/vf-banner--gdpr.scss
@@ -5,7 +5,8 @@
 
     background-color: $vf-gdpr-banner-color--background;
 
-    .vf-text {
+    .vf-banner__text,
+    .vf-text { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal
       color: $vf-gdpr-banner-color--text;
       margin-bottom: 24px;
       max-width: 64em;

--- a/components/vf-banner/vf-banner--inline.njk
+++ b/components/vf-banner/vf-banner--inline.njk
@@ -1,5 +1,5 @@
 <div class="vf-banner vf-banner--phase">
   <div class="vf-banner__content">
-    <p class="vf-text-body--3">This is a new web page. <a href="{{ vf-banner--inline_href }}" class="vf-link">Complete our quick survey</a> to help us make it better.</p>
+    <p class="vf-banner__text">This is a new web page. <a href="{{ vf-banner--inline_href }}" class="vf-link">Complete our quick survey</a> to help us make it better.</p>
   </div>
 </div>

--- a/components/vf-banner/vf-banner--phase.scss
+++ b/components/vf-banner/vf-banner--phase.scss
@@ -3,7 +3,8 @@
 
   margin: 16px 0;
 
-  [class*='vf-text'] {
+  .vf-banner__text,
+  [class*='vf-text'] { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal
     color: $vf-phase-banner-color--text;
     margin: 0; // makes the text have no margin so the parent component defines the spacing
 

--- a/components/vf-banner/vf-banner--top.njk
+++ b/components/vf-banner/vf-banner--top.njk
@@ -4,6 +4,6 @@ data-vf-js-banner-state="dismissible"
 data-vf-js-banner-button-text="Close notice">
   <div class="vf-banner__content" data-vf-js-banner-text>
     <span class="vf-badge vf-badge--primary">BETA</span>
-    <p class="vf-text-body--3">This is the new EMBL.org <a href="{{ vf-banner--inline__url }}" class="vf-link">Complete our quick survey</a> to help us make it better.</p>
+    <p class="vf-banner__text">This is the new EMBL.org <a href="{{ vf-banner--inline__url }}" class="vf-link">Complete our quick survey</a> to help us make it better.</p>
   </div>
 </div>

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -52,8 +52,11 @@
 }
 
 .vf-banner__text {
-  @include set-type(text-body--3);
-}
+  @include set-type(text-body--3, $custom-margin-bottom: 0);
+} 
+.vf-banner__text--lg {
+  @include set-type(text-body--2, $custom-margin-bottom: 0);
+} 
 
 .vf-banner--top {
   top: 0;
@@ -66,7 +69,8 @@
 .vf-banner--notice {
   background-color: $vf-notice-banner-color--background;
 
-  .vf-text {
+  .vf-banner__text,
+  .vf-text { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal
     color: $vf-notice-banner-color--text;
     margin-bottom: 24px;
     max-width: 64em;


### PR DESCRIPTION
Dismisaable notifications are working but there are some things left to do:

 - [x] add vf-link class to any links
 - [x] support custom button text (needs to be passed from contentHub)
 - [x] "Learn more" should be conditionally shown

Bonuses:
- cookie name, version
- extra button text, link

Getting this in will allow us to drop explicit loading of the data protection banner from the contentHub and instead use the notifications approach. 