### PR TITLE
changes required astericks colour

### DIFF
--- a/components/vf-form/vf-form__label/CHANGELOG.md
+++ b/components/vf-form/vf-form__label/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.0
+
+- changes the required asterick colour from red to blue, as red is more of an 'error' colour. 
+
 ## 1.0.0
 
 - adds a required asterick label (uses `<p>` tag).

--- a/components/vf-form/vf-form__label/vf-form__label.scss
+++ b/components/vf-form/vf-form__label/vf-form__label.scss
@@ -21,7 +21,7 @@
   float: right;
   margin-bottom: 0;
   .vf-icon svg {
-    fill: set-ui-color(vf-ui-color--red);
+    fill: set-color(vf-color--blue);
     height: 12px;
     width: 16px;
   }


### PR DESCRIPTION
I noticed for some project mockups that a blue asterisk was use - I think this is nicer than the red currently used for required form inputs. 

Red is like 'you are wrong, fill this out' before you've even started.