### PR TITLE
update tab layout in fractal theme

### DIFF
--- a/components/vf-card-container/vf-card-container.config.yml
+++ b/components/vf-card-container/vf-card-container.config.yml
@@ -21,22 +21,20 @@ context:
     - To promote molecular biology across Europe
     - To create a centre of excellence for Europe's leading young molecular biologists
   vf_cards:
-    - card_type: easy
-      card_title: One card
+    - card_title: One card
       card_href: "JavaScript:Void(0);"
-      modifier: vf-card--easy
+      variant: easy
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
-    - card_type: normal
-      card_title: A card here
+    - card_title: A card here
       card_href: "JavaScript:Void(0);"
-      modifier: vf-card--normal
+      variant: normal
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
-    - card_type: normal
-      card_title: Another card
+    - card_title: Another card
       card_href: "JavaScript:Void(0);"
-      modifier: vf-card--normal vf-card-theme--primary
+      variant: normal
+      theme: primary
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   # custom-values: passed as {{custom-values}}

--- a/components/vf-card-container/vf-card-container.njk
+++ b/components/vf-card-container/vf-card-container.njk
@@ -1,11 +1,50 @@
-<section class="vf-card-container{% if modifier %} | {{modifier}}{% endif %}">
-  <div class="vf-card-container__inner">
-    {% include '@vf-section-header' %}
+<style>
+  .vf-container-theme--primary {
+    --vf-container-theme--foreground: var(--vf-ui-color--white);
+    --vf-container-theme--background: var(--vf-color--green);
+    --vf-container-theme-color--border: var(--vf-color--green);
+  }
+  .vf-container--easy .vf-card {
+    border-bottom: 8px solid black;
+    border-bottom-color:
+      var(--vf-container-theme-color--border, var(--vf-card-theme-color--border, black));
+  }
 
+  .vf-container--easy * .vf-card__title {
+    --card-text-color: blue;
+  }
+  .vf-container--easy * .vf-card__text {
+    --card-text-color: black;
+  }
+  [class*='ary'].vf-container--easy .vf-card * {
+    background-color: white !important;
+  }
+</style>
+
+<section class="vf-card-container
+  {% if context %}{% set theme = context.theme %}{% endif %}
+  {%- if theme %} vf-container-theme--{{theme}}{% endif -%}
+
+  {% if context %}{% set variant = context.variant %}{% endif %}
+  {%- if variant %} vf-container--{{variant}}{% endif %}
+
+  {% if context %}{% set modifier = context.modifier %}{% endif %}
+  {% if modifier %} | {{modifier}}{% endif -%}
+">
+
+  <div class="vf-card-container__inner">
+
+    {% if context %}{% set section_title = context.section_title %}{% endif %}
+    {% render '@vf-section-header', { section_title: section_title } %}
+
+    {% if context %}{% set vf_cards = context.vf_cards %}{% endif %}
     {% asyncEach card in vf_cards %}
-       {# prefix cardtype #}
-       {% set card_type = '@vf-card--'+card.card_type %}
-       {% render card_type, { 'context': card } %}
+      {% render '@vf-card', { context: card } %}
     {% endeach %}
   </div>
 </section>
+
+{% if context %}{% set divider = context.divider %}{% endif %}
+{% if divider == true %}
+<hr class="vf-divider" style="margin-bottom: 48px;"></hr>
+{% endif %}

--- a/tools/vf-frctl-theme/views/partials/pen/preview.njk
+++ b/tools/vf-frctl-theme/views/partials/pen/preview.njk
@@ -9,21 +9,23 @@
     {% endif %}
     {% if variants.size > 1 and entity.preview != '@preview--blocks' and entity.preview != '@preview--elements' %}
         <div class="vf-tabs">
+          <p class="vf-text vf-text-body--4 vf-u-margin__bottom--sm vf-u-padding__left--lg">This component has variants:</p>
           <ul class="vf-tabs__list">
-            <li class="vf-tabs__item">
-              This component has variants:
-            </li>
             {% for variant in variants.items() %}
 
               {% if entity.handle == variant.handle %}
-                <a class="vf-tabs__link is-active" href="#is-active">
-                  {{ variant.label }}
-                </a>
+                <li class="vf-tabs__item">
+                  <a class="vf-tabs__link is-active" href="#is-active">
+                    {{ variant.label }}
+                  </a>
+                </li>
               {% else %}
                 {% if variant.isHidden == false %}
+                <li class="vf-tabs__item">
                   <a class="vf-tabs__link" href="{{ path(frctl.theme.urlFromRoute('component', { handle: variant.handle })) }}">
                     {{ variant.label }}
                   </a>
+                </li>
                 {% endif %} {# end variant.isHidden #}
               {% endif %} {# end entity.handle == variant.handle #}
 


### PR DESCRIPTION
I've changed the markup for the tabs in the fractal theme so that the "This component has variants:" text is now on it's own line.

This should save a bit of space for 'all the tabs'
![Screenshot 2020-06-17 at 11 04 36](https://user-images.githubusercontent.com/925197/84885049-64b85980-b08a-11ea-9d96-ca19bd0ccfe7.png)


