### PR TITLE
the one that makes the background image width the same as the content

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.2
+
+* fixes an issue with vf-hero--inlay and the background image width
+
 # 1.4.0
 
 * Adds ability to specify height of the image.

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -30,7 +30,8 @@
   margin-bottom: 2rem;
   position: relative;
 
-  &:not(.vf-hero--very-easy):not(.vf-hero--intense) {
+  // TODO: look to improve the CSS for excluding .vf-hero--inlay sizes
+  &:not(.vf-hero--very-easy):not(.vf-hero--intense):not(.vf-hero--inlay) {
     &::before {
       background-image: var(--vf-hero-bg-image);
       content: '';
@@ -113,9 +114,21 @@
   --vf-hero-text-color: 1;
 }
 
+
+// TODO: look to improve the CSS for excluding .vf-hero--inlay sizes
 .vf-hero--inlay {
   max-width: 76.5em;
   margin: 0 auto;
+  &::before {
+    background-image: var(--vf-hero-bg-image);
+    content: '';
+    grid-column: 1 / -1;
+    grid-row: 1 / span 1;
+    background-position: top center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    height: var(--vf-hero-grid__row--initial, 320px);
+  }
 }
 
 .vf-hero__content {


### PR DESCRIPTION
We have an issue using `::before` in that it ignores the `vf-hero--inlay` variant and still displays the background image at full with.

This fixes that (for the short term). The CSS can probably be improved to reduce the amount of `:not` statements.