### PR TITLE
The one that adds more z-index to the system.

### DIFF
--- a/components/vf-design-tokens/CHANGELOG.md
+++ b/components/vf-design-tokens/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.5
+
+* Updates the z-index to separate any banner or hero from banner
+
 ## 1.0.4
 
 * Swaps `--vf-ui-color--grey` and `--vf-ui-color--grey--light` which had been inverted

--- a/components/vf-design-tokens/dist/json/vf-zindex.ios.json
+++ b/components/vf-design-tokens/dist/json/vf-zindex.ios.json
@@ -9,6 +9,12 @@
     {
       "type": "number",
       "category": "layer",
+      "name": "vfZIndexPseudoElementFix",
+      "value": 1
+    },
+    {
+      "type": "number",
+      "category": "layer",
       "name": "vfZIndexFormInput",
       "value": 1
     },
@@ -22,7 +28,13 @@
       "type": "number",
       "category": "layer",
       "name": "vfZIndexBanner",
-      "value": 5150
+      "value": 1984
+    },
+    {
+      "type": "number",
+      "category": "layer",
+      "name": "vfZIndexHero",
+      "value": 1984
     },
     {
       "type": "number",

--- a/components/vf-design-tokens/dist/json/vf-zindex.ios.json
+++ b/components/vf-design-tokens/dist/json/vf-zindex.ios.json
@@ -27,12 +27,6 @@
     {
       "type": "number",
       "category": "layer",
-      "name": "vfZIndexBanner",
-      "value": 1984
-    },
-    {
-      "type": "number",
-      "category": "layer",
       "name": "vfZIndexHero",
       "value": 1984
     },
@@ -40,6 +34,12 @@
       "type": "number",
       "category": "layer",
       "name": "vfZIndexMasthead",
+      "value": 1984
+    },
+    {
+      "type": "number",
+      "category": "layer",
+      "name": "vfZIndexBanner",
       "value": 5150
     }
   ]

--- a/components/vf-design-tokens/dist/sass/custom-properties/vf-zindex.custom-properties.scss
+++ b/components/vf-design-tokens/dist/sass/custom-properties/vf-zindex.custom-properties.scss
@@ -8,7 +8,7 @@
   --vf-z-index--pseudo-element-fix: 1;
   --vf-z-index--form-input: 1;
   --vf-z-index--form-label: 1;
-  --vf-z-index--banner: 1984;
   --vf-z-index--hero: 1984;
-  --vf-z-index--masthead: 5150;
+  --vf-z-index--masthead: 1984;
+  --vf-z-index--banner: 5150;
 }

--- a/components/vf-design-tokens/dist/sass/custom-properties/vf-zindex.custom-properties.scss
+++ b/components/vf-design-tokens/dist/sass/custom-properties/vf-zindex.custom-properties.scss
@@ -5,8 +5,10 @@
 
 :root {
   --vf-z-index--negative: -1;
+  --vf-z-index--pseudo-element-fix: 1;
   --vf-z-index--form-input: 1;
   --vf-z-index--form-label: 1;
-  --vf-z-index--banner: 5150;
+  --vf-z-index--banner: 1984;
+  --vf-z-index--hero: 1984;
   --vf-z-index--masthead: 5150;
 }

--- a/components/vf-design-tokens/dist/sass/maps/vf-zindex.map.scss
+++ b/components/vf-design-tokens/dist/sass/maps/vf-zindex.map.scss
@@ -8,7 +8,7 @@ $vf-zindex-map: (
   'vf-z-index--pseudo-element-fix': (1),
   'vf-z-index--form-input': (1),
   'vf-z-index--form-label': (1),
-  'vf-z-index--banner': (1984),
   'vf-z-index--hero': (1984),
-  'vf-z-index--masthead': (5150),
+  'vf-z-index--masthead': (1984),
+  'vf-z-index--banner': (5150),
 );

