### PR TITLE
Enhancement: notification cookie support

### DIFF
--- a/components/embl-notifications/CHANGELOG.md
+++ b/components/embl-notifications/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-alpha.2
 
 * Improved formatting support and conditional logic https://github.com/visual-framework/vf-core/pull/817
+* Notification cookies and memory options
 
 ## 1.0.0-alpha.1 (2020-03-20)
 

--- a/components/embl-notifications/README.md
+++ b/components/embl-notifications/README.md
@@ -7,7 +7,7 @@ Fetches notifications from the EMBL contentHub and will display them, if a match
 ## Possible features not currently planned:
 
 - Only show if a wrapping element has `data-vf-js-embl-notifications`
-- Also load messages from EBI's folder https://ebi.emblstatic.net/announcements.js
+- Also load messages from EBI's existing announcement JS at https://ebi.emblstatic.net/announcements.js
 - Use the vf-banner precompiled njk template to render output
 - Test for better support on non-VF 2.0 sites
 

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -11,6 +11,9 @@ import { vfBanner } from 'vf-banner/vf-banner';
 function emblNotificationsInject(message) {
   let output = document.createElement('div');
 
+  // @todo:
+  // - add support in contentHub for extra button text, link
+
   // preperation
   message.body = message.body.replace(/<[/]?[p>]+>/g, ' '); // no <p> tags allowed in inline messages, preserve a space to not colide words
   // add vf-link to link
@@ -21,20 +24,22 @@ function emblNotificationsInject(message) {
   }
   // custom button text
   message.field_notification_button_text = message.field_notification_button_text || 'Close notice';
+  // notification memory and cookie options
+  if (message.field_notification_cookie == "True") {
+    output.dataset.vfJsBannerCookieName = message.cookieName;
+    output.dataset.vfJsBannerCookieVersion = message.cookieVersion;  
+    if (message.field_notification_auto_accept == "True") {
+      output.dataset.vfJsBannerAutoAccept = true;
+    }
+  }
   
-  // @todo:
-  // - cookie name, version
-  // - extra button text, link
   if (message.field_notification_position == 'fixed') {
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--bottom', 'vf-banner--notice');
     output.dataset.vfJsBanner = true;
     output.dataset.vfJsBannerState = message.field_notification_presentation;
     output.dataset.vfJsBannerButtonText = message.field_notification_button_text;
     // These features are not yet supported by the notification content type in the EMBL contentHub
-    // output.dataset.vfJsBannerCookieName = "CookieName";
-    // output.dataset.vfJsBannerCookieVersion = "CookieVersion";
     // output.dataset.vfJsBannerExtraButton = "<a href='#'>Optional button</a><a target='_blank' href='#'>New tab button</a>";
-    // output.dataset.vfJsBannerAutoAccept = false;
     output.innerHTML = `
       <div class="vf-banner__content | vf-grid" data-vf-js-banner-text>
         <p class="vf-text vf-text-body--2">${message.body}</p>
@@ -74,10 +79,7 @@ function emblNotificationsInject(message) {
     output.dataset.vfJsBannerState = message.field_notification_presentation;
     output.dataset.vfJsBannerButtonText = message.field_notification_button_text;
     // These features are not yet supported by the notification content type in the EMBL contentHub
-    // output.dataset.vfJsBannerCookieName = "CookieName";
-    // output.dataset.vfJsBannerCookieVersion = "CookieVersion";
     // output.dataset.vfJsBannerExtraButton = "<a href='#'>Optional button</a><a target='_blank' href='#'>New tab button</a>";
-    // output.dataset.vfJsBannerAutoAccept = false;
     output.innerHTML = `
       <div class="vf-banner__content" data-vf-js-banner-text>
         <p class="vf-banner__text">${message.body}</p>


### PR DESCRIPTION
Follows on #817 and adds support for cookies in embl-notifcations. Important so a data protection banner doesn't repeatadily show.

Also adds options for notifcation "memory" so the notificatio can be conditonally shown repetadely.