### PR TITLE
the one where we get IE11 working better, again.

### DIFF
--- a/components/vf-grid/CHANGELOG.md
+++ b/components/vf-grid/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.3 (2020-04-22)
+
+* fixes a bug with IE11 where we relied on the calc function inside the flex (which IE11 does not support) in the flexbox fallback grid defined columned classes (.vf-grid__col-2 > * {...) etc).
+
 # 1.0.2 (2020-03-20)
 
 * fixes issue with vf-grid inside vf-body https://github.com/visual-framework/vf-core/pull/802

--- a/components/vf-grid/vf-grid.scss
+++ b/components/vf-grid/vf-grid.scss
@@ -18,7 +18,7 @@
   margin: 10px 0 10px 1.6339%;
 }
 
-.vf-grid >*:first-child {
+.vf-grid > *:first-child {
   margin-left: 0;
 }
 

--- a/components/vf-grid/vf-grid.scss
+++ b/components/vf-grid/vf-grid.scss
@@ -26,6 +26,9 @@
 [class*='vf-grid__'] {
   flex-wrap: wrap;
 }
+// Originally the calculations in the flex declarations below were created using CSS calc
+// Unfortunately IE11 (which this flexbox grid is for) does not support calc inside of flex
+// So we've hard coded the percentage values. All other modern browsers get to use grid.
 .vf-grid__col-2 > * {
   flex: 0 0 49.18305%;
 }

--- a/components/vf-grid/vf-grid.scss
+++ b/components/vf-grid/vf-grid.scss
@@ -21,19 +21,19 @@
   flex-wrap: wrap;
 }
 .vf-grid__col-2 > * {
-  flex: 0 0 calc(50% - 20px);
+  flex: 0 0 48.3672885894%
 }
 .vf-grid__col-3 > *{
-  flex: 0 0 calc(33.3333% - 20px);
+  flex: 0 0 31.7006216049%
 }
 .vf-grid__col-4 > * {
-  flex: 0 0 calc(25% - 20px);
+  flex: 0 0 23.3672895431%
 }
 .vf-grid__col-5 > * {
-  flex: 0 0 calc(16% - 20px);
+  flex: 0 0 18.3670339584%;
 }
 .vf-grid__col-6 > * {
-  flex: 0 0 calc(16.666666667% - 20px);
+  flex: 0 0 0 0 15.0339550971%
 }
 @media (max-width: 1023px) {
   .vf-grid {

--- a/components/vf-grid/vf-grid.scss
+++ b/components/vf-grid/vf-grid.scss
@@ -15,25 +15,31 @@
 }
 .vf-grid > * {
   flex: 1;
-  margin: 10px;
+  margin: 10px 0 10px 1.6339%;
 }
+
+.vf-grid >*:first-child {
+  margin-left: 0;
+}
+
+
 [class*='vf-grid__'] {
   flex-wrap: wrap;
 }
 .vf-grid__col-2 > * {
-  flex: 0 0 48.3672885894%
+  flex: 0 0 49.18305%;
 }
 .vf-grid__col-3 > *{
-  flex: 0 0 31.7006216049%
+  flex: 0 0 32.244066667%;
 }
 .vf-grid__col-4 > * {
-  flex: 0 0 23.3672895431%
+  flex: 0 0 23.774575%;
 }
 .vf-grid__col-5 > * {
-  flex: 0 0 18.3670339584%;
+  flex: 0 0 18.69288%;
 }
 .vf-grid__col-6 > * {
-  flex: 0 0 0 0 15.0339550971%
+  flex: 0 0 15.305083333%;
 }
 @media (max-width: 1023px) {
   .vf-grid {


### PR DESCRIPTION
This should close #881 

IE11 does not support `calc()` inside of `flex` because, why not‽ 

This fixes the issue that was reported where the size of grid items was being ignored because `calc()` was not working.

Here we have 'hard coded' the percentage values.

Testing on IE11 before moving from Draft.