### PR TITLE
The one that fixes text inputs on iOS

### DIFF
--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -15,8 +15,8 @@
   appearance: none;
   border-color: set-ui-color(vf-ui-color--grey);
   border-style: solid;
-  border-width: 3px;
   border-radius: 0;
+  border-width: 3px;
   box-sizing: border-box;
   color: set-color(vf-color--grey--dark);
   display: block;

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -14,8 +14,8 @@
 
   appearance: none;
   border-color: set-ui-color(vf-ui-color--grey);
-  border-style: solid;
   border-radius: 0;
+  border-style: solid;
   border-width: 3px;
   box-sizing: border-box;
   color: set-color(vf-color--grey--dark);

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -12,9 +12,11 @@
 .vf-form__input:not([type='file']) {
   @include set-type(text-body--3, $custom-margin-bottom: 4px);
 
+  appearance: none;
   border-color: set-ui-color(vf-ui-color--grey);
   border-style: solid;
   border-width: 3px;
+  border-radius: 0;
   box-sizing: border-box;
   color: set-color(vf-color--grey--dark);
   display: block;

--- a/components/vf-form/vf-form__textarea/vf-form__textarea.scss
+++ b/components/vf-form/vf-form__textarea/vf-form__textarea.scss
@@ -12,7 +12,9 @@
 .vf-form__textarea {
   @include set-type(text-body--3);
 
+  appearance: none;
   border: 3px solid set-ui-color(vf-ui-color--grey);
+  border-radius: 0;
   box-sizing: border-box;
   display: block;
   padding: 12px 22px; // to make up for the border?


### PR DESCRIPTION
iOS has a 'fun quirk' in that it adds additional CSS styles to forms because… why not‽ 

We had managed to catch most of these except for a couple of things on `vf-form__input` and `vf-form__textarea`. 

This pull request adds the below CSS rules to both components.

```
appearance: none;
border-radius: 0;
```

note: `appearance` needs to be prefixed in (at least) iOS with `-webkit-`. This is done on `build` but not `dev` tasks for local development.

This will close #831 