### PR TITLE
Bug: breakpoint map missing from vf-variables.scss

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+## 1.0.3
 
-# 1.0.1 (2020-01-24)
+* Breakpoint map was missing from vf-variables.scss
+
+## 1.0.1 (2020-01-24)
 
 * Tweaks link mixin, adds `@mixin inline-link--dark-mode`
 
-# 1.0.0 (2019-12-17)
+## 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-sass-config/variables/vf-variables.scss
+++ b/components/vf-sass-config/variables/vf-variables.scss
@@ -2,6 +2,7 @@
 
 @import 'vf-border-radius.variables.scss';
 @import 'vf-breakpoints.variables.scss';
+@import 'vf-breakpoints.map.scss';
 @import 'vf-colors.map.scss';
 @import 'vf-ui-colors.map.scss';
 @import 'vf-font--monospace.scss';


### PR DESCRIPTION
This meant the breakpoint map was unavailable in some situations.

![image](https://user-images.githubusercontent.com/928100/84892935-bc60c000-b09e-11ea-9456-3caf675b5a26.png)
