### PR TITLE
the one that removes a parent class for the screen reader only class

### DIFF
--- a/components/vf-utility-classes/vf-u-screen-reader.scss
+++ b/components/vf-utility-classes/vf-u-screen-reader.scss
@@ -1,13 +1,11 @@
-.vf-js {
-  // Some things should only be show to screen readers
-  .vf-u-sr-only {
-    border: 0;
-    clip: rect(0, 0, 0, 0);
-    height: 1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
+// Some things should only be show to screen readers
+.vf-u-sr-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }


### PR DESCRIPTION
related to and will close #665 

I cannot recall why the class for hiding text for screen readers - `vf-u-sr-only` - was a child of the class `vf-js` and I cannot think of a good reason now. 

This removes the need for there to be JS working or not for `vf-u-sr-only` to work. 

