### PR TITLE
The one where we make our CSS grid-gaps gaps

### DIFF
--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -29,18 +29,18 @@
     }
   }
   @media (min-width: $vf-breakpoint--sm) {
-    display: grid;
     column-gap: var(--page-grid-gap);
+    display: grid;
     /* stylelint-disable declaration-colon-space-after */
-    grid-template-columns: 
-      calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser)) 
-      [main-start] 
-      repeat(auto-fit, minmax(288px, 1fr)) 
+    grid-template-columns:
+      calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser))
+      [main-start]
+      repeat(auto-fit, minmax(288px, 1fr))
       [main-end]
     ;
     /* stylelint-enable */
   }
-  
+
 }
 
 .embl-grid--has-centered-content {

--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -30,7 +30,7 @@
   }
   @media (min-width: $vf-breakpoint--sm) {
     display: grid;
-    grid-column-gap: var(--page-grid-gap);
+    column-gap: var(--page-grid-gap);
     /* stylelint-disable declaration-colon-space-after */
     grid-template-columns: 
       calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser)) 

--- a/components/vf-card-container/vf-card-container.scss
+++ b/components/vf-card-container/vf-card-container.scss
@@ -34,7 +34,7 @@
   @supports (display: grid) {
     --vf-card-container__grid--size: 18rem;
     display: grid;
-    grid-gap: 40px;
+    gap: 40px;
     grid-template-columns: repeat(auto-fit, minmax(var(--vf-card-container__grid--size), 1fr));
     margin: 0 auto;
     max-width: 76.5em;

--- a/components/vf-footer/vf-footer.scss
+++ b/components/vf-footer/vf-footer.scss
@@ -41,7 +41,7 @@
 
 .vf-footer__legal {
   color: set-ui-color(vf-ui-color--white);
-  grid-column-gap: var(--page-grid-gap);
+  column-gap: var(--page-grid-gap);
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   .vf-list {
     width: 100%;

--- a/components/vf-grid/vf-grid.scss
+++ b/components/vf-grid/vf-grid.scss
@@ -45,9 +45,9 @@
 }
 @supports (display: grid) {
   .vf-grid {
+    column-gap: var(--page-grid-gap);
     display: grid;
     grid-column: main;
-    column-gap: var(--page-grid-gap);
   }
 
   @media (min-width: 840px) {

--- a/components/vf-grid/vf-grid.scss
+++ b/components/vf-grid/vf-grid.scss
@@ -47,7 +47,7 @@
   .vf-grid {
     display: grid;
     grid-column: main;
-    grid-column-gap: var(--page-grid-gap);
+    column-gap: var(--page-grid-gap);
   }
 
   @media (min-width: 840px) {

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -102,8 +102,8 @@
 
   // at a small-medium breakpoint the sidebar should allow for 2 columns of content
   @media (max-width: $vf-breakpoint--lg) and (min-width: $vf-breakpoint--sm) {
-    display: grid;
     column-gap: var(--page-grid-gap);
+    display: grid;
     grid-template-columns: repeat(2, 1fr);
   }
 

--- a/components/vf-inlay/vf-inlay.scss
+++ b/components/vf-inlay/vf-inlay.scss
@@ -103,7 +103,7 @@
   // at a small-medium breakpoint the sidebar should allow for 2 columns of content
   @media (max-width: $vf-breakpoint--lg) and (min-width: $vf-breakpoint--sm) {
     display: grid;
-    grid-column-gap: var(--page-grid-gap);
+    column-gap: var(--page-grid-gap);
     grid-template-columns: repeat(2, 1fr);
   }
 

--- a/components/vf-intro/vf-intro.scss
+++ b/components/vf-intro/vf-intro.scss
@@ -48,7 +48,7 @@
 
 @media (min-width: $vf-breakpoint--lg) {
   .vf-intro {
-    grid-column-gap: var(--page-grid-gap);
+    column-gap: var(--page-grid-gap);
     grid-template-areas: '... header header' '... ...    links';
     grid-template-columns: var(--embl-grid-module--prime) auto var(--embl-grid-module--prime);
   }

--- a/components/vf-link-list/vf-link-list.scss
+++ b/components/vf-link-list/vf-link-list.scss
@@ -109,11 +109,11 @@
   }
 
   .vf-links__list {
+    column-gap: 40px;
     display: grid;
     grid-column: 1 / -1;
-    column-gap: 40px;
-    row-gap: 30px;
     grid-template-columns: repeat( auto-fit, minmax(300px, 1fr) );
+    row-gap: 30px;
   }
 
   .vf-list__item {

--- a/components/vf-link-list/vf-link-list.scss
+++ b/components/vf-link-list/vf-link-list.scss
@@ -111,8 +111,8 @@
   .vf-links__list {
     display: grid;
     grid-column: 1 / -1;
-    grid-column-gap: 40px;
-    grid-row-gap: 30px;
+    column-gap: 40px;
+    row-gap: 30px;
     grid-template-columns: repeat( auto-fit, minmax(300px, 1fr) );
   }
 

--- a/components/vf-sass-config/variables/vf-global-variables.scss
+++ b/components/vf-sass-config/variables/vf-global-variables.scss
@@ -8,7 +8,7 @@ $global-font-family: $vf-font-family--sans-serif !default;
 $vf-text-margin--bottom: 16px !default;
 
 // grid variables
-$global-column-gap: 1em !default;
+$global-grid-column-gap: 1em !default;
 $global-page-max-width: 76.5em !default;
 
 // deprecation variables

--- a/components/vf-sass-config/variables/vf-global-variables.scss
+++ b/components/vf-sass-config/variables/vf-global-variables.scss
@@ -8,7 +8,7 @@ $global-font-family: $vf-font-family--sans-serif !default;
 $vf-text-margin--bottom: 16px !default;
 
 // grid variables
-$global-grid-column-gap: 1em !default;
+$global-column-gap: 1em !default;
 $global-page-max-width: 76.5em !default;
 
 // deprecation variables

--- a/components/vf-summary/vf-summary--has-image.scss
+++ b/components/vf-summary/vf-summary--has-image.scss
@@ -1,6 +1,6 @@
 .vf-summary--has-image {
 
-  grid-column-gap: 18px;
+  column-gap: 18px;
   grid-template-columns: minmax($vf-summary--has-image-width, auto) 1fr;
   grid-template-rows: auto;
   @include margin--block(bottom, 48px);

--- a/components/vf-summary/vf-summary--news.scss
+++ b/components/vf-summary/vf-summary--news.scss
@@ -1,9 +1,9 @@
 .vf-summary--news {
 
   column-gap: 0;
-  row-gap: 16px;
   grid-template-rows: auto;
   margin-bottom: 48px;
+  row-gap: 16px;
 
   .vf-summary__image{
     grid-column: 1 / span 1;
@@ -44,8 +44,8 @@
   }
 
   @media (min-width: 600px) {
-    row-gap: unset;
     grid-template-columns: minmax(0, auto) 1fr;
+    row-gap: unset;
   }
 
 }

--- a/components/vf-summary/vf-summary--news.scss
+++ b/components/vf-summary/vf-summary--news.scss
@@ -1,7 +1,7 @@
 .vf-summary--news {
 
-  grid-column-gap: 0;
-  grid-row-gap: 16px;
+  column-gap: 0;
+  row-gap: 16px;
   grid-template-rows: auto;
   margin-bottom: 48px;
 
@@ -44,7 +44,7 @@
   }
 
   @media (min-width: 600px) {
-    grid-row-gap: unset;
+    row-gap: unset;
     grid-template-columns: minmax(0, auto) 1fr;
   }
 

--- a/components/vf-summary/vf-summary--profile.scss
+++ b/components/vf-summary/vf-summary--profile.scss
@@ -1,5 +1,5 @@
 .vf-summary--profile {
-  grid-column-gap: 16px;
+  column-gap: 16px;
   grid-template-columns: minmax( 0, var(--vf-icon--avatar-width) ) 1fr;
   grid-template-rows: auto;
   margin-bottom: 48px;

--- a/components/vf-summary/vf-summary.scss
+++ b/components/vf-summary/vf-summary.scss
@@ -14,7 +14,7 @@
 .vf-summary {
   align-self: start;
   display: grid;
-  grid-column-gap: 16px;
+  column-gap: 16px;
   margin-bottom: $vf-summary-margin-bottom;
   position: relative;
 

--- a/components/vf-summary/vf-summary.scss
+++ b/components/vf-summary/vf-summary.scss
@@ -13,8 +13,8 @@
 
 .vf-summary {
   align-self: start;
-  display: grid;
   column-gap: 16px;
+  display: grid;
   margin-bottom: $vf-summary-margin-bottom;
   position: relative;
 


### PR DESCRIPTION
Whilst reading an article on grid I cam across [this comment from Rachel Andrew](https://css-tricks.com/4-css-grid-properties-and-one-value-for-most-of-your-layout-needs/#comment-1755417) about how we should be able to mov away from the, now deprecated, `grid-column/row-gap` and use `gap` without any prefixes. 

This PR does this, tested in Safari, Firefox, and Chrome

closes #826