### PR TITLE
the one that removes horizontal padding from the global-header

### DIFF
--- a/components/vf-breadcrumbs/CHANGELOG.md
+++ b/components/vf-breadcrumbs/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 1.0.1
-
-* removes left and right padding so we rely on the parent for horizontal spacing for better alignment
-
 # 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-breadcrumbs/CHANGELOG.md
+++ b/components/vf-breadcrumbs/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.1
+
+* removes left and right padding so we rely on the parent for horizontal spacing for better alignment
+
 # 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.1
+
+* removes left and right padding so we rely on the parent for horizontal spacing for better alignment
+
 ## 1.0.0
 
 * makes global header work on smaller screens

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -20,7 +20,7 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
   height: auto;
   margin: 0 auto;
   max-width: 78.5em;
-  padding: .5rem;
+  padding: .5rem 0;
   width: 100%;
 
   .vf-logo,
@@ -30,10 +30,6 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
   }
   .vf-navigation--global .vf-navigation__item:not(:first-child) {
     margin-left: 8px;
-  }
-
-  @media (min-width: $vf-breakpoint--lg) {
-    padding: .5em 1em;
   }
 }
 


### PR DESCRIPTION
as we are using padding on the parent we do not need it here … this should also enforce good structure and use of classnames on parent elements for it to look correct

"the parent dictates the spacing of the child, or lack thereof"

This will close #934