### PR TITLE
adds :focus styles to vf-button--outline

### DIFF
--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -102,6 +102,7 @@ a.vf-button {
   color: set-color(vf-color--blue); // fallback, IE
   color: var(--vf-button-border-color, var(--vf-button__color__background--default) );
 
+  &:focus,
   &:hover {
     color: set-color(vf-color--blue); // fallback, IE
     color: var(--vf-button-border-color);


### PR DESCRIPTION
Looking at #724 

When we have an outline button in use and it is focused the text colour reverts to white. 

This PR fixes that by duplicating the hover styles to the focused styles.

This will close #724 
