### PR TITLE
the one that removes additional spacing from text

### DIFF
--- a/components/vf-sass-config/mixins/_text-crop.scss
+++ b/components/vf-sass-config/mixins/_text-crop.scss
@@ -1,0 +1,64 @@
+@mixin text-crop($line-height: 1.3, $top-adjustment: 0px, $bottom-adjustment: 0px) {
+    // Configured in Step 1
+    $top-crop: 9;
+    $bottom-crop: 8;
+    $crop-font-size: 36;
+    $crop-line-height: 1.2;
+
+    // Apply values to calculate em-based margins that work with any font size
+    $dynamic-top-crop: max(($top-crop + ($line-height - $crop-line-height) * ($crop-font-size / 2)), 0) / $crop-font-size;
+    $dynamic-bottom-crop: max(($bottom-crop + ($line-height - $crop-line-height) * ($crop-font-size / 2)), 0) / $crop-font-size;
+
+    // Mixin output
+    line-height: $line-height;
+
+    &::before,
+    &::after {
+        content: '';
+        display: block;
+        height: 0;
+        width: 0;
+    }
+
+    &::before {
+        margin-bottom: calc(-#{$dynamic-top-crop}em + #{$top-adjustment});
+    }
+
+    &::after {
+        margin-top: calc(-#{$dynamic-bottom-crop}em + #{$bottom-adjustment});
+    }
+}
+// Mixin generated at: http://text-crop.eightshapes.com/?typeface-selection=google-font&typeface=IBM%20Plex%20Sans&custom-typeface-name=Helvetica&custom-typeface-url=&custom-typeface-weight=400&custom-typeface-style=normal&weight-and-style=regular&size=36&line-height=1.2&top-crop=9&bottom-crop=8
+
+/* Usage Examples
+    .my-level-1-heading-class {
+        @include text-crop; // Will use default line height of 1.3
+        font-size: 48px;
+        margin: 0 0 0 16px;
+    }
+
+    .my-level-2-heading-class {
+        @include text-crop; // Will use default line height of 1.3
+        font-size: 32px; // Don't need to change any settings, will work with any font size automatically
+        margin: 0 0 0 16px;
+    }
+
+    .my-body-copy-class {
+        @include text-crop($line-height: 2); // Larger line height desired, set the line height via the mixin
+        font-size: 16px;
+    }
+
+    // Sometimes depending on the font-size, the rendering, the browser, etc. you may need to tweak the output.
+    // You can adjust the top and bottom cropping when invoking the component using the $top-adjustment and $bottom-adjustment settings
+
+    .slight-adjustment-needed {
+        @include text-crop($top-adjustment: -0.5px, $bottom-adjustment: 2px);
+        font-size: 17px;
+    }
+
+    .dont-do-this {
+        @include text-crop;
+        font-size: 16px;
+        line-height: 3; // DO NOT set line height outside of the mixin, the mixin needs the line height value to calculate the crop correctly
+    }
+*/

--- a/components/vf-sass-config/mixins/_vf-mixins.scss
+++ b/components/vf-sass-config/mixins/_vf-mixins.scss
@@ -10,5 +10,6 @@
 @import 'margin.scss';
 @import 'padding.scss';
 @import 'text-color.scss';
+@import 'text-crop.scss';
 @import 'typography.scss';
 @import 'vf-disabled.scss';


### PR DESCRIPTION
line-height `!=` leading and so the em box for a glyph has weird vertical spacing which can make things look odd. If we remove these using a tool we can then have better control over how we want the typography to display.

More info –
- https://medium.com/eightshapes-llc/cropping-away-negative-impacts-of-line-height-84d744e016ce 
- https://codyhouse.co/blog/post/line-height-crop