### PR TITLE
The one that updates article meta information

### DIFF
--- a/components/vf-article-meta-information/vf-article-meta-information.config.yml
+++ b/components/vf-article-meta-information/vf-article-meta-information.config.yml
@@ -14,10 +14,16 @@ context:
   meta__comment_count: 61
   meta__links_title: On This Page
   meta__links:
-    - heading link 1
-    - heading link 2
-    - heading link 3
-    - heading link 4
-    - heading link 5
-    - heading link 6
+    - text: heading link 1
+      url: 'JavaScript:Void(0);'
+    - text: heading link 2
+      url: 'JavaScript:Void(0);'
+    - text: heading link 3
+      url: 'JavaScript:Void(0);'
+    - text: heading link 4
+      url: 'JavaScript:Void(0);'
+    - text: heading link 5
+      url: 'JavaScript:Void(0);'
+    - text: heading link 6
+      url: 'JavaScript:Void(0);'
   meta__url: 'JavaScript:Void(0);'

--- a/components/vf-article-meta-information/vf-article-meta-information.njk
+++ b/components/vf-article-meta-information/vf-article-meta-information.njk
@@ -10,14 +10,14 @@
   </div>
   <div class="vf-meta__details">
     <p class="vf-meta__date">{{ meta__date }}</p>
-    
+
     <p class="vf-meta__topics">Topics:
       {% for item in meta__topics %}
       <a href="JavaScript:Void(0);" class="vf-link">{{ item }}</a>
       {% endfor %}
   </div>
   <div class="vf-meta__comments">
-    <p>Comments — <a href="JavaScript:Void(0);" class="vf-link">{{ meta__comment_count }}</a></p>
+    <p class"vf-meta__text">Comments — <a href="JavaScript:Void(0);" class="vf-link">{{ meta__comment_count }}</a></p>
   </div>
   {% if meta__links %}
   <div class="vf-links vf-links--tight vf-links__list--s">

--- a/components/vf-article-meta-information/vf-article-meta-information.njk
+++ b/components/vf-article-meta-information/vf-article-meta-information.njk
@@ -1,6 +1,6 @@
 <aside class="vf-article-meta-information">
   <div class="vf-author | vf-article-meta-info__author">
-    <p class="vf-author__name | vf-text-body--6">
+    <p class="vf-author__name">
       <a class="vf-link" href="{{ meta__url }}">{{ author__name }}</a>
     </p>
    <a class="vf-author--avatar__link | vf-link" href="{{ meta__url }}">
@@ -9,19 +9,26 @@
    </a>
   </div>
   <div class="vf-meta__details">
-    <p class="vf-meta__topics | vf-text-body--6">Topic:
+    <p class="vf-meta__date">{{ meta__date }}</p>
+    
+    <p class="vf-meta__topics">Topics:
       {% for item in meta__topics %}
       <a href="JavaScript:Void(0);" class="vf-link">{{ item }}</a>
       {% endfor %}
-    <p class="vf-meta__date | vf-text-body--6">{{ meta__date }}</p>
   </div>
   <div class="vf-meta__comments">
-    <p class="vf-text-body--6">Comments — <a href="JavaScript:Void(0);" class="vf-link">{{ meta__comment_count }}</a></p>
+    <p>Comments — <a href="JavaScript:Void(0);" class="vf-link">{{ meta__comment_count }}</a></p>
   </div>
-  <div class="vf-links | vf-article-meta-info__links">
-    <h6 class="vf-text vf-text-body--6">{{ meta__links_title}}</h6>
-    {% for item in meta__links %}
-      <a href="JavaScript:Void(0);" class="vf-link | vf-text-body--6">{{ item }}</a>
-    {% endfor %}
+  {% if meta__links %}
+  <div class="vf-links vf-links--tight vf-links__list--s">
+    <p class="vf-links__heading">{{meta__links_title}}</p>
+    <ul class="vf-links__list vf-links__list--secondary | vf-list">
+      {% for item in meta__links %}
+      <li class="vf-list__item">
+        <a class="vf-list__link" href="{{item.url}}">{{item.text}}</a>
+      </li>
+      {% endfor %}
+    </ul>
   </div>
+  {% endif %}
 </aside>

--- a/components/vf-article-meta-information/vf-article-meta-information.scss
+++ b/components/vf-article-meta-information/vf-article-meta-information.scss
@@ -29,9 +29,9 @@
 
   .vf-author__name {
     @include set-type(text-body--3, $custom-margin-bottom: 0);
-    line-height: 1.3;
 
     align-self: center;
+    line-height: 1.3;
     margin: 0 0 0 8px;
     word-spacing: 100vw; // so first name and surname split
   }

--- a/components/vf-article-meta-information/vf-article-meta-information.scss
+++ b/components/vf-article-meta-information/vf-article-meta-information.scss
@@ -104,10 +104,7 @@
   }
 }
 
-
-.vf-meta__comments {
-  p {
-    @include set-type(text-body--3, $custom-margin-bottom: 0);
-    color: set-color(vf-color--grey);
-  }
+.vf-meta__text {
+  @include set-type(text-body--3, $custom-margin-bottom: 0);
+  color: set-color(vf-color--grey);
 }

--- a/components/vf-article-meta-information/vf-article-meta-information.scss
+++ b/components/vf-article-meta-information/vf-article-meta-information.scss
@@ -28,6 +28,9 @@
   display: inline-flex;
 
   .vf-author__name {
+    @include set-type(text-body--3, $custom-margin-bottom: 0);
+    line-height: 1.3;
+
     align-self: center;
     margin: 0 0 0 8px;
     word-spacing: 100vw; // so first name and surname split
@@ -36,15 +39,10 @@
   .vf-author__title {
     align-self: center;
     margin: 0 0 0 8px;
-
-    // span {
-    //   display: block;
-    // }
   }
 
   .vf-author--avatar,
   .vf-link.vf-author--avatar__link {
-    border: 1px solid set-ui-color(vf-ui-color--black);
     border-radius: 500px;
     height: 48px;
     order: -1;
@@ -84,8 +82,9 @@
   }
 
   .vf-meta__date {
+    @include set-type(text-body--3, $custom-margin-bottom: 4px);
+
     color: set-color(vf-color--grey);
-    margin: 0;
   }
 }
 
@@ -93,10 +92,10 @@
 .vf-article-meta-info__links {
   padding: 0;
 
-  h6.vf-text-body--6 {
+  .vf-text {
+    @include set-type(text-body--3, $custom-margin-bottom: 8px);
+
     color: set-color(vf-color--grey);
-    font-weight: 400;
-    margin-bottom: 8px;
   }
 
   .vf-link {
@@ -107,9 +106,8 @@
 
 
 .vf-meta__comments {
-
-  .vf-text-body--6 {
+  p {
+    @include set-type(text-body--3, $custom-margin-bottom: 0);
     color: set-color(vf-color--grey);
-    margin: 0;
   }
 }


### PR DESCRIPTION
This PR updates the meta information for articles component. 

- removes any usage of `vf-text--` classnames and applies component specific typography as needed
- moves around the content order a little
- makes use of the `vf-links-list` `--tight` variant

todo (when `vf-summary` gets merged and updated) - replace the avatar with `vf-summary--profile` smaller variant. 