### PR TITLE
BUG - Add underline to links in vf-banner

### DIFF
--- a/components/embl-notifications/CHANGELOG.md
+++ b/components/embl-notifications/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.0-beta.1
+
+* Use `.vf-banner__link`
+
 ## 1.0.0-alpha.2
 
 * Improved formatting support and conditional logic https://github.com/visual-framework/vf-core/pull/817

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -17,22 +17,22 @@ function emblNotificationsInject(message) {
   // preperation
   message.body = message.body.replace(/<[/]?[p>]+>/g, ' '); // no <p> tags allowed in inline messages, preserve a space to not colide words
   // add vf-link to link
-  message.body = message.body.replace('<a href=', '<a class="vf-link" href='); // we might need a more clever regex, but this should also avoid links that aleady have a class
+  message.body = message.body.replace('<a href=', '<a class="vf-banner__link" href='); // we might need a more clever regex, but this should also avoid links that aleady have a class
   // Learn more link is conditionally shown
   if (message.field_notification_link) {
-    message.body = `${message.body} <a class="vf-link" href="${message.field_notification_link}">Learn more</a>`;
+    message.body = `${message.body} <a class="vf-banner__link" href="${message.field_notification_link}">Learn more</a>`;
   }
   // custom button text
   message.field_notification_button_text = message.field_notification_button_text || 'Close notice';
   // notification memory and cookie options
   if (message.field_notification_cookie == "True") {
     output.dataset.vfJsBannerCookieName = message.cookieName;
-    output.dataset.vfJsBannerCookieVersion = message.cookieVersion;  
+    output.dataset.vfJsBannerCookieVersion = message.cookieVersion;
     if (message.field_notification_auto_accept == "True") {
       output.dataset.vfJsBannerAutoAccept = true;
     }
   }
-  
+
   if (message.field_notification_position == 'fixed') {
     output.classList.add('vf-banner', 'vf-banner--fixed', 'vf-banner--bottom', 'vf-banner--notice');
     output.dataset.vfJsBanner = true;
@@ -56,7 +56,7 @@ function emblNotificationsInject(message) {
           <p class="vf-banner__text">${message.body}</p>
         </div>
       </div>`;
-  
+
     // insert after `vf-header` or at after `vf-body`
     // @todo: add support for where "inline" message should be shown
     // @todo: don't rely on the presence of vf-header to show inline notification, maybe <div data-notifications-go-here>
@@ -87,7 +87,7 @@ function emblNotificationsInject(message) {
 
     let target = document.body.firstChild;
     target.parentNode.prepend(output);
-    vfBanner();    
+    vfBanner();
   }
 
   // console.log('emblNotifications, showing:', message);
@@ -129,7 +129,7 @@ function emblNotifications(currentHost, currentPath) {
       matchFound = compareUrls(currentHost+currentPath, targetUrl, true);
     }
 
-    // if a match has been made on the current url path, show the message 
+    // if a match has been made on the current url path, show the message
     if (matchFound == true) {
       // console.log('emblNotifications: MATCH FOUND 🎉', targetUrl, currentHost, currentPath);
       message.hasBeenShown = true;
@@ -147,12 +147,12 @@ function emblNotifications(currentHost, currentPath) {
     url2 = url2.toLowerCase();
 
     // don't allow matches to end in `*`
-    if (url1.slice(-1) == '*') url1 = url1.substring(0, url1.length - 1); 
-    if (url2.slice(-1) == '*') url2 = url2.substring(0, url2.length - 1); 
+    if (url1.slice(-1) == '*') url1 = url1.substring(0, url1.length - 1);
+    if (url2.slice(-1) == '*') url2 = url2.substring(0, url2.length - 1);
 
     // don't allow matches to end in `/`
-    if (url1.slice(-1) == '/') url1 = url1.substring(0, url1.length - 1); 
-    if (url2.slice(-1) == '/') url2 = url2.substring(0, url2.length - 1); 
+    if (url1.slice(-1) == '/') url1 = url1.substring(0, url1.length - 1);
+    if (url2.slice(-1) == '/') url2 = url2.substring(0, url2.length - 1);
 
     // console.log('emblNotifications, comparing:', url1 + "," + url2);
 
@@ -180,13 +180,13 @@ function emblNotifications(currentHost, currentPath) {
 
       // track if a message has already been show on the page
       // we want to be sure a message isn't accidently shown twice
-      currentMessage.hasBeenShown = false; 
+      currentMessage.hasBeenShown = false;
 
       // Process the URLs for each path in a message
       let currentUrls = currentMessage.field_notification_urls.split(',');
       for (let indexUrls = 0; indexUrls < currentUrls.length; indexUrls++) {
         let url = currentUrls[indexUrls].trim();
-        matchNotification(currentMessage, url); // pass the notification and active url to compare       
+        matchNotification(currentMessage, url); // pass the notification and active url to compare
       }
     }
   }

--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.0.6
 
-* Adds underline on links
+* Adds underline on links using `.vf-banner__link`
+* Resolves IE11 bug assigning classes
 
 ## 1.0.5
 
@@ -15,7 +16,7 @@
 * Makes use of `vf-banner__text`
 * Use of `vf-text` is deprecated
 
-## 1.0.2 
+## 1.0.2
 
 * Links in text areas of banners regain an underline.
 

--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.6
+
+* Adds underline on links
+
 ## 1.0.5
 
 * Add alert `--alert` and `--warning` banners

--- a/components/vf-banner/vf-banner--fixed.njk
+++ b/components/vf-banner/vf-banner--fixed.njk
@@ -9,7 +9,7 @@ data-vf-js-banner-extra-button="<a href='#'>Optional button</a><a target='_blank
 data-vf-js-banner-auto-accept="false">
   <div class="vf-banner__content | vf-grid" data-vf-js-banner-text>
     <p class="vf-banner__text vf-banner__text--lg">
-      This website uses cookies, and the limiting processing of your personal data to function. By using the site you are agreeing to this as outlined in our <a class="vf-link" href="JavaScript:Void(0);">Privacy Notice</a> and <a class="vf-link" href="JavaScript:Void(0);">Terms Of Use</a>.
+      This website uses cookies, and the limiting processing of your personal data to function. By using the site you are agreeing to this as outlined in our <a class="vf-banner__link" href="JavaScript:Void(0);">Privacy Notice</a> and <a class="vf-banner__link" href="JavaScript:Void(0);">Terms Of Use</a>.
     </p>
   </div>
 </div>

--- a/components/vf-banner/vf-banner--gdpr.scss
+++ b/components/vf-banner/vf-banner--gdpr.scss
@@ -11,6 +11,7 @@
       margin-bottom: 24px;
       max-width: 64em;
 
+      & .vf-banner__link,
       & .vf-link {
         color: $vf-banner-color--link;
       }

--- a/components/vf-banner/vf-banner--phase.scss
+++ b/components/vf-banner/vf-banner--phase.scss
@@ -8,6 +8,7 @@
     color: $vf-phase-banner-color--text;
     margin: 0; // makes the text have no margin so the parent component defines the spacing
 
+    & .vf-banner__link,
     & .vf-link {
       color: $vf-banner-color--link;
     }

--- a/components/vf-banner/vf-banner--top.njk
+++ b/components/vf-banner/vf-banner--top.njk
@@ -4,6 +4,6 @@ data-vf-js-banner-state="dismissible"
 data-vf-js-banner-button-text="Close notice">
   <div class="vf-banner__content" data-vf-js-banner-text>
     <span class="vf-badge vf-badge--primary">BETA</span>
-    <p class="vf-banner__text">This is the new EMBL.org <a href="{{ vf-banner--inline__url }}" class="vf-link">Complete our quick survey</a> to help us make it better.</p>
+    <p class="vf-banner__text">This is the new EMBL.org <a href="{{ vf-banner--inline__url }}" class="vf-banner__link">Complete our quick survey</a> to help us make it better.</p>
   </div>
 </div>

--- a/components/vf-banner/vf-banner.config.yml
+++ b/components/vf-banner/vf-banner.config.yml
@@ -15,7 +15,7 @@ variants:
     hidden: true
   - name: info
     context:
-      alert_message: Here is some very, <em>very</em> <a class="vf-link" href="JavaScript:Void(0);">important information</a>
+      alert_message: Here is some very, <em>very</em> <a class="vf-banner__link" href="JavaScript:Void(0);">important information</a>
   - name: warning
     context:
       alert_message: Easy now, easy does it.
@@ -24,6 +24,6 @@ variants:
       alert_message: Oh dear, what have you done?
   - name: success
     context:
-      alert_message: Congratulations! You have made something <a class="vf-link" href="JavaScript:Void(0);">awesome</a>!
+      alert_message: Congratulations! You have made something <a class="vf-banner__link" href="JavaScript:Void(0);">awesome</a>!
   - name: inline
     hidden: true

--- a/components/vf-banner/vf-banner.config.yml
+++ b/components/vf-banner/vf-banner.config.yml
@@ -15,7 +15,7 @@ variants:
     hidden: true
   - name: info
     context:
-      alert_message: Here is some very, <em>very</em> important information
+      alert_message: Here is some very, <em>very</em> <a class="vf-link" href="JavaScript:Void(0);">important information</a>
   - name: warning
     context:
       alert_message: Easy now, easy does it.
@@ -24,6 +24,6 @@ variants:
       alert_message: Oh dear, what have you done?
   - name: success
     context:
-      alert_message: Congratulations! You have made something <a href="JavaScript:Void(0);">awesome</a>!
+      alert_message: Congratulations! You have made something <a class="vf-link" href="JavaScript:Void(0);">awesome</a>!
   - name: inline
     hidden: true

--- a/components/vf-banner/vf-banner.js
+++ b/components/vf-banner/vf-banner.js
@@ -30,7 +30,7 @@ function vfBannerReset(vfBannerCookieNameAndVersion) {
  * Confirm a banner, initiate cookie logging
  */
 function vfBannerConfirm(banner,vfBannerCookieNameAndVersion) {
-  banner.classList += " vf-u-display-none";
+  banner.classList.add('vf-u-display-none');
   if (vfBannerCookieNameAndVersion !== 'null') {
     vfBannerSetCookie(vfBannerCookieNameAndVersion,true);
   }
@@ -161,7 +161,7 @@ function vfBannerInsert(banner,bannerId,scope) {
         var newButton = document.createElement('button');
         newButton.innerHTML = button;
         newButton = newButton.firstChild;
-        newButton.classList = 'vf-button vf-button--primary';
+        newButton.classList.add('vf-button','vf-button--primary');
         generatedBannerHtml += newButton.outerHTML;
       }
     });
@@ -202,7 +202,7 @@ function vfBannerInsert(banner,bannerId,scope) {
     // if banner has been previously accepted
     if (vfBannerGetCookie(vfBannerCookieNameAndVersion) === 'true') {
       // banner has been accepted, close
-      targetBanner.classList += " vf-u-display-none";
+      targetBanner.classList.add('vf-u-display-none');
       // exit, nothng more to do
       return;
     }

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -21,7 +21,7 @@
 }
 
 // all vf-text links should be underlined in banners
-.vf-banner__text .vf-link,
+.vf-banner__text .vf-banner__link,
 .vf-banner [class*='vf-text'] .vf-link { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal
   text-decoration: underline;
 }
@@ -77,6 +77,7 @@
     margin-bottom: 24px;
     max-width: 64em;
 
+    & .vf-banner__link,
     & .vf-link {
       color: $vf-banner-color--link;
     }

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -21,7 +21,8 @@
 }
 
 // all vf-text links should be underlined in banners
-.vf-banner [class*='vf-text'] .vf-link {
+.vf-banner__text .vf-link,
+.vf-banner [class*='vf-text'] .vf-link { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal
   text-decoration: underline;
 }
 


### PR DESCRIPTION
Links in `vf-banner` were appearing without distinction from the surrounding text.

![image](https://user-images.githubusercontent.com/928100/79978042-8983bc80-849f-11ea-846a-892ac713bd81.png)

Also adds not that `vf-text` usage in `vf-banner` is deprecated (already noted elsewhere in the Sass)