--- a/components/vf-design-tokens/dist/sass/maps/vf-zindex.map.scss
+++ b/components/vf-design-tokens/dist/sass/maps/vf-zindex.map.scss
@@ -5,8 +5,10 @@
 
 $vf-zindex-map: (
   'vf-z-index--negative': (-1),
+  'vf-z-index--pseudo-element-fix': (1),
   'vf-z-index--form-input': (1),
   'vf-z-index--form-label': (1),
-  'vf-z-index--banner': (5150),
+  'vf-z-index--banner': (1984),
+  'vf-z-index--hero': (1984),
   'vf-z-index--masthead': (5150),
 );

--- a/components/vf-design-tokens/src/maps/vf-zindex.yml
+++ b/components/vf-design-tokens/src/maps/vf-zindex.yml
@@ -7,11 +7,11 @@ props:
     value: 1
   - name: vf-z-index--form-label
     value: 1
-  - name: vf-z-index--banner
-    value: 1984
   - name: vf-z-index--hero
     value: 1984
   - name: vf-z-index--masthead
+    value: 1984
+  - name: vf-z-index--banner
     value: 5150
 global:
   type: number

--- a/components/vf-design-tokens/src/maps/vf-zindex.yml
+++ b/components/vf-design-tokens/src/maps/vf-zindex.yml
@@ -1,12 +1,16 @@
 props:
   - name: vf-z-index--negative
     value: -1
+  - name: vf-z-index--pseudo-element-fix
+    value: 1
   - name: vf-z-index--form-input
     value: 1
   - name: vf-z-index--form-label
     value: 1
   - name: vf-z-index--banner
-    value: 5150
+    value: 1984
+  - name: vf-z-index--hero
+    value: 1984
   - name: vf-z-index--masthead
     value: 5150
 global:

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -114,7 +114,7 @@
 
   padding: calc( (0 + var(--vf-hero__padding) ) * .1em );
 
-  z-index: 5150;
+  z-index: set-layer(vf-z-index--hero);
 }
 
 

--- a/components/vf-navigation/vf-navigation--additional.scss
+++ b/components/vf-navigation/vf-navigation--additional.scss
@@ -30,13 +30,13 @@
   .vf-navigation__heading {
     color: set-ui-color(vf-ui-color--white);
     padding-top: 6px; // magic number
-    z-index: 1;
+    z-index: set-layer(vf-z-index--pseudo-element-fix);
   }
 
   .vf-navigation__list {
     margin-left: auto;
     padding-top: 5px; // magic number
-    z-index: 1;
+    z-index: set-layer(vf-z-index--pseudo-element-fix);
   }
 
   .vf-navigation__item:not(:first-child) {

--- a/components/vf-navigation/vf-navigation--main.scss
+++ b/components/vf-navigation/vf-navigation--main.scss
@@ -194,7 +194,7 @@ html.vf-global-layout--normal {
     height: 260px;
     position: absolute;
     width: 100%;
-    z-index: -1;
+    z-index: set-layer(vf-z-index--negative);
   }
 }
 
@@ -208,6 +208,6 @@ html.vf-global-layout--hard {
     height: 480px;
     position: absolute;
     width: 100%;
-    z-index: -1;
+    z-index: set-layer(vf-z-index--negative);
   }
 }

--- a/components/vf-u-fullbleed/vf-u-fullbleed.scss
+++ b/components/vf-u-fullbleed/vf-u-fullbleed.scss
@@ -39,7 +39,7 @@
     position: absolute;
     top: 0; /* 7 */
     width: 100vw; /* 8 */
-    z-index: -1; /* 9 */
+    z-index: set-layer(vf-z-index--negative); /* 9 */
   }
 
   @at-root #{$vf-u-fullbleed-parent} {


### PR DESCRIPTION
This should close #883.

And also close https://github.com/visual-framework/vf-wp/issues/236

We had a `z-index: 5150;` on bother the banner and the hero.

This now pushes the hero down a little to `z-index: 1984`. 

This PR also updates the design tokens to include these z-index key/value pairs. 

This PR also updates all instances of `z-index` being used to use the Sass map.