### PR TITLE
the one that adds the vf-core ui colours as tokens

### DIFF
--- a/components/vf-design-tokens/dist/json/vf-ui-colors.ios.json
+++ b/components/vf-design-tokens/dist/json/vf-ui-colors.ios.json
@@ -15,7 +15,7 @@
       "type": "color",
       "category": "color",
       "name": "vfUiColorGrey",
-      "value": "#f3f3f3",
+      "value": "#d8d8d8",
       "meta": {
         "friendlyName": "UI Grey",
         "sassVariable": "$vf-ui-colors-map, vf-ui-color-color--grey",
@@ -26,7 +26,7 @@
       "type": "color",
       "category": "color",
       "name": "vfUiColorGreyLight",
-      "value": "#d8d8d8",
+      "value": "#f3f3f3",
       "meta": {
         "friendlyName": "UI Grey light",
         "sassVariable": "$vf-ui-colors-map, vf-ui-color-color--grey--light",

--- a/components/vf-design-tokens/dist/sass/custom-properties/vf-ui-colors.custom-properties.scss
+++ b/components/vf-design-tokens/dist/sass/custom-properties/vf-ui-colors.custom-properties.scss
@@ -5,8 +5,8 @@
 
 :root {
   --vf-ui-color--black: #000000;
-  --vf-ui-color--grey: #f3f3f3;
-  --vf-ui-color--grey--light: #d8d8d8;
+  --vf-ui-color--grey: #d8d8d8;
+  --vf-ui-color--grey--light: #f3f3f3;
   --vf-ui-color--yellow: #fffadc;
   --vf-ui-color--red: #d32f2f;
   --vf-ui-color--white: #ffffff;

--- a/components/vf-design-tokens/dist/sass/maps/vf-ui-colors.map.scss
+++ b/components/vf-design-tokens/dist/sass/maps/vf-ui-colors.map.scss
@@ -5,8 +5,8 @@
 
 $vf-ui-colors-map: (
   'vf-ui-color--black': (#000000),
-  'vf-ui-color--grey': (#f3f3f3),
-  'vf-ui-color--grey--light': (#d8d8d8),
+  'vf-ui-color--grey': (#d8d8d8),
+  'vf-ui-color--grey--light': (#f3f3f3),
   'vf-ui-color--yellow': (#fffadc),
   'vf-ui-color--red': (#d32f2f),
   'vf-ui-color--white': (#ffffff),

--- a/components/vf-design-tokens/src/core.palette.alias.yml
+++ b/components/vf-design-tokens/src/core.palette.alias.yml
@@ -61,8 +61,8 @@ aliases:
   # VF Core Colours
 
   ui-color--black: 'rgb(0,0,0)'
-  ui-color--grey: 'rgb(243,243,243)'
-  ui-color--grey--light: 'rgb(216,216,216)'
+  ui-color--grey: 'rgb(216,216,216)'
+  ui-color--grey--light: 'rgb(243,243,243)'
   ui-color--yellow: 'rgb(255,250,220)'
   ui-color--red: 'rgb(211,47,47)'
   ui-color--white: 'rgb(255,255,255)'

--- a/components/vf-design-tokens/vf-design-tokens--ui-colours.njk
+++ b/components/vf-design-tokens/vf-design-tokens--ui-colours.njk
@@ -1,0 +1,118 @@
+<style>
+/* vf-swatches might one day be a component, but for now it's CSS we'll just use for the design token demonstration */
+.vf-swatches {
+  grid-row-gap: 32px;
+  margin: 48px 0;
+}
+.vf-swatch {
+  border: 1px solid #d0d0ce;
+  display: grid;
+  grid-template-rows: 160px 1fr;
+}
+
+.vf-swatch__details {
+  padding: 16px;
+  border-top: 1px solid #d0d0ce;
+}
+
+.vf-swatch__colour {
+  /* margin: 16px;
+  height: calc(100% - 32px);
+  width: calc(100% - 32px); */
+  height: 100%;
+  width: 100%;
+}
+.vf-swatch__colour-name {
+  margin: 0 0 12px 0;
+}
+
+.vf-swatch__colour-hex,
+.vf-swatch__sass-variable,
+.vf-swatch__comment,
+.vf-swatch__css-property {
+  margin: 0 0 12px 0;
+}
+.vf-swatch__colour-hex {
+  text-transform: uppercase;
+}
+.vf-swatch__colour-hex,
+.vf-swatch__sass-variable,
+.vf-swatch__css-property {
+  font-family: monospace;
+  font-size: 1em;
+  align-items: start;
+}
+
+.vf-swatch__colour-hex,
+.vf-swatch__sass-variable,
+.vf-swatch__css-property {
+  font-family: 'IBM Plex Mono', Monaco, Consolas, 'Lucida Console', monospace;
+  font-size: 14px;
+}
+
+.vf-swatch__notes {
+  margin: 12px 0 0px 0;
+}
+
+.vf-swatch__notes,
+.vf-swatch__colour-name,
+.vf-swatch__meta {
+  font-family: 'IBM Plex Sans', Helvetica, Arial, sans-serif;
+}
+.vf-swatch__colour-name {
+  padding: 16px;
+}
+
+.vf-swatch__meta {
+  font-size: 16px;
+}
+
+.vf-swatch__details p {
+  margin-bottom: 16px;
+}
+.vf-swatch__details p:last-of-type {
+  margin-bottom: 0;
+}
+</style>
+
+
+<main class="vf-swatches | vf-grid vf-grid__col-3">
+{% for item in uiColors.properties %}
+
+
+<article class="vf-swatch">
+  <div class="vf-swatch__colour" style="background-color: {{ item.value}};">
+  </div>
+
+  <section class="vf-swatch__details">
+    <h3 class="vf-swatch__colour-name">{{ item.meta.friendlyName }}</h3>
+    <hr class="vf-divider">
+    <p>Colour code:</p>
+    <p class="vf-swatch__colour-hex">{{ item.value }}</p>
+    <p class="vf-swatch__colour-hex">{{ item.value | hextorgb }}</p>
+    {% if item.meta.sassVariable %}
+    <hr class="vf-divider">
+    <p>Sass:</p>
+      <p class="vf-swatch__sass-variable">${{ item.meta.sassVariable }}</p>
+      <p class="vf-swatch__sass-variable">map-get($vf-colors-map, {{ item.meta.sassVariable }})</p>
+    {% endif %}
+    {% if item.meta.CSSCustomProperty %}
+    <hr class="vf-divider">
+    <p>CSS custom property:</p>
+      <p class="vf-swatch__css-property">{{ item.meta.CSSCustomProperty }}</p>
+    {% endif %}
+    {% if item.meta.comment %}
+      <h4 class="vf-swatch__notes">notes:</h4>
+      <p class="vf-swatch__comment">
+        {{ item.meta.comment }}
+      </p>
+    {% endif %}
+  </section>
+</article>
+
+{% else %}
+
+<p>Something went wrong.</p>
+
+{% endfor %}
+</main>

--- a/components/vf-design-tokens/vf-design-tokens.config.js
+++ b/components/vf-design-tokens/vf-design-tokens.config.js
@@ -23,6 +23,7 @@ try {
     fractalConfig.context = {
       'component-type': 'utility',
       colors: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-colors.ios.json')),
+      uiColors: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-ui-colors.ios.json')),
       spacing: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-spacing.ios.json')),
       typography: require(path.join(process.cwd(), 'components/vf-design-tokens/dist/json/vf-font--sans.ios.json'))
     };
@@ -31,6 +32,7 @@ try {
   fractalConfig.context = {
     'component-type': 'utility',
       colors: null,
+      uiColors: null,
       spacing: null,
       typography: null
   };


### PR DESCRIPTION
This PR firstly adds the vf-core ui colours to the documentation, giving them their own page, which will close #789.

It also fixes the issue with `vf-ui-color--grey` and `vf-ui-color--grey--light` where they needed to be swapped, which will close #788.

They are swapped in the docs and in the CSS for components (I think I got them all).