### PR TITLE
vf_hero_link should be vf_hero_href

### DIFF
--- a/components/vf-hero/vf-hero.config.yml
+++ b/components/vf-hero/vf-hero.config.yml
@@ -13,7 +13,7 @@ preview: '@preview--nogrid'
 context:
   component-type: container
   modifier_class: vf-hero--easy
-  vf_hero_link: https://example.com/
+  vf_hero_href: https://example.com/
   vf_hero_subheading: an example of some ancillary text
   vf_hero_text:
     - The Hentze group combines biochemical and systems–level approaches to investigate the connections between gene expression and cell metabolism, and their roles in human disease.

--- a/components/vf-hero/vf-hero.config.yml
+++ b/components/vf-hero/vf-hero.config.yml
@@ -13,13 +13,13 @@ preview: '@preview--nogrid'
 context:
   component-type: container
   modifier_class: vf-hero--easy
-  vf_hero_href: https://example.com/
+  vf_hero_href: 'JavaScript:Void(0);'
   vf_hero_subheading: an example of some ancillary text
   vf_hero_text:
     - The Hentze group combines biochemical and systems–level approaches to investigate the connections between gene expression and cell metabolism, and their roles in human disease.
   vf_hero_link_text: Learn more.
   vf_hero_heading: About the Hentze group!
-  vf_hero_image: url('../../assets/vf-hero/assets/vf-intro-group.png');
+  vf_hero_image: url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/vf-hero-intense.png');
 variants:
   - name: default
     hidden: true


### PR DESCRIPTION
Looks like an artefact of changes.

Also, might be good to drop vf-intro-group.png and use https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/vf-hero-intense.png

As the image doesn't show in the component library (https://visual-framework.github.io/vf-core/components/detail/vf-hero--tertiary.html). I think this might be due to the local vs github.io paths — and I don't think we _need_ to include this PNG asset as a default?