### PR TITLE
the one where we look at link colours, again.

### DIFF
--- a/components/vf-content/README.md
+++ b/components/vf-content/README.md
@@ -4,24 +4,15 @@
 
 ## About
 
-Use this container to get simple support for narrative content where it is not
-practical to assign classes, such as Markdown or WYSIWYG text.
+This container adds support for long form content where it may not be practical to assign classes, such as Markdown or WYSIWYG text.
+
+It also makes some adjustments for longer form text, such as vertical spacing and making visited links purple.
 
 This container adds basic support for `p`, `ul`, `hr`, `a` and other core
-html elements. Some components may also add specific support for `.vf-content`
+html elements.
 
-### Demonstration
+Some components may also add specific support for `.vf-content`
 
-<div class="vf-content">
-{{ "#### Sub-header" | marked }}
-
-{% markdown %}
-- list items
-- list items
-- list item [with a link](#)
-- list items
-{% endmarkdown %}
-</div>
 
 ## Install
 

--- a/components/vf-content/vf-content.config.yml
+++ b/components/vf-content/vf-content.config.yml
@@ -3,4 +3,4 @@ label: Content
 status: live
 preview: '@preview'
 context:
-  component-type: utility
+  component-type: container

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -145,3 +145,11 @@
     margin-bottom: 42px;
   }
 }
+
+
+[class*='dark'].vf-content,
+.vf-content > [class*='dark'] {
+  a:not([class*='vf-']) {
+    @include inline-link($vf-link--dark-mode--hover-color, $vf-link--dark-mode--hover-color, set-color(vf-color--purple--light),  $vf-include-normalisations: true);
+  }
+}

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -57,17 +57,14 @@
   p:not([class*='vf-']) {
     @include set-type(text-body--2, $custom-margin-bottom: 24px);
   }
-
+  
+  .vf-link,
   a:not([class*='vf-']) {
-    @include inline-link;
-
-    &:visited {
-      color: set-color(vf-color--purple);
-    }
-
-    &:hover {
-      color: $vf-link--hover-color;
-    }
+    @include inline-link(
+      $vf-link--hover-color: $vf-link--hover-color,
+      $vf-link--visited-color: set-color(vf-color--purple),
+      $vf-include-normalisations: true
+    );
   }
 
   small:not([class*='vf-']) {
@@ -147,9 +144,15 @@
 }
 
 
