### PR TITLE
the one that finally removes calc from vf-grid fallback

### DIFF
--- a/components/vf-grid/CHANGELOG.md
+++ b/components/vf-grid/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change Log
 
-## 1.0.4 (2020-05-01)
+## 1.0.5 (2020-05-01)
 
 * fixes a remaing bug with IE11 where we relied on the calc function
   * https://github.com/visual-framework/vf-core/pull/900
 
-## 1.0.3 (2020-04-22)
+## 1.0.4 (2020-04-22)
 
 * fixes a bug with IE11 where we relied on the calc function inside the flex (which IE11 does not support) in the flexbox fallback grid defined columned classes (.vf-grid__col-2 > * {...) etc).
   * https://github.com/visual-framework/vf-core/pull/882

--- a/components/vf-grid/CHANGELOG.md
+++ b/components/vf-grid/CHANGELOG.md
@@ -1,20 +1,23 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+## 1.0.4 (2020-05-01)
 
-# 1.0.3 (2020-04-22)
+* fixes a remaing bug with IE11 where we relied on the calc function
+  * https://github.com/visual-framework/vf-core/pull/900
+
+## 1.0.3 (2020-04-22)
 
 * fixes a bug with IE11 where we relied on the calc function inside the flex (which IE11 does not support) in the flexbox fallback grid defined columned classes (.vf-grid__col-2 > * {...) etc).
+  * https://github.com/visual-framework/vf-core/pull/882
 
-# 1.0.2 (2020-03-20)
+## 1.0.2 (2020-03-20)
 
 * fixes issue with vf-grid inside vf-body https://github.com/visual-framework/vf-core/pull/802
 
-# 1.0.1 (2020-01-24)
+## 1.0.1 (2020-01-24)
 
 * Removes over-agressive border on 1 column layouts
 
-# 1.0.0 (2019-12-17)
+## 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-grid/vf-grid.scss
+++ b/components/vf-grid/vf-grid.scss
@@ -49,7 +49,7 @@
     flex-wrap: wrap;
   }
   .vf-grid > *{
-    flex: 0 0 calc(50% - 20px);
+    flex: 0 0 49.18305%;
   }
 }
 @supports (display: grid) {


### PR DESCRIPTION
Although we fixed the flex sizes for grid columns in #882 I missed the 'heavy handed' decision to make all grid items 50% on smaller viewports. 

This should fix that as it is not using calc anymore