### PR TITLE
Bug: EMBL favicon and breadcrumbs

### DIFF
--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup-example.njk
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup-example.njk
@@ -1,0 +1,9 @@
+{# {% render "@embl-content-meta-properties", {"meta_who": "Christian Löw", "meta_what": "Löw", "meta_where": "EMBL Barcelona", "meta_active": "what"} %} #}
+{# {% render "@embl-content-meta-properties", {"meta_who": "Terry O'Connor",  "meta_active": "who"} %} #}
+{# {% render "@embl-content-meta-properties", {"meta_who": "Cian O´Luanaigh", "meta_what": "Communications", "meta_where": "EMBL Heidelberg", "meta_active": "what" } %} #}
+{# {% render "@embl-content-meta-properties", {"meta_who": "James Sharpe", "meta_what": "Sharpe Group", "meta_where": "EMBL Barcelona", "meta_active": "what"} %} #}
+{% render "@embl-content-meta-properties", {"meta_who": "notSet", "meta_what": "Topics", "meta_where": "EMBL", "meta_active": "what"} %}
+
+<nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
+  <div class="vf-list vf-list--inline | vf-breadcrumbs__list | embl-breadcrumbs-lookup--ghosting"></div>
+</nav> 

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.njk
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.njk
@@ -1,9 +1,3 @@
-{# {% render "@embl-content-meta-properties", {"meta_who": "Christian Löw", "meta_what": "Löw", "meta_where": "EMBL Barcelona", "meta_active": "what"} %} #}
-{# {% render "@embl-content-meta-properties", {"meta_who": "Terry O'Connor",  "meta_active": "who"} %} #}
-{# {% render "@embl-content-meta-properties", {"meta_who": "Cian O´Luanaigh", "meta_what": "Communications", "meta_where": "EMBL Heidelberg", "meta_active": "what" } %} #}
-{# {% render "@embl-content-meta-properties", {"meta_who": "James Sharpe", "meta_what": "Sharpe Group", "meta_where": "EMBL Barcelona", "meta_active": "what"} %} #}
-{% render "@embl-content-meta-properties", {"meta_who": "notSet", "meta_what": "Topics", "meta_where": "EMBL", "meta_active": "what"} %}
-
 <nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
   <div class="vf-list vf-list--inline | vf-breadcrumbs__list | embl-breadcrumbs-lookup--ghosting"></div>
-</nav> 
+</nav>

--- a/components/embl-conditional-edit/CHANGELOG.md
+++ b/components/embl-conditional-edit/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+## 1.0.2
 
-# 1.0.1
+* embl-breadcrumb-lookup.njk was loading demo embl-content-meta-properties that were only needed for an example, 
+  this resulted in unneeded and wrong meta properties in the html body
+* https://github.com/visual-framework/vf-core/pull/838
+
+## 1.0.1
 
 * Bug: Avoid a recursion issue in embl-conditional-edit https://github.com/visual-framework/vf-core/pull/829
 
-# 1.0.0 (2019-12-17)
+## 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/embl-favicon/CHANGELOG.md
+++ b/components/embl-favicon/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+## 1.0.2
 
-# 1.0.0 (2019-12-17)
+* missing a link to favicon.ico 
+* adds better defaults to the site.webmanifest
+* https://github.com/visual-framework/vf-core/pull/838
+
+## 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/embl-favicon/assets/site.webmanifest
+++ b/components/embl-favicon/assets/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "EMBL.org",
+    "short_name": "EMBL",
     "icons": [
         {
             "src": "/android-chrome-144x144.png",
@@ -8,7 +8,7 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
+    "theme_color": "#18974c",
+    "background_color": "#a8a99e",
     "display": "standalone"
 }

--- a/components/embl-favicon/embl-favicon.njk
+++ b/components/embl-favicon/embl-favicon.njk
@@ -1,5 +1,6 @@
+<link rel="shortcut icon" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/favicon.ico">
 <link rel="apple-touch-icon" sizes="180x180" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets//favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/favicon-16x16.png">
 <link rel="manifest" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/site.webmanifest">
 <link rel="mask-icon" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/safari-pinned-tab.svg" color="#ffffff">

--- a/components/vf-favicon/CHANGELOG.md
+++ b/components/vf-favicon/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+## 1.0.2
+
+* missing a link to favicon.ico 
+* adds better defaults to the site.webmanifest
+* https://github.com/visual-framework/vf-core/pull/838
 
 ## 1.0.1
 

--- a/components/vf-favicon/assets/site.webmanifest
+++ b/components/vf-favicon/assets/site.webmanifest
@@ -1,14 +1,14 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Visual Framework 2.0",
+    "short_name": "VF 2.0",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
+    "theme_color": "#a8a99e",
+    "background_color": "#373a36",
     "display": "standalone"
 }

--- a/components/vf-favicon/vf-favicon.config.yml
+++ b/components/vf-favicon/vf-favicon.config.yml
@@ -7,6 +7,7 @@ variants:
   - name: default
     context:
       apple_touch_icon: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/apple-touch-icon.png
+      icon_favicon: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/favicon.ico
       icon_32: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/favicon-32x32.png
       icon_16: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/favicon-16x16.png
       manifest: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/site.webmanifest

--- a/components/vf-favicon/vf-favicon.njk
+++ b/components/vf-favicon/vf-favicon.njk
@@ -1,3 +1,4 @@
+<link rel="shortcut icon" href="{{ icon_favicon }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ apple_touch_icon }}">
 <link rel="icon" type="image/png" sizes="32x32" href="{{ icon_32 }}">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ icon_16 }}">


### PR DESCRIPTION
Resolves a few bugs I've seen while using these njk templates in production

- embl-favicon missing a link to favicon.ico (some browsers seem to want it)
- embl-breadcrumb-lookup.njk was loading demo `embl-content-meta-properties` that were only needed for an example

Also adds some better defaults to the site.webmanifest