### PR TITLE
Enhancement: on ebi pages vf-divider shouldn't be capped at 80rem

### DIFF
--- a/components/ebi-vf1-integration/CHANGELOG.md
+++ b/components/ebi-vf1-integration/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+## 1.0.1
 
-# 1.0.0 (2019-12-17)
+* vf-divider needs to be able go full width
+
+## 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/ebi-vf1-integration/ebi-vf1-integration.scss
+++ b/components/ebi-vf1-integration/ebi-vf1-integration.scss
@@ -66,22 +66,22 @@ body.ebi-vf1-integration,
     font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   }
 
-  // Drop the dotted underlines in favour of VF 2.0 underlines 
+  // Drop the dotted underlines in favour of VF 2.0 underlines
   a {
     border: unset;
     text-decoration: underline;
   }
-  
+
   a:hover {
     text-decoration: unset;
     border-bottom-style: unset;
-  }  
-  
+  }
+
   // EBI Global header and local masthead
   #local-title a,
-  .masthead-black-bar .global-nav a, 
+  .masthead-black-bar .global-nav a,
   .masthead ul li a,
-  ul.menu.secondary-menu a, 
+  ul.menu.secondary-menu a,
   .secondary-menu ul.menu a {
     text-decoration: none;
 
@@ -91,7 +91,7 @@ body.ebi-vf1-integration,
   }
 
   // vf 1.x utility class
-  .no-underline a, 
+  .no-underline a,
   a.no-underline {
      text-decoration: none;
      border-bottom: none;
@@ -130,7 +130,7 @@ body.ebi-vf1-integration,
     max-width: 76.5em;
   }
 
-  // Fixes an issue with heigh and bacgkround colour for EBI 1.x 
+  // Fixes an issue with heigh and bacgkround colour for EBI 1.x
   .vf-form__input:not([type=file]) {
     height: unset;
     background: unset;
@@ -139,6 +139,11 @@ body.ebi-vf1-integration,
   .vf-form__input:not([type=file]):focus, .vf-form__input:not([type=file]):hover {
     border-width: unset;
     box-shadow: unset;
+  }
+
+  // vf-divider needs to be able go full width
+  hr.vf-divider {
+    max-width: unset;
   }
 
 }


### PR DESCRIPTION
The default for ebi vf 1.x is to cap `hr` at 80rem, this conflicts with vf-divider's normal behaviour.

Example of the wrong behaviour:

https://wwwdev.ebi.ac.uk/about/teams/web-development/
![image](https://user-images.githubusercontent.com/928100/82289232-9f07db80-99a4-11ea-9f42-97ab039841ea.png)
