### PR TITLE
the one that styles checkboxes inside of checkbox divs

### DIFF
--- a/components/vf-form/vf-form__checkbox/CHANGELOG.md
+++ b/components/vf-form/vf-form__checkbox/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 
+## 1.1.0
+
+- the vf-form__checkbox is now used in more than forms so we have added some 'context' styling for when it is in a form.
+
+
 ## 1.0.0
 
 - moves `vf-form__checkbox--inline` into it's own .njk file.
 - tidies up alignment of label and checkbox
-

--- a/components/vf-form/vf-form__checkbox/vf-form__checkbox--inline.njk
+++ b/components/vf-form/vf-form__checkbox/vf-form__checkbox--inline.njk
@@ -1,4 +1,4 @@
 <div class="vf-form__item vf-form__item--checkbox vf-form__item--checkbox--inline">
-  <input type="checkbox" id="checkbox-01" class="vf-form__checkbox">
-  <label for="checkbox-01" class="vf-form__label">Form Label</label>
+  <input type="checkbox" id="checkbox-inline-01" class="vf-form__checkbox">
+  <label for="checkbox-inline-01" class="vf-form__label">Form Label</label>
 </div>

--- a/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
+++ b/components/vf-form/vf-form__checkbox/vf-form__checkbox.scss
@@ -12,6 +12,19 @@
 .vf-form__item.vf-form__item--checkbox {
   margin-bottom: 16px;
 }
+
+// Because we want the checkbox to be used in various context. We need the context to define
+// Any layout things, and colours like below
+.vf-form__item--checkbox {
+  .vf-form__checkbox {
+    + .vf-form__label::before {
+      border-color: set-ui-color(vf-ui-color--grey--light);
+      margin-right: 8px;
+      top: 8px;
+    }
+  }
+}
+
 .vf-form__checkbox {
   opacity: 0; // hide it
   position: absolute; // take it out of document flow


### PR DESCRIPTION
The more we work on the Visual Framework the more I think we should have given all 'elements' nothing more than general styles like: colours, font size, font weight and let their parents determine their spacing and layout, and any overriding colours.

This fixes up the checkbox for when it's in a form to have different spacing to when it is in a table