### PR TITLE
the one that adds lots of more table things

### DIFF
--- a/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
+++ b/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
@@ -26,14 +26,13 @@
   // Box.
   + .vf-form__label::before {
     background: set-ui-color(vf-ui-color--white);
-    border: 3px solid set-ui-color(vf-ui-color--grey--light);
+    border: 3px solid set-ui-color(vf-ui-color--grey--dark);
     content: '';
     display: inline-block;
-    height: 16px;
-    margin-right: 8px;
+    height: 24px;
     position: relative;
     top: 3px;
-    width: 16px;
+    width: 24px;
   }
 
   // Box hover
@@ -48,7 +47,10 @@
 
   // Box checked
   &:checked + .vf-form__label:before {
-    background: set-color(vf-color--blue);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ctitle%3Echeck%3C/title%3E%3Cpath d='M23.146,5.4,20.354,2.6a.5.5,0,0,0-.708,0L7.854,14.4a.5.5,0,0,1-.708,0L4.354,11.6a.5.5,0,0,0-.708,0L.854,14.4a.5.5,0,0,0,0,.707L7.146,21.4a.5.5,0,0,0,.708,0L23.146,6.1A.5.5,0,0,0,23.146,5.4Z' fill='%233b6fb6'/%3E%3C/svg%3E");
+    background-size: 80%;
+    background-position: center center;
+    background-repeat: no-repeat;
     border-color: set-color(vf-color--blue);
   }
 

--- a/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
+++ b/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
@@ -48,9 +48,9 @@
   // Box checked
   &:checked + .vf-form__label:before {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ctitle%3Echeck%3C/title%3E%3Cpath d='M23.146,5.4,20.354,2.6a.5.5,0,0,0-.708,0L7.854,14.4a.5.5,0,0,1-.708,0L4.354,11.6a.5.5,0,0,0-.708,0L.854,14.4a.5.5,0,0,0,0,.707L7.146,21.4a.5.5,0,0,0,.708,0L23.146,6.1A.5.5,0,0,0,23.146,5.4Z' fill='%233b6fb6'/%3E%3C/svg%3E");
-    background-size: 80%;
     background-position: center center;
     background-repeat: no-repeat;
+    background-size: 80%;
     border-color: set-color(vf-color--blue);
   }
 

--- a/components/vf-table/CHANGELOG.md
+++ b/components/vf-table/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.0
+
+* Adds more table examples to the component
+
 ## 1.0.0
 
 * Initial stable release

--- a/components/vf-table/README.md
+++ b/components/vf-table/README.md
@@ -2,18 +2,16 @@
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-table.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-table)
 
-Tables are everywhere and we provide a variety of implementations depending on need:
+### CSS Class Reference
 
