### PR TITLE
the one that adds a border to a vf-footer with vf-u-fullbleed

### DIFF
--- a/components/vf-footer/vf-footer.scss
+++ b/components/vf-footer/vf-footer.scss
@@ -17,6 +17,30 @@
   grid-column: 1 / -1;
   padding-bottom: 60px;
   padding-top: 24px;
+  position: relative;
+
+  &::before {
+    background-color: inherit;
+    content: '';
+    grid-column: 1 / -1;
+    height: 100%;
+    margin-left: calc(50% - 50vw);
+    position: absolute;
+    top: 0;
+    width: 100vw;
+    z-index: set-layer(vf-z-index--negative);
+  }
+
+  &::after {
+    background-color: set-color(vf-color--green);
+    content: '';
+    height: 8px;
+    margin-left: calc(50% - 50vw);
+    position: absolute;
+    top: -8px;
+    width: 100vw;
+    z-index: 5150;
+  }
 
   .vf-links {
     margin-bottom: 0;
@@ -100,7 +124,7 @@
 
     color: set-color(vf-color--grey--lightest);
     text-transform: uppercase;
-  
+
     .vf-heading__link {
       @include inline-link(
         $vf-link--color: $vf-footer-link--color,
@@ -110,7 +134,7 @@
     }
   }
 
-  
+
 
   .vf-links {
     padding-bottom: 0;

--- a/components/vf-u-fullbleed/CHANGELOG.md
+++ b/components/vf-u-fullbleed/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.0
+
+* adds specific use case CSS for vf-footer
+
 ## 1.0.0-alpha.2 (2020-03-20)
 
 * adds a variable for defining where the parent CSS is placed https://github.com/visual-framework/vf-core/pull/800

--- a/components/vf-u-fullbleed/vf-u-fullbleed.scss
+++ b/components/vf-u-fullbleed/vf-u-fullbleed.scss
@@ -46,3 +46,16 @@
     position: relative; /* 10 */
   }
 }
+
+.vf-footer.vf-u-fullbleed {
+  &::after {
+    background-color: set-color(vf-color--green);
+    content: '';
+    height: 8px;
+    margin-left: calc(50% - 50vw);
+    position: absolute;
+    top: -8px;
+    width: 100vw;
+    z-index: 5150;
+  }
+}

--- a/components/vf-u-fullbleed/vf-u-fullbleed.scss
+++ b/components/vf-u-fullbleed/vf-u-fullbleed.scss
@@ -46,16 +46,3 @@
     position: relative; /* 10 */
   }
 }
-
-.vf-footer.vf-u-fullbleed {
-  &::after {
-    background-color: set-color(vf-color--green);
-    content: '';
-    height: 8px;
-    margin-left: calc(50% - 50vw);
-    position: absolute;
-    top: -8px;
-    width: 100vw;
-    z-index: 5150;
-  }
-}


### PR DESCRIPTION
As we have removed the CSS grid from vf-body we need to have the `vf-footer` component make use of `vf-u-fullbleed`.

This is fine and should be an easy addition for teams to update but we also need to accommodate for the `vf-footer` border. This CSS does that.

This will close #931 
