### PR TITLE
the one that makes the gdpr banner not merge with the footer

### DIFF
--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -68,6 +68,7 @@
 
 .vf-banner--notice {
   background-color: $vf-notice-banner-color--background;
+  border-top: 1px colod $vf-notice-banner-color--border;
 
   .vf-banner__text,
   .vf-text { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -68,7 +68,7 @@
 
 .vf-banner--notice {
   background-color: $vf-notice-banner-color--background;
-  border-top: 1px colod $vf-notice-banner-color--border;
+  border-top: 1px solid $vf-notice-banner-color--border;
 
   .vf-banner__text,
   .vf-text { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal

--- a/components/vf-banner/vf-banner.variables.scss
+++ b/components/vf-banner/vf-banner.variables.scss
@@ -1,8 +1,9 @@
-$vf-gdpr-banner-color--background: set-color(vf-color--grey--dark);
+$vf-gdpr-banner-color--background: set-color(vf-color--grey);
 $vf-gdpr-banner-color--text: set-ui-color(vf-ui-color--white);
 $vf-gdpr-banner-padding: map-get($vf-spacing-map, vf-spacing--md);
 
-$vf-notice-banner-color--background: set-color(vf-color--grey--dark);
+$vf-notice-banner-color--background: set-color(vf-color--grey);
+$vf-notice-banner-color--border: set-color(vf-color--grey--darkest);
 
 $vf-notice-banner-color--text: set-ui-color(vf-ui-color--white);
 $vf-notice-banner-padding: map-get($vf-spacing-map, vf-spacing--md);


### PR DESCRIPTION
This PR lightens the grey used for the GDPR banner and adds a darker border to separate it from the footer component visually. This will close #728 