-- Generic: basic styling with no special functionality
-- Striped: with striped rows
-- Borderless: no borders
-- Compact: tighter spacing
-- Data: typography and spacing considerations for data
-- Responsive:
-   - Scroll: on overflow it will scroll left-to-right
-   - Stack: on overflow stack cells
-
-This is a draft component, it is not yet functional. Background on the implementation, goals and work plan [can be found in the issue](https://github.com/visual-framework/vf-core/issues/235). Inspiration may be drawn from [Bootstrap tables](https://getbootstrap.com/docs/4.4/content/tables/).
+| Class                | Applie To  | Result                                                                 |
+| -------------------- | ---------- | ---------------------------------------------------------------------- |
+| `vf-table`           | `table`    | Gives initial generic styling to the `table` element and it's children |
+| `vf-table--striped`  | `vf-table` | Adds striped rows to the relevant `tr` elements.                       |
+| `vf-table--bordered` | `vf-table` | adds a border around all elements                                      |
+| `vf-table--compact`  | `vf-table` | Reduces the padding on the heading and cells                           |
+| `vf-table--loose`    | `vf-table` | Increases the padding on the heading and cells                         |
+|                      |            |                                                                        |
 
 ## Install
 

--- a/components/vf-table/vf-table.config.yml
+++ b/components/vf-table/vf-table.config.yml
@@ -22,6 +22,19 @@ variants:
   - name: fixed header
     context:
       tableLayoutFixed: true
+  - name: interactive
+    context:
+      table_variant: "vf-table--interactive"
+      interactive: true
+  - name: actions
+    context:
+      table_variant: "vf-table--actions"
+      actions: true
+  - name: full
+    context:
+      table_variant: "vf-table--actions vf-table--interactive vf-table--striped"
+      interactive: true
+      actions: true
   # - name: data
   # - name: responsive-scroll
   # - name: responsive-stack
@@ -30,6 +43,8 @@ context:
   firstCellIsHeader: true
 
   table_caption: Hello Caption
+
+  count: 0
 
   table_headings:
     - title: Event

--- a/components/vf-table/vf-table.config.yml
+++ b/components/vf-table/vf-table.config.yml
@@ -9,40 +9,77 @@ variants:
     hidden: false
   - name: striped
     context:
-      table_variant: "vf-table--striped"
+      striped: true
   - name: bordered
     context:
-      table_variant: "vf-table--bordered"
+      bordered: true
   - name: compact
     context:
       table_variant: "vf-table--tight"
   - name: loose
     context:
       table_variant: "vf-table--loose"
+  - name: has footer
+    context:
+      table_footer:
+        - text: Hello
+          colspans: 3
+        - text: world
+          colspans: 1
+  - name: has caption
+    context:
+      table_caption: Hello Caption
+  - name: has row heading
+    context:
+      firstCellIsHeader: true
   - name: fixed header
     context:
       tableLayoutFixed: true
-  - name: interactive
-    context:
-      table_variant: "vf-table--interactive"
-      interactive: true
   - name: actions
     context:
-      table_variant: "vf-table--actions"
-      actions: true
-  - name: full
+      inline_actions:
+        - edit
+        - delete
+  - name: sortable
     context:
-      table_variant: "vf-table--actions vf-table--interactive vf-table--striped"
-      interactive: true
-      actions: true
-  # - name: data
-  # - name: responsive-scroll
-  # - name: responsive-stack
+      sortable: true
+  - name: selectable
+    context:
+      selectable: true
+  - name: selectable (selected)
+    context:
+      selected: true
+      selectable: true
+      actions:
+        - edit
+        - delete
+        - download
+        - cancel
+  - name: kitchen sink
+    context:
+      table_caption: Hello Caption
+      firstCellIsHeader: true
+      striped: true
+      bordered: true
+      table_footer:
+        - text: Hello
+          colspans: 5
+        - text: world
+          colspans: 1
+      selected: true
+      sortable: true
+      selectable: true
+      inline_actions:
+        - edit
+        - delete
+      actions:
+        - edit
+        - delete
+        - download
+        - cancel
+
 context:
   component-type: block
-  firstCellIsHeader: true
-
-  table_caption: Hello Caption
 
   count: 0
 
@@ -54,6 +91,7 @@ context:
 
   table_rows:
     -
+      - selected_row: true
       - text: dave
       - text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima accusamus a nostrum odit aliquid repudiandae architecto molestiae, dolores.
       - text: roger

--- a/components/vf-table/vf-table.njk
+++ b/components/vf-table/vf-table.njk
@@ -12,11 +12,24 @@
     please add headings to table
     {% endif %}
     <tr class="vf-table__row">
+      {%- if interactive -%}
+        <th class="vf-table__heading" scope="col">
+          <input type="checkbox" id="select-all" class="vf-form__checkbox | vf-table__checkbox">
+          <label for="select-all" class="vf-form__label vf-table__label">
+            <span class="vf-u-sr-only">Select all rows</span>
+          </label>
+        </th>
+      {%- endif -%}
       {% for cell in table_headings %}
         <th class="vf-table__heading" scope="col"
         {% if cell.colspans %} colspan="{{cell.colspans}}"{% endif %}
         >{{cell.title}}</th>
       {% endfor %}
+      {%- if actions -%}
+        <th class="vf-table__heading vf-table__heading--actions">
+          Actions
+        </th>
+      {%- endif -%}
     </tr>
   </thead>
 
@@ -24,6 +37,17 @@
     {%- for row in table_rows %}
     {% if row %}
     <tr class="vf-table__row">
+
+      {%- if interactive -%}
+        <td class="vf-table__cell">
+            {% set count = count + 1 %}
+            <input type="checkbox" id="checkbox-{{count}}" class="vf-form__checkbox | vf-table__checkbox">
+            <label for="checkbox-{{count}}" class="vf-form__label vf-table__label">
+              <span class="vf-u-sr-only">Form Label</span>
+            </label>
+        </td>
+
+      {%- endif -%}
 
       {%- for cell in row %}
 
@@ -42,7 +66,12 @@
         {% endif -%}
 
       {% endfor -%}
-
+      {%- if actions -%}
+        <td class="vf-table__cell vf-table__cell--actions">
+          <a href="" class="vf-link">edit</a>
+          <a href="" class="vf-link">delete</a>
+        </td>
+      {%- endif -%}
     </tr>
     {% endif %}
     {% endfor %}

--- a/components/vf-table/vf-table.njk
+++ b/components/vf-table/vf-table.njk
@@ -1,5 +1,22 @@
+<svg class="vf-icon-sprite vf-icon-sprite--tables" display="none">
+	<defs>
+		<g id="vf-table-sortable--up">
+			<path xmlns="http://www.w3.org/2000/svg" d="M17.485,5.062,12.707.284a1.031,1.031,0,0,0-1.415,0L6.515,5.062a1,1,0,0,0,.707,1.707H10.25a.25.25,0,0,1,.25.25V22.492a1.5,1.5,0,1,0,3,0V7.019a.249.249,0,0,1,.25-.25h3.028a1,1,0,0,0,.707-1.707Z"/>
+		</g>
+		<g id="vf-table-sortable--down">
+			<path xmlns="http://www.w3.org/2000/svg" d="M17.7,17.838a1,1,0,0,0-.924-.617H13.75a.249.249,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0V16.971a.25.25,0,0,1-.25.25H7.222a1,1,0,0,0-.707,1.707l4.777,4.778a1,1,0,0,0,1.415,0l4.778-4.778A1,1,0,0,0,17.7,17.838Z"/>
+		</g>
+		<g id="vf-table-sortable">
+			<path xmlns="http://www.w3.org/2000/svg" d="M9,19a1,1,0,0,0-.707,1.707l3,3a1,1,0,0,0,1.414,0l3-3A1,1,0,0,0,15,19H13.5a.25.25,0,0,1-.25-.25V5.249A.25.25,0,0,1,13.5,5H15a1,1,0,0,0,.707-1.707l-3-3a1,1,0,0,0-1.414,0l-3,3A1,1,0,0,0,9,5h1.5a.25.25,0,0,1,.25.25v13.5a.25.25,0,0,1-.25.25Z"/>
+		</g>
+	</defs>
+</svg>
+
 <table class="vf-table
   {%- if table_variant %} {{table_variant}}{% endif -%}
+  {%- if striped %} vf-table--striped{% endif -%}
+  {%- if sortable %} vf-table--sortable{% endif -%}
+  {%- if bordered %} vf-table--bordered{% endif -%}
   {%- if tableLayoutFixed %} vf-table--fixed{% endif -%}
 ">
 
@@ -12,7 +29,7 @@
     please add headings to table
     {% endif %}
     <tr class="vf-table__row">
-      {%- if interactive -%}
+      {%- if selectable -%}
         <th class="vf-table__heading" scope="col">
           <input type="checkbox" id="select-all" class="vf-form__checkbox | vf-table__checkbox">
           <label for="select-all" class="vf-form__label vf-table__label">
@@ -23,9 +40,20 @@
       {% for cell in table_headings %}
         <th class="vf-table__heading" scope="col"
         {% if cell.colspans %} colspan="{{cell.colspans}}"{% endif %}
-        >{{cell.title}}</th>
+      >
+      {%- if sortable -%}
+        <button class="vf-button vf-button--sm vf-button--icon">
+          {{cell.title}}
+          <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" version="1.1" preserveAspectRatio="xMinYMin">
+          	<use xlink:href="#vf-table-sortable"></use>
+          </svg>
+        </button>
+      {% else %}
+        {{cell.title}}
+      {% endif %}
+      </th>
       {% endfor %}
-      {%- if actions -%}
+      {%- if inline_actions -%}
         <th class="vf-table__heading vf-table__heading--actions">
           Actions
         </th>
@@ -36,40 +64,57 @@
   <tbody class="vf-table__body">
     {%- for row in table_rows %}
     {% if row %}
-    <tr class="vf-table__row">
+    <tr class="vf-table__row
+    {% if selected %}
+    {%- for cell in row %}
+      {%- if cell.selected_row %} vf-table__row--selected
+    {%- endif -%}
+    {%- endfor -%}
+    {%- endif -%}
+    ">
 
-      {%- if interactive -%}
-        <td class="vf-table__cell">
+      {%- if selectable -%}
+        <th class="vf-table__cell vf-table__cell--selectable" scope="row">
             {% set count = count + 1 %}
-            <input type="checkbox" id="checkbox-{{count}}" class="vf-form__checkbox | vf-table__checkbox">
+            <input type="checkbox" id="checkbox-{{count}}" class="vf-form__checkbox | vf-table__checkbox"
+            {% if selected %}
+            {%- for cell in row %}
+              {%- if cell.selected_row %} checked{%- endif -%}
+            {%- endfor -%}
+            {%- endif -%}
+            >
             <label for="checkbox-{{count}}" class="vf-form__label vf-table__label">
               <span class="vf-u-sr-only">Form Label</span>
             </label>
-        </td>
+        </th>
 
       {%- endif -%}
 
       {%- for cell in row %}
 
-        {%- if loop.first and firstCellIsHeader == true %}
-          <th class="vf-table__cell | vf-table__heading" scope="row"
-          {% if cell.colspans %} colspan="{{cell.colspans}}"{% endif %}
-          {% if cell.rowspans %} rowspan="{{cell.rowspans}}"{% endif %}
-          >{{ cell.text }}</th>
+        {%- if cell.selected_row %}
+        {% else %}
 
-        {%- else -%}
+          {%- if loop.first and firstCellIsHeader == true %}
+            <th class="vf-table__cell | vf-table__heading" scope="row"
+            {% if cell.colspans %} colspan="{{cell.colspans}}"{% endif %}
+            {% if cell.rowspans %} rowspan="{{cell.rowspans}}"{% endif %}
+            >{{ cell.text }}</th>
 
-          <td class="vf-table__cell"
-          {% if cell.colspans %} colspan="{{cell.colspans}}"{% endif %}
-          {% if cell.rowspans %} rowspan="{{cell.rowspans}}"{% endif %}
-          >{{ cell.text }}</td>
+          {%- else -%}
+
+            <td class="vf-table__cell"
+            {% if cell.colspans %} colspan="{{cell.colspans}}"{% endif %}
+            {% if cell.rowspans %} rowspan="{{cell.rowspans}}"{% endif %}
+            >{{ cell.text }}</td>
+          {% endif -%}
         {% endif -%}
-
       {% endfor -%}
-      {%- if actions -%}
+      {%- if inline_actions -%}
         <td class="vf-table__cell vf-table__cell--actions">
-          <a href="" class="vf-link">edit</a>
-          <a href="" class="vf-link">delete</a>
+          {%- for action in inline_actions %}
+          <button class="vf-button vf-button--sm vf-button--icon">{{action}}</button>
+          {%- endfor -%}
         </td>
       {%- endif -%}
     </tr>
@@ -77,4 +122,26 @@
     {% endfor %}
   </tbody>
 
+  {%- if table_footer %}
+  <tfoot class="vf-table__footer">
+    <tr class="vf-table__row">
+      {% for cell in table_footer %}
+      <td class="vf-table__cell"
+      {% if cell.colspans %} colspan="{{cell.colspans}}"{% endif %}
+      {% if cell.rowspans %} rowspan="{{cell.rowspans}}"{% endif %}
+      >
+        {{cell.text}}
+      </td>
+      {% endfor %}
+    </tr>
+  </tfoot>
+  {%- endif -%}
 </table>
+
+{% if selected %}
+<div class="vf-table__actions">
+  {%- for action in actions %}
+  <button class="vf-button vf-button--sm vf-button--icon">{{action}}</button>
+  {%- endfor -%}
+</div>
+{% endif %}

--- a/components/vf-table/vf-table.scss
+++ b/components/vf-table/vf-table.scss
@@ -24,7 +24,7 @@
   border-collapse: collapse;
 
   .vf-button--icon,
-  &:visited
+  &:visited,
   &:hover,
   &:focus {
     color: set-color(vf-color--blue);
@@ -35,15 +35,17 @@
 .vf-table__heading {
   .vf-button--icon {
     align-items: center;
+    color: currentColor;
     display: flex;
     font-weight: 700;
-    color: currentColor;
+
     svg {
-      opacity: 0;
-      margin-left: 4px;
       height: 20px;
+      margin-left: 4px;
+      opacity: 0;
       padding: 2px;
     }
+
     &:hover {
       svg {
         opacity: 1;
@@ -160,7 +162,7 @@
   .vf-table__label {
     &::before {
       // TODO: sort this important out
-      border-color: black !important;
+      border-color: set-ui-color(vf-ui-color--black) !important;
     }
   }
 }
@@ -179,7 +181,7 @@
     &:first-child {
       margin-left: 0;
     }
-    &:visited
+    &:visited,
     &:hover,
     &:focus {
       color: set-color(vf-color--blue);
@@ -190,8 +192,8 @@
 
 
 .vf-table__footer {
-  border-top: 1px solid set-ui-color(vf-ui-color--black);
   background-color: set-color(vf-color--grey--lightest);
+  border-top: 1px solid set-ui-color(vf-ui-color--black);
 
   .vf-table__cell {
     padding: 8px 16px;

--- a/components/vf-table/vf-table.scss
+++ b/components/vf-table/vf-table.scss
@@ -22,7 +22,36 @@
 .vf-table {
   background-color: set-ui-color(vf-ui-color--white);
   border-collapse: collapse;
+
+  .vf-button--icon,
+  &:visited
+  &:hover,
+  &:focus {
+    color: set-color(vf-color--blue);
+    font-weight: 400;
+  }
 }
+
+.vf-table__heading {
+  .vf-button--icon {
+    align-items: center;
+    display: flex;
+    font-weight: 700;
+    color: currentColor;
+    svg {
+      opacity: 0;
+      margin-left: 4px;
+      height: 20px;
+      padding: 2px;
+    }
+    &:hover {
+      svg {
+        opacity: 1;
+      }
+    }
+  }
+}
+
 
 .vf-table--fixed {
   table-layout: fixed;
@@ -49,8 +78,10 @@
 }
 
 .vf-table__cell {
-  @include set-type(text-body--3, $custom-margin-bottom: 0);
-  padding: 4px 16px;
+  @include set-type(text-body--2, $custom-margin-bottom: 0);
+
+  padding: 8px 16px;
+  vertical-align: top;
 }
 
 .vf-table--tight {
@@ -82,9 +113,6 @@
     & .vf-table__row:nth-of-type(even) {
       background-color: set-ui-color(vf-ui-color--grey--light);
     }
-    & .vf-table__row:hover {
-      background-color: set-ui-color(vf-ui-color--yellow);
-    }
   }
 }
 
@@ -103,7 +131,7 @@
 
 
 .vf-table__body {
-  & .vf-table__row:hover {
+  & .vf-table__row:not(.vf-table__row--selected):hover {
     background-color: set-ui-color(vf-ui-color--yellow);
   }
 }
@@ -111,4 +139,61 @@
 .vf-table__label {
   margin: 0;
   text-align: center;
+}
+
+
+// Selectable
+
+.vf-table__cell--selectable {
+  // vertical-align: middle;
+}
+
+.vf-table__row--selected {
+  background-color: set-color(vf-color--blue);
+  color: set-ui-color(vf-ui-color--white);
+
+
+  .vf-button {
+    color: set-ui-color(vf-ui-color--white);
+  }
+
+  .vf-table__label {
+    &::before {
+      // TODO: sort this important out
+      border-color: black !important;
+    }
+  }
+}
+
+
+.vf-table__actions {
+  background-color: set-color(vf-color--blue);;
+  padding: 16px;
+
+  .vf-button {
+    @include set-type(text-body--2, $custom-margin-bottom: 0);
+
+    color: set-ui-color(vf-ui-color--white);
+    margin-left: 1em;
+
+    &:first-child {
+      margin-left: 0;
+    }
+    &:visited
+    &:hover,
+    &:focus {
+      color: set-color(vf-color--blue);
+      font-weight: 400;
+    }
+  }
+}
+
+
+.vf-table__footer {
+  border-top: 1px solid set-ui-color(vf-ui-color--black);
+  background-color: set-color(vf-color--grey--lightest);
+
+  .vf-table__cell {
+    padding: 8px 16px;
+  }
 }

--- a/components/vf-table/vf-table.scss
+++ b/components/vf-table/vf-table.scss
@@ -107,3 +107,8 @@
     background-color: set-ui-color(vf-ui-color--yellow);
   }
 }
+
+.vf-table__label {
+  margin: 0;
+  text-align: center;
+}


### PR DESCRIPTION
Now we have the `vf-table` there is a need for some more advanced options so the component can be used in more places. 

We include the HTML and CSS so that you can:

- use selectable table rows.
- add actions for a row or as a toolbar for a selection of rows.
- adds a footer.
- adds 'sortable' styles with a (currently) inline SVG of icons.
- better examples of 'one variant' doing 'one thing' and then a 'kitchen sink'.
- a small start to the documentation.


This PR does not include any JS functionality for the tables.