-[class*='dark'].vf-content,
+[class*='--dark'].vf-content,
 .vf-content > [class*='dark'] {
+  .vf-link,
   a:not([class*='vf-']) {
-    @include inline-link($vf-link--dark-mode--hover-color, $vf-link--dark-mode--hover-color, set-color(vf-color--purple--light),  $vf-include-normalisations: true);
+    @include inline-link(
+      $vf-link--dark-mode--hover-color,
+      $vf-link--dark-mode--hover-color,
+      set-color(vf-color--purple--light),
+      $vf-include-normalisations: true
+    );
   }
 }

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -62,7 +62,7 @@
     @include inline-link;
 
     &:visited {
-      color: $vf-link--visited-color;
+      color: set-color(vf-color--purple);
     }
 
     &:hover {

--- a/components/vf-design-tokens/dist/sass/vf-links.variables.scss
+++ b/components/vf-design-tokens/dist/sass/vf-links.variables.scss
@@ -6,7 +6,7 @@
 $vf-link--color: #3b6fb6;
 $vf-link--disabled-color: #d0d0ce;
 $vf-link--hover-color: #193f90;
-$vf-link--visited-color: #734595;
+$vf-link--visited-color: #3b6fb6;
 $vf-link--decoration: underline;
 $vf-link--dark-mode--hover-color: #a8d2ff;
-$vf-link--dark-mode--visited-color: #cba3d8;
+$vf-link--dark-mode--visited-color: #a8d2ff;

--- a/components/vf-design-tokens/src/core.palette.alias.yml
+++ b/components/vf-design-tokens/src/core.palette.alias.yml
@@ -56,7 +56,7 @@ aliases:
   # EMBL Link Colours
 
   vf-color--link--dark-mode--hover: '#a8d2ff'
-  vf-color--link--dark-mode--visited: '#cba3d8'
+  vf-color--link--dark-mode--visited: '#a8d2ff'
 
   # VF Core Colours
 

--- a/components/vf-design-tokens/src/variables/vf-links.yml
+++ b/components/vf-design-tokens/src/variables/vf-links.yml
@@ -15,7 +15,7 @@ props:
     value: "{!vf-color--blue--dark}"
     type: color
   vf-link--visited-color:
-    value: "{!vf-color--purple}"
+    value: "{!vf-color--blue}"
     type: color
   vf-link--decoration:
     value: underline

--- a/components/vf-link-list/vf-link-list.scss
+++ b/components/vf-link-list/vf-link-list.scss
@@ -55,6 +55,7 @@
   .vf-list__link {
     @include inline-link(
       $vf-link--color: set-color(vf-color--grey),
+      $vf-link--visited-color: set-color(vf-color--grey),
       $vf-link--hover-color: set-color(vf-color--grey--dark)
     );
 
@@ -102,7 +103,7 @@
 
 
 .vf-links__list--easy {
-  
+
   .vf-links__heading {
     grid-column: 1 / -1;
   }

--- a/components/vf-link/vf-link--example.njk
+++ b/components/vf-link/vf-link--example.njk
@@ -1,4 +1,4 @@
-<div class="vf-grid vf-u-padding--lg">
+{# <div class="vf-grid vf-u-padding--lg">
   <!-- {{buttonType}} -->
   <a href="{{link_href}}" class="vf-link ">A {{buttonType}} link</a>
   <!-- {{buttonType}} Hover -->
@@ -18,7 +18,7 @@
   <a href="{{link_href}}" class="vf-link vf-link--visited">A default:visited link</a>
   <!-- Default Disabled -->
   <a href="{{link_href}}" class="vf-link vf-link--disabled" disabled>A disabled default link</a>
-</div>
+</div> #}
 <div class="vf-grid vf-u-padding--lg">
   <!-- Primary -->
   <a href="{{link_href}}" class="vf-link vf-link--primary ">A primary link</a>
@@ -58,4 +58,14 @@
   <a href="{{link_href}}" class="vf-link vf-link--secondary vf-link--secondary--visited">A secondary:visited link</a>
   <!-- Secondary Disabled -->
   <a href="{{link_href}}" class="vf-link vf-link--secondary vf-link--disabled" disabled>A disabled secondary link</a>
+</div>
+
+
+<div class="vf-grid vf-u-padding--lg vf-content">
+  <p class="vf-u-margin__bottom--0 vf-text-body vf-text-body--2">This is an example of using <a href="{{link_href}}">inline links</a> when you are using the <code>.vf-content</code> container.</p>
+</div>
+
+
+<div class="vf-grid | vf-u-padding--lg vf-u-background-color--grey--dark | vf-content">
+  <p class="vf-u-margin__bottom--0 vf-u-text-color--ui--white vf-text-body vf-text-body--2">This is an example of using <a href="{{link_href}}">inline links</a> when you are using the <code class="vf-u-text-color--ui--black">.vf-content</code> container and the parent of the text also has a class for dark backgrounds.</p>
 </div>

--- a/components/vf-link/vf-link--example.njk
+++ b/components/vf-link/vf-link--example.njk
@@ -1,65 +1,61 @@
+<div class="vf-grid vf-u-padding--lg">
+  <!-- {{buttonType}} -->
+  <a href="{{link_href}}" class="vf-link ">A {{buttonType}} link</a>
+  <!-- {{buttonType}} Hover -->
+  <a href="{{link_href}}" class="vf-link vf-link--hover">A {{buttonType}}:hover link</a>
+  <!-- {{buttonType}} Visited -->
+  <a href="{{link_href}}" class="vf-link vf-link--visited">A {{buttonType}}:visited link</a>
+  <!-- {{buttonType}} Disabled -->
+  <a href="{{link_href}}" class="vf-link vf-link--disabled" disabled>A disabled {{buttonType}} link</a>
+</div>
 
+<div class="vf-grid vf-u-background-color--grey--dark vf-u-padding--lg">
+  <!-- Default -->
+  <a href="{{link_href}}" class="vf-link ">A default link</a>
+  <!-- Default Hover -->
+  <a href="{{link_href}}" class="vf-link vf-link--hover">A default:hover link</a>
+  <!-- Default Visited -->
+  <a href="{{link_href}}" class="vf-link vf-link--visited">A default:visited link</a>
+  <!-- Default Disabled -->
+  <a href="{{link_href}}" class="vf-link vf-link--disabled" disabled>A disabled default link</a>
+</div>
 <div class="vf-grid vf-u-padding--lg">
-<!-- Default -->
-<a href="JavaScript:Void(0);" class="vf-link ">A default link</a>
-<!-- Default Hover -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--hover">A default:hover link</a>
-<!-- Default Visited -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--visited">A default:visited link</a>
-<!-- Default Disabled -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--disabled" disabled>A disabled default link</a>
+  <!-- Primary -->
+  <a href="{{link_href}}" class="vf-link vf-link--primary ">A primary link</a>
+  <!-- Primary Hover -->
+  <a href="{{link_href}}" class="vf-link vf-link--primary vf-link--hover">A primary:hover link</a>
+  <!-- Primary Visited -->
+  <a href="{{link_href}}" class="vf-link vf-link--primary vf-link--visited">A primary:visited link</a>
+  <!-- Primary Disabled -->
+  <a href="{{link_href}}" class="vf-link vf-link--primary vf-link--disabled" disabled>A disabled primary link</a>
 </div>
 <div class="vf-grid vf-u-background-color--grey--dark vf-u-padding--lg">
-<!-- Default -->
-<a href="JavaScript:Void(0);" class="vf-link ">A default link</a>
-<!-- Default Hover -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--hover">A default:hover link</a>
-<!-- Default Visited -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--visited">A default:visited link</a>
-<!-- Default Disabled -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--disabled" disabled>A disabled default link</a>
+  <!-- Primary -->
+  <a href="{{link_href}}" class="vf-link vf-link--primary ">A primary link</a>
+  <!-- Primary Hover -->
+  <a href="{{link_href}}" class="vf-link vf-link--primary vf-link--hover">A primary:hover link</a>
+  <!-- Primary Visited -->
+  <a href="{{link_href}}" class="vf-link vf-link--primary vf-link--visited">A primary:visited link</a>
+  <!-- Primary Disabled -->
+  <a href="{{link_href}}" class="vf-link vf-link--primary vf-link--disabled" disabled>A disabled primary link</a>
 </div>
 <div class="vf-grid vf-u-padding--lg">
-<!-- Primary -->
-<a href="JavaScript:Void(0);" class="vf-link ">A primary link</a>
-<!-- Primary Hover -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--hover">A primary:hover link</a>
-<!-- Primary Visited -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--visited">A primary:visited link</a>
-<!-- Primary Disabled -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--disabled" disabled>A disabled primary link</a>
-</div>
-<div class="vf-grid vf-u-background-color--grey--dark vf-u-padding--lg">
-<!-- Primary -->
-<a href="JavaScript:Void(0);" class="vf-link ">A primary link</a>
-<!-- Primary Hover -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--hover">A primary:hover link</a>
-<!-- Primary Visited -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--visited">A primary:visited link</a>
-<!-- Primary Disabled -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--disabled" disabled>A disabled primary link</a>
-</div>
-<div class="vf-grid vf-u-padding--lg">
-<!-- Secondary -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--secondary ">A secondary link</a>
-<!-- Secondary Hover -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--secondary--hover">A secondary:hover link</a>
-<!-- Secondary Visited -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--secondary--visited">A secondary:visited link</a>
-<!-- Secondary Disabled -->
-<a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--disabled" disabled>A disabled secondary link</a>
-<!-- Example -->
-<a href="" class="vf-link "></a>
+  <!-- Secondary -->
+  <a href="{{link_href}}" class="vf-link vf-link--secondary ">A secondary link</a>
+  <!-- Secondary Hover -->
+  <a href="{{link_href}}" class="vf-link vf-link--secondary vf-link--secondary--hover">A secondary:hover link</a>
+  <!-- Secondary Visited -->
+  <a href="{{link_href}}" class="vf-link vf-link--secondary vf-link--secondary--visited">A secondary:visited link</a>
+  <!-- Secondary Disabled -->
+  <a href="{{link_href}}" class="vf-link vf-link--secondary vf-link--disabled" disabled>A disabled secondary link</a>
 </div>
 <div class="vf-grid vf-u-background-color--grey--dark vf-u-padding--lg">
   <!-- Secondary -->
-  <a href="JavaScript:Void(0);" class="vf-link vf-link--secondary ">A secondary link</a>
+  <a href="{{link_href}}" class="vf-link vf-link--secondary ">A secondary link</a>
   <!-- Secondary Hover -->
-  <a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--secondary--hover">A secondary:hover link</a>
+  <a href="{{link_href}}" class="vf-link vf-link--secondary vf-link--secondary--hover">A secondary:hover link</a>
   <!-- Secondary Visited -->
-  <a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--secondary--visited">A secondary:visited link</a>
+  <a href="{{link_href}}" class="vf-link vf-link--secondary vf-link--secondary--visited">A secondary:visited link</a>
   <!-- Secondary Disabled -->
-  <a href="JavaScript:Void(0);" class="vf-link vf-link--secondary vf-link--disabled" disabled>A disabled secondary link</a>
-  <!-- Example -->
-  <a href="JavaScript:Void(0);" class="vf-link "></a>
+  <a href="{{link_href}}" class="vf-link vf-link--secondary vf-link--disabled" disabled>A disabled secondary link</a>
 </div>

--- a/components/vf-link/vf-link--primary.scss
+++ b/components/vf-link/vf-link--primary.scss
@@ -1,14 +1,14 @@
 // vf-link--primary
 @import 'vf-link.variables.scss';
 
-.vf-link {
+.vf-link--primary {
   @include inline-link;
 }
 
-.vf-link--visited {
+.vf-link--primary .vf-link--visited {
   color: $vf-link--visited-color;
 }
 
-.vf-link--hover {
+.vf-link--primary .vf-link--hover {
   color: $vf-link--hover-color;
 }

--- a/components/vf-link/vf-link--secondary.scss
+++ b/components/vf-link/vf-link--secondary.scss
@@ -13,7 +13,7 @@
   color: set-color(vf-color--grey--dark);
 }
 
-[class*=dark]  {
+[class*='dark']  {
   .vf-link--secondary {
     @include inline-link(set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), $vf-include-normalisations: true);
   }

--- a/components/vf-link/vf-link--secondary.scss
+++ b/components/vf-link/vf-link--secondary.scss
@@ -2,11 +2,11 @@
 @import 'vf-link.variables.scss';
 
 .vf-link--secondary {
-  @include inline-link(set-color(vf-color--grey--dark), set-color(vf-color--grey--dark), set-color(vf-color--purple), $vf-include-normalisations: true);
+  @include inline-link(set-color(vf-color--grey--dark), set-color(vf-color--grey--dark), set-color(vf-color--grey--dark), $vf-include-normalisations: true);
 }
 
 .vf-link--secondary--visited {
-  color: set-color(vf-color--purple);
+  color: set-color(vf-color--grey--dark);
 }
 
 .vf-link--secondary--hover {
@@ -15,11 +15,11 @@
 
 .vf-u-background-color--grey--dark {
   .vf-link--secondary {
-    @include inline-link(set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), $vf-link--dark-mode--visited-color, $vf-include-normalisations: true);
+    @include inline-link(set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), $vf-include-normalisations: true);
   }
 
   .vf-link--secondary--visited {
-    color: $vf-link--dark-mode--visited-color;
+    color: set-ui-color(vf-ui-color--white);
   }
 
   .vf-link--secondary--hover {

--- a/components/vf-link/vf-link--secondary.scss
+++ b/components/vf-link/vf-link--secondary.scss
@@ -13,7 +13,7 @@
   color: set-color(vf-color--grey--dark);
 }
 
-.vf-u-background-color--grey--dark {
+[class*=dark]  {
   .vf-link--secondary {
     @include inline-link(set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), $vf-include-normalisations: true);
   }

--- a/components/vf-link/vf-link--secondary.scss
+++ b/components/vf-link/vf-link--secondary.scss
@@ -13,7 +13,7 @@
   color: set-color(vf-color--grey--dark);
 }
 
-[class*='dark']  {
+[class*='--dark']  {
   .vf-link--secondary {
     @include inline-link(set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), set-ui-color(vf-ui-color--white), $vf-include-normalisations: true);
   }

--- a/components/vf-link/vf-link.config.yml
+++ b/components/vf-link/vf-link.config.yml
@@ -5,6 +5,8 @@ collated: true
 preview: '@preview--nogrid'
 context:
   component-type: element
+  link_href: "JavaScript:Void(0);"
+  buttonType: default
 variants:
   - name: default
     hidden: true;

--- a/components/vf-link/vf-link.scss
+++ b/components/vf-link/vf-link.scss
@@ -21,7 +21,7 @@
   color: $vf-link--hover-color;
 }
 
-.vf-u-background-color--grey--dark {
+[class*='--dark']  {
   .vf-link {
     @include inline-link($vf-link--dark-mode--hover-color, $vf-link--dark-mode--hover-color, $vf-link--dark-mode--visited-color, $vf-include-normalisations: true);
   }

--- a/components/vf-navigation/vf-navigation--global.scss
+++ b/components/vf-navigation/vf-navigation--global.scss
@@ -1,6 +1,6 @@
 
 .vf-navigation--global {
-  
+
   .vf-navigation__item:not(:first-child) {
     margin-left: 24px;
   }
@@ -8,6 +8,7 @@
   .vf-navigation__link {
     @include inline-link(
       $vf-link--color: set-color(vf-color--grey--dark),
+      $vf-link--visited-color: set-color(vf-color--grey--dark),
       $vf-link--hover-color: set-ui-color(vf-ui-color--black)
     );
 

--- a/components/vf-sass-config/mixins/_links.scss
+++ b/components/vf-sass-config/mixins/_links.scss
@@ -79,7 +79,7 @@
   $vf-link--color: $vf-link--color,
   $vf-link--hover-color: $vf-link--hover-color,
   $vf-link--visited-color: $vf-link--visited-color
-  ) {
+)  {
 
   background-color: $vf-link--color;
   border: 2px solid $vf-link--color;

--- a/components/vf-summary/vf-summary--profile.scss
+++ b/components/vf-summary/vf-summary--profile.scss
@@ -30,7 +30,7 @@
   @include inline-link;
 }
 .vf-summary__link--secondary {
-  @include inline-link(set-color(vf-color--grey--darkest), set-ui-color(vf-ui-color--black), set-color(vf-color--purple), $vf-include-normalisations: true);
+  @include inline-link(set-color(vf-color--grey--darkest), set-ui-color(vf-ui-color--black), set-color(vf-color--grey--darkest), $vf-include-normalisations: true);
 }
 
 .vf-summary__image--avatar {

--- a/components/vf-text/vf-text.njk
+++ b/components/vf-text/vf-text.njk
@@ -3,7 +3,7 @@
 <p
 {% if id %} id="{{-id-}}"{% endif %}
 
-class="vf-text--body
+class="vf-text-body
 
 {%- if type %} vf-text-body--{{type}}{% endif -%}
 

--- a/components/vf-text/vf-text.scss
+++ b/components/vf-text/vf-text.scss
@@ -10,7 +10,7 @@
  */
 
 .vf-text-body {
-  > a {
+  a {
     @include inline-link;
   }
 }


### PR DESCRIPTION
More often than not the `:visited` style for links that is designed makes the page look a little 'off' as links in the page UI can have sprinkles of purple. Here we remove keep the `:visited` styles the same age `:link` for the generic mixin `@include inline-link` and alter as needed (for `--secondary`) including having `:visited` links for long form content in `vf-content`.

- new link colours for UI, or components that use the default `@include inline-link` mixin.

![Screen Shot 2020-04-06 at 10 37 27](https://user-images.githubusercontent.com/925197/78544815-a1e2ae80-77f2-11ea-8579-24b1da254311.png)

- an example of a visited link in long form content.

![Screenshot 2020-04-06 at 10 38 11](https://user-images.githubusercontent.com/925197/78544880-bc1c8c80-77f2-11ea-8745-82212be7eafd.png)

Because components are generally using `@include inline-link` there should be nothing that dramatically explodes.  