### PR TITLE
the one that removes padding and reduces margin from breadcrumbs

### DIFF
--- a/components/vf-breadcrumbs/CHANGELOG.md
+++ b/components/vf-breadcrumbs/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.1
+
+* removes left and right padding so we rely on the parent for horizontal spacing for better alignment
+
 # 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-breadcrumbs/vf-breadcrumbs.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.scss
@@ -18,7 +18,6 @@
   margin-right: auto;
   margin-top: $vf-breadcrumbs__margin--top;
   max-width: 76.5em;
-  padding: 0 1rem;
   width: 100%;
 
   @media (min-width: $vf-breakpoint--lg) {

--- a/components/vf-breadcrumbs/vf-breadcrumbs.variables.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.variables.scss
@@ -6,5 +6,5 @@ $vf-breadcrumbs__item-related-text--color: set-color(vf-color--grey);
 $vf-breadcrumbs__item-related-link--color: set-color(vf-color--blue);
 $vf-breadcrumbs__item-related-link--color--hover: set-color(vf-color--grey);
 
-$vf-breadcrumbs__margin--bottom: 16px;
-$vf-breadcrumbs__margin--top: 16px;
+$vf-breadcrumbs__margin--bottom: 8px;
+$vf-breadcrumbs__margin--top: 8px;


### PR DESCRIPTION
as we are using padding on the parent we do not need it here … this should also enforce good structure and use of classnames on parent elements for it to look correct


"the parent dictates the spacing of the child, or lack thereof"

This will close #933