### PR TITLE
the quick one that fixes colour problems with summary links

### DIFF
--- a/components/vf-summary/vf-summary--profile.scss
+++ b/components/vf-summary/vf-summary--profile.scss
@@ -30,7 +30,7 @@
   @include inline-link;
 }
 .vf-summary__link--secondary {
-  @include inline-link($vf-link---secondary-color, $vf-link---secondary-color--hover, $vf-link---secondary-color--visited, $vf-include-normalisations: true);
+  @include inline-link(set-color(vf-color--grey--darkest), set-ui-color(vf-ui-color--black), set-color(vf-color--purple), $vf-include-normalisations: true);
 }
 
 .vf-summary__image--avatar {


### PR DESCRIPTION
since updating how the `inline-links` Sass mixin is used to create link styles - we had an issue in how this effected the profile summaries. This fixes that. 