### PR TITLE
the one that makes section header links pass some #a11y rules

### DIFF
--- a/components/vf-section-header/CHANGELOG.md
+++ b/components/vf-section-header/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.1.1
+
+* SVG is a visual queue: adds aria-role="hidden" to the SVG in the component so screen readers don't announce it
+  https://github.com/visual-framework/vf-core/pull/873
+
 ## 1.1.0
 
 * adds ability for section header to have sub-heading and text.

--- a/components/vf-section-header/vf-section-header.njk
+++ b/components/vf-section-header/vf-section-header.njk
@@ -12,7 +12,7 @@
     class="vf-section-header__heading{% if href %} vf-section-header__heading--is-link{% endif %}" {% if href %}href="{{href}}"{% endif %}>
     {{ section_title }}
     {% if href %}
-      <svg class="vf-section-header__icon | vf-icon vf-icon-arrow--inline-end" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="" fill-rule="nonzero"></path></svg>
+      <svg aria-hidden="true" class="vf-section-header__icon | vf-icon vf-icon-arrow--inline-end" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="" fill-rule="nonzero"></path></svg>
     {% endif %}
   </{{tags}}>
   {% if section__subheading %}


### PR DESCRIPTION
I ran https://www.covid19dataportal.org/ through Firefox's accessibility panel and found a glaring issue with the `vf-section-header` when it is a link. The SVG was being seen by assistive technologies and was reporting a missing label.

As the SVG is a visual queue only I have added `aria-role="hidden"` to the SVG in the component to fix it.