### PR TITLE
the one that brings the vf-footer styling back a z-index layer

### DIFF
--- a/components/vf-footer/vf-footer.scss
+++ b/components/vf-footer/vf-footer.scss
@@ -39,7 +39,7 @@
     position: absolute;
     top: -8px;
     width: 100vw;
-    z-index: 5150;
+    z-index: set-layer(vf-z-index--negative);
   }
 
   .vf-links {


### PR DESCRIPTION
the border green had the same value z-index as the GDPR banner.

This PR makes the `:after` use the same z-index as `:before` and stops the border from spilling over the top of other content.

This will close #950 