### PR TITLE
the one that centres content with less code

### DIFF
--- a/components/vf-grid-page/CHANGELOG.md
+++ b/components/vf-grid-page/CHANGELOG.md
@@ -3,9 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 1.0.1
+# 2.0.0
 
 * removes the CSS grid that generated a central column for content, now it's working across all browsers with less code.
+* this makes vf-u-grid-reset redundant.
+* you might need to add vf-u-fullbleed to certain containers
 
 # 1.0.0 (2019-12-17)
 

--- a/components/vf-grid-page/CHANGELOG.md
+++ b/components/vf-grid-page/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.1
+
+* removes the CSS grid that generated a central column for content, now it's working across all browsers with less code.
+
 # 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-grid-page/vf-grid-page.scss
+++ b/components/vf-grid-page/vf-grid-page.scss
@@ -22,33 +22,13 @@
  *
  */
 
-// Initial set up for browsers that do not support CSS grid layout
 html {
-  margin: 0 1.25em;
+  margin: 0;
 }
 
 .vf-body {
   display: block;
   margin: 0 auto;
   max-width: 76.5em;
-}
-
-// If the browser does support grid it will get this
-@supports (display: grid) {
-  // first we need to unset some rulesets
-  html {
-    margin: unset;
-  }
-
-  .vf-body {
-    display: grid;
-    grid-template-columns: minmax(var(--page-grid-gap), auto) [main-start] minmax(288px, 76.5em) [main-end] minmax(var(--page-grid-gap), auto);
-    margin: 0;
-    max-width: unset;
-  }
-
-  // for the moment - we cannot rely on vf-body being applied to the body element so:
-  body {
-    margin: 0;
-  }
+  padding: 0 1em;
 }


### PR DESCRIPTION
originally we used CSS grid to create a centred column with left and right grid items. But this is more cumbersome than centering with `margin: 0 auto;` especially now we have `vf-u-fullbleed` for things.

This closes #930 