### PR TITLE
the one that makes headings in vf-content stick to the correct font-weight

### DIFF
--- a/components/vf-content/CHANGELOG.md
+++ b/components/vf-content/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.5
+
+* fixes an issue when content creators add the bold/strong tags to hedaing to make them bolder - when they shouldn't be.
+
 ## 1.1.4
 
 * fixes support for vf-figure alignment options

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -21,6 +21,10 @@
       margin-bottom: 35px;
       margin-top: 22px;
     }
+
+    b, strong {
+      font-weight: inherit;
+    }
   }
 
   h2:not([class*='vf-']) {
@@ -28,30 +32,50 @@
 
     margin-top: 0;
     padding-top: 13px;
+
+    b, strong {
+      font-weight: inherit;
+    }
   }
 
   h3:not([class*='vf-']) {
     @include set-type(text-heading--3, $custom-margin-bottom: 13px);
 
     margin-top: 24px;
+
+    b, strong {
+      font-weight: inherit;
+    }
   }
 
   h4:not([class*='vf-']) {
     @include set-type(text-heading--4, $custom-margin-bottom: 13px);
 
     margin-top: 24px;
+
+    b, strong {
+      font-weight: inherit;
+    }
   }
 
   h5:not([class*='vf-']) {
     @include set-type(text-heading--5, $custom-margin-bottom: 13px);
 
     margin-top: 24px;
+
+    b, strong {
+      font-weight: inherit;
+    }
   }
 
   h6:not([class*='vf-']) {
     @include set-type(text-heading--5, $custom-margin-bottom: 13px);
 
     margin-top: 24px;
+
+    b, strong {
+      font-weight: inherit;
+    }
   }
 
   p:not([class*='vf-']) {
@@ -113,7 +137,7 @@
       margin-bottom: 0;
     }
   }
-  
+
   table:not([class*='vf-']) {
     background-color: set-ui-color(vf-ui-color--white);
     border-collapse: collapse;

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -22,7 +22,8 @@
       margin-top: 22px;
     }
 
-    b, strong {
+    b,
+    strong {
       font-weight: inherit;
     }
   }
@@ -33,7 +34,8 @@
     margin-top: 0;
     padding-top: 13px;
 
-    b, strong {
+    b,
+    strong {
       font-weight: inherit;
     }
   }
@@ -43,7 +45,8 @@
 
     margin-top: 24px;
 
-    b, strong {
+    b,
+    strong {
       font-weight: inherit;
     }
   }
@@ -53,7 +56,8 @@
 
     margin-top: 24px;
 
-    b, strong {
+    b,
+    strong {
       font-weight: inherit;
     }
   }
@@ -63,7 +67,8 @@
 
     margin-top: 24px;
 
-    b, strong {
+    b,
+    strong {
       font-weight: inherit;
     }
   }
@@ -73,7 +78,8 @@
 
     margin-top: 24px;
 
-    b, strong {
+    b,
+    strong {
       font-weight: inherit;
     }
   }


### PR DESCRIPTION
I took a look at this - https://www.embl.org/news/lab-matters/welcome-georgia-rapti/ - today and thought the headings looked a little 'off' in the content.

Inspecting I noticed that the headings had a wrapper of b, or strong around the text making them not have the correct font-weight.

This fixes that