### PR TITLE
the one where we had a spelling mistake

### DIFF
--- a/components/vf-masthead/CHANGELOG.md
+++ b/components/vf-masthead/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.2
+
+* replaces foreround with foreground 
+
 ## 1.0.1
 
 * Lerna Release bump

--- a/components/vf-masthead/vf-masthead.js
+++ b/components/vf-masthead/vf-masthead.js
@@ -52,9 +52,9 @@ function vfMastheadSetStyle() {
         cBrightness = getCorrectTextColor(bannerBGC);
 
         if (cBrightness > threshold){
-          el.style.setProperty('--vf-masthead__color--foreround-default', "#000000");
+          el.style.setProperty('--vf-masthead__color--foreground-default', "#000000");
         } else if (cBrightness < threshold) {
-          el.style.setProperty('--vf-masthead__color--foreround-default', "#FFFFFF");
+          el.style.setProperty('--vf-masthead__color--foreground-default', "#FFFFFF");
         }
       }
       else {

--- a/components/vf-masthead/vf-masthead.scss
+++ b/components/vf-masthead/vf-masthead.scss
@@ -13,7 +13,7 @@
   background-color: set-ui-color(vf-ui-color--black);
   background-color: var(--vf-masthead__color--background-default, var(--global-theme-bg-color, set-ui-color(vf-ui-color--black)));
   color: set-ui-color(vf-ui-color--white);
-  color: var(--vf-masthead__color--foreround-default, var(--global-theme-fg-color, set-ui-color(vf-ui-color--white)));
+  color: var(--vf-masthead__color--foreground-default, var(--global-theme-fg-color, set-ui-color(vf-ui-color--white)));
   padding-bottom: 36px;
   padding-top: 24px;
 }
@@ -22,17 +22,17 @@
 
 .vf-masthead-theme--primary {
   --vf-masthead__color--background-default: #{set-color(vf-color--blue)};
-  --vf-masthead__color--foreround-default: #{set-ui-color(vf-ui-color--white)};
+  --vf-masthead__color--foreground-default: #{set-ui-color(vf-ui-color--white)};
 }
 
 .vf-masthead-theme--secondary {
   --vf-masthead__color--background-default: #{set-color(vf-color--green)};
-  --vf-masthead__color--foreround-default: #{set-ui-color(vf-ui-color--white)};
+  --vf-masthead__color--foreground-default: #{set-ui-color(vf-ui-color--white)};
 }
 
 .vf-masthead-theme--tertiary {
   --vf-masthead__color--background-default: #{set-color(vf-color--grey--dark)};
-  --vf-masthead__color--foreround-default: #{set-ui-color(vf-ui-color--white)};
+  --vf-masthead__color--foreground-default: #{set-ui-color(vf-ui-color--white)};
 }
 
 .vf-masthead--has-image {
@@ -100,7 +100,7 @@
   .vf-masthead__title {
     align-self: flex-end;
     background-color: var(--vf-masthead__color--background-default, var(--global-theme-bg-color, set-ui-color(vf-ui-color--white)));
-    color: var(--vf-masthead__color--foreround-default, var(--global-theme-fg-color, set-ui-color(vf-ui-color--black)));
+    color: var(--vf-masthead__color--foreground-default, var(--global-theme-fg-color, set-ui-color(vf-ui-color--black)));
     display: inline-flex;
     padding-right: 16px;
     padding-top: 16px;


### PR DESCRIPTION
This will close #911

When updating the masthead CSS custom properties I managed to write `foreround` instead of `foreground`.

This PR fixes that.

Luckily as the CSS custom properties are used with the additional theming classes and the JS to determine if the text should be white or black depending on the background image - this won't break any thing as the user would be defining the classnames - not overriding the CSS themselves.

