### PR TITLE
the one that makes a tiny change to vf-banner

### DIFF
--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.2.0
+
+* Makes the alert style banner the default .njk
+* puts the style of alert banner as a prop from yaml/nunjucks
+* removes hardcoded variants of alert banners
+* fixes hover colour of `vf-banner__button`.
+
 ## 1.1.0
 
 * Adds option to determine button theme using data attributes.

--- a/components/vf-banner/vf-banner--alerts.scss
+++ b/components/vf-banner/vf-banner--alerts.scss
@@ -48,4 +48,8 @@
   &:focus {
     outline: 1px solid currentColor;
   }
+
+  &:hover {
+    color: inherit;
+  }
 }

--- a/components/vf-banner/vf-banner--danger.njk
+++ b/components/vf-banner/vf-banner--danger.njk
@@ -1,9 +1,0 @@
-<div class="vf-banner vf-banner--alert vf-banner--danger">
-  <div class="vf-banner__content">
-    <p class="vf-banner__text">{{alert_message}}</p>
-    <button class="vf-button vf-button--icon vf-button--dismiss | vf-banner__button">
-      <span aria-hidden="true" class="vf-sr-only">{{alert_icon_text}}</span>
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>dismiss banner</title><path d="M14.3,12.179a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.442L12.177,9.7a.25.25,0,0,1-.354,0L2.561.442A1.5,1.5,0,0,0,.439,2.563L9.7,11.825a.25.25,0,0,1,0,.354L.439,21.442a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,0,0,2.122-2.121Z"/></svg>
-    </button>
-  </div>
-</div>

--- a/components/vf-banner/vf-banner--info.njk
+++ b/components/vf-banner/vf-banner--info.njk
@@ -1,8 +1,0 @@
-<div class="vf-banner vf-banner--alert vf-banner--info">
-  <div class="vf-banner__content">
-    <p class="vf-banner__text">{{alert_message}}</p>
-    <button class="vf-button vf-button--icon vf-button--dismiss | vf-banner__button">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>dismiss banner</title><path d="M14.3,12.179a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.442L12.177,9.7a.25.25,0,0,1-.354,0L2.561.442A1.5,1.5,0,0,0,.439,2.563L9.7,11.825a.25.25,0,0,1,0,.354L.439,21.442a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,0,0,2.122-2.121Z"/></svg>
-    </button>
-  </div>
-</div>

--- a/components/vf-banner/vf-banner--success.njk
+++ b/components/vf-banner/vf-banner--success.njk
@@ -1,8 +1,0 @@
-<div class="vf-banner vf-banner--alert vf-banner--success">
-  <div class="vf-banner__content">
-    <p class="vf-banner__text">{{alert_message}}</p>
-    <button class="vf-button vf-button--icon vf-button--dismiss | vf-banner__button">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>dismiss banner</title><path d="M14.3,12.179a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.442L12.177,9.7a.25.25,0,0,1-.354,0L2.561.442A1.5,1.5,0,0,0,.439,2.563L9.7,11.825a.25.25,0,0,1,0,.354L.439,21.442a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,0,0,2.122-2.121Z"/></svg>
-    </button>
-  </div>
-</div>

--- a/components/vf-banner/vf-banner--warning.njk
+++ b/components/vf-banner/vf-banner--warning.njk
@@ -1,8 +1,0 @@
-<div class="vf-banner vf-banner--alert vf-banner--warning">
-  <div class="vf-banner__content">
-    <p class="vf-banner__text">{{alert_message}}</p>
-    <button class="vf-button vf-button--icon vf-button--dismiss | vf-banner__button">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>dismiss banner</title><path d="M14.3,12.179a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.442L12.177,9.7a.25.25,0,0,1-.354,0L2.561.442A1.5,1.5,0,0,0,.439,2.563L9.7,11.825a.25.25,0,0,1,0,.354L.439,21.442a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,0,0,2.122-2.121Z"/></svg>
-    </button>
-  </div>
-</div>

--- a/components/vf-banner/vf-banner.config.yml
+++ b/components/vf-banner/vf-banner.config.yml
@@ -11,19 +11,29 @@ context:
   vf-banner--inline_href: 'JavaScript:Void(0);'
   alert_icon_text: dismiss
 variants:
-  - name: default
-    hidden: true
+
   - name: info
     context:
-      alert_message: Here is some very, <em>very</em> <a class="vf-banner__link" href="JavaScript:Void(0);">important information</a>
+      banner__info: true
+      banner__dismissable: true
+      banner__message: Here is some very, <em>very</em> <a class="vf-banner__link" href="JavaScript:Void(0);">important information</a>
   - name: warning
     context:
-      alert_message: Easy now, easy does it.
+      banner__warning: true
+      banner__dismissable: true
+      banner__message: Easy now, easy does it.
   - name: danger
     context:
-      alert_message: Oh dear, what have you done?
+      banner__danger: true
+      banner__dismissable: true
+      banner__message: Oh dear, what have you done?
   - name: success
     context:
-      alert_message: Congratulations! You have made something <a class="vf-banner__link" href="JavaScript:Void(0);">awesome</a>!
+      banner__success: true
+      banner__dismissable: true
+      banner__message: Congratulations! You have made something <a class="vf-banner__link" href="JavaScript:Void(0);">awesome</a>!
+
+  - name: default
+    hidden: true
   - name: inline
     hidden: true

--- a/components/vf-banner/vf-banner.njk
+++ b/components/vf-banner/vf-banner.njk
@@ -1,1 +1,19 @@
-Intentionally blank.
+<div class="vf-banner
+  {%- if banner__info == true %} vf-banner--alert vf-banner--info{% endif -%}
+  {%- if banner__warning == true %} vf-banner--alert vf-banner--warning{% endif -%}
+  {%- if banner__danger == true %} vf-banner--alert vf-banner--danger{% endif -%}
+  {%- if banner__success == true %} vf-banner--alert vf-banner--success{% endif -%}">
+
+  <div class="vf-banner__content">
+
+    <p class="vf-banner__text">{{banner__message}}</p>
+
+    {% if banner__dismissable == true %}
+    <button class="vf-button vf-button--icon vf-button--dismiss | vf-banner__button">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>dismiss banner</title><path d="M14.3,12.179a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.442L12.177,9.7a.25.25,0,0,1-.354,0L2.561.442A1.5,1.5,0,0,0,.439,2.563L9.7,11.825a.25.25,0,0,1,0,.354L.439,21.442a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,0,0,2.122-2.121Z"/></svg>
+    </button>
+    {% endif %}
+
+  </div>
+
+</div>


### PR DESCRIPTION
This will close #920 

- makes the default `.njk` file take on the various `vf-banner--alert` variants that are available so `vf-wp` can make use of it more easily as a block.
- removes now unrequited hard-coded variants
- fixes a little hover bug on the dismiss icon in `vf-banner__button`

We have only a slight breaking change for the `vf-banner--alert` variants where we've changed the nunjucks variable from `alert_message` to `banner__message` to match semantics.

This has not been changed where used in other banners.

This update might need testing with what contentHub does with text