### PR TITLE
the one that makes header components a little better

### DIFF
--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -15,18 +15,17 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
 .vf-global-header {
   align-items: center;
   background-color: $vf-global-header-background--color;
-  border-bottom: solid 1px set-color(vf-color--grey);
-  display: grid;
+  box-sizing: border-box;
   grid-column: 1 / -1;
-  grid-template-columns: minmax(var(--page-grid-gap), auto) minmax(auto, $global-page-max-width) minmax(var(--page-grid-gap), auto);
   height: auto;
-  // margin-bottom: 16px; removed because of group pages background - adding margin-top to breadcrumbs
-  padding: .5rem 0;
+  margin: 0 auto;
+  max-width: 78.5em;
+  padding: .5rem 1rem;
+  width: 100%;
 }
 
 .vf-global-header__inner {
   display: flex;
-  grid-column: 2 / -2;
 }
 
 .vf-global-header__site-name {
@@ -36,8 +35,10 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
 }
 
 .vf-global-header {
+
   [class*='navigation'] {
     align-self: center;
     margin-left: auto;
   }
+
 }

--- a/components/vf-header/vf-header.config.yml
+++ b/components/vf-header/vf-header.config.yml
@@ -1,5 +1,5 @@
-title: Site Header
-label: Site Header
+title: Header
+label: Header
 status: live
 preview: '@preview--nogrid'
 context:

--- a/components/vf-header/vf-header.scss
+++ b/components/vf-header/vf-header.scss
@@ -15,7 +15,7 @@
   box-sizing: border-box;
   display: grid;
   grid-column: 1 / -1;
-  grid-template-columns: minmax(var(--page-grid-gap), auto) minmax(auto, $global-page-max-width) minmax(var(--page-grid-gap), auto);
+  width: 100%;
 }
 
 .vf-header {
@@ -56,7 +56,7 @@
   @media (min-width: $vf-breakpoint--lg) {
     .vf-masthead__heading {
       // padding: 0 3rem; // this makes the header have the same spacing as the rest of the inlay
-      padding: 0 1rem;
+      // padding: 0 1rem;
     }
     // .vf-navigation--main {
     //   box-sizing: border-box;

--- a/components/vf-masthead/vf-masthead--supports.scss
+++ b/components/vf-masthead/vf-masthead--supports.scss
@@ -1,9 +1,7 @@
 .vf-header .vf-masthead {
+  @include padding--inline(all, map-get($vf-spacing-map, vf-spacing--md));
+  
   grid-column: 1 / -1;
-
-  @media (max-width: 1023px) {
-    @include padding--inline(all, map-get($vf-spacing-map, vf-spacing--md));
-  }
 }
 
 .embl-group-header__header .vf-masthead {

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -32,10 +32,6 @@ $vf-masthead__subtitle-text--color: set-color(vf-color--grey);
   margin: 0 auto;
   max-width: 76.5em;
   width: 100%;
-
-  @media (max-width: $vf-breakpoint--sm) {
-    padding: 1em;
-  }
 }
 
 .vf-masthead__title {

--- a/components/vf-navigation/vf-navigation--additional.scss
+++ b/components/vf-navigation/vf-navigation--additional.scss
@@ -3,13 +3,11 @@
 
 .vf-navigation--additional {
   background-color: set-color(vf-color--grey--dark);
-  border: 0px solid set-color(vf-color--grey);
-  border-width: 1px 0 1px 0;
   box-sizing: border-box;
   display: flex;
   margin: 0 auto;
-  max-width: 76.5em;
-  padding: 4px 0;
+  max-width: 78.5em;
+  padding: 4px 1rem;
   position: relative;
   text-transform: uppercase;
   width: 100%;
@@ -27,17 +25,18 @@
     right: 50%;
     top: 0;
     width: 100vw;
-    z-index: set-layer(vf-z-index--negative);
   }
 
   .vf-navigation__heading {
     color: set-ui-color(vf-ui-color--white);
     padding-top: 6px; // magic number
+    z-index: 1;
   }
 
   .vf-navigation__list {
     margin-left: auto;
     padding-top: 5px; // magic number
+    z-index: 1;
   }
 
   .vf-navigation__item:not(:first-child) {

--- a/components/vf-navigation/vf-navigation--main.scss
+++ b/components/vf-navigation/vf-navigation--main.scss
@@ -87,10 +87,10 @@
 
   .vf-navigation__list {
     box-sizing: border-box;
-    padding: .75rem 1rem;
     margin-left: auto;
     margin-right: auto;
     max-width: 78.5em;
+    padding: .75rem 1rem;
     width: 100%;
   }
 

--- a/components/vf-navigation/vf-navigation--main.scss
+++ b/components/vf-navigation/vf-navigation--main.scss
@@ -86,7 +86,12 @@
 .vf-navigation--main {
 
   .vf-navigation__list {
+    box-sizing: border-box;
     padding: .75rem 1rem;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 78.5em;
+    width: 100%;
   }
 
   .vf-navigation__item {


### PR DESCRIPTION
We want to remove the reliance on CSS grid to define the size of the `<header>` components as we cannot always rely on a direct parent/child relationship. 

Here we move to a better supported, simpler (more verbose) solution using –

```
  box-sizing: border-box;
  margin: 0 auto;
  max-width: 78.5em;
  padding: 0 1rem;
  width: 100%;
```

