### PR TITLE
the one where there was a disco bug on the vf-tree's show/hide button

### DIFF
--- a/components/vf-tree/CHANGELOG.md
+++ b/components/vf-tree/CHANGELOG.md
@@ -6,7 +6,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 2019-04-08
 
-Added a little specificity to the `.vf-show-hide__button` so that it didn't break. No changes except for when `vf-show-hide__button` is declased we now have `.vf-button.vf-show-hide__button`.
+Added a little specificity to the `.vf-show-hide__button`  and `vf-tree__button` so that it didn't break. No changes except for when `vf-show-hide__button` and `.vf-tree__button` are declared we now have `.vf-button.vf-show-hide__button` and `.vf-button.vf-tree__button`.
 
 ## 0.0.2-alpha.0 (2019-10-23)
 

--- a/components/vf-tree/CHANGELOG.md
+++ b/components/vf-tree/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+## 2019-04-08
+
+Added a little specificity to the `.vf-show-hide__button` so that it didn't break. No changes except for when `vf-show-hide__button` is declased we now have `.vf-button.vf-show-hide__button`.
+
 ## 0.0.2-alpha.0 (2019-10-23)
 
 **Note:** Version bump only for package @visual-framework/vf-tree

--- a/components/vf-tree/vf-tree.scss
+++ b/components/vf-tree/vf-tree.scss
@@ -40,7 +40,7 @@
     }
   }
 
-  .vf-show-hide__button {
+  .vf-button.vf-show-hide__button {
     transform-origin: center;
     transform: rotate(180deg);
     &:hover {
@@ -68,7 +68,7 @@
   }
 }
 
-.vf-tree__button {
+.vf-button.vf-tree__button {
   all: unset;
   cursor: pointer;
   float: right;
@@ -109,7 +109,8 @@
     background-color: #fff;
   }
 
-  > .vf-tree__button {
+  > .vf-tree__button,
+  &:hover > .vf-tree__button {
     transform-origin: center;
     transform: rotate(90deg);
   }
@@ -168,7 +169,7 @@
   }
 }
 
-.vf-show-hide__button {
+.vf-button.vf-show-hide__button {
   all: unset;
   cursor: pointer;
   margin-left: auto;


### PR DESCRIPTION
At some point the `vf-tree` components buttons had some crazy problems with the `vf-button` styles leaking into the 'unstyled' buttons.

This fixes that.

It's probably not possible now but I'd love to have some simple reset on `vf-button` and we layer on top the styles as needed.
