### PR TITLE
Refactor/vf logo

### DIFF
--- a/components/embl-logo/CHANGELOG.md
+++ b/components/embl-logo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.3
+
+* this removes the 'resize' for homepages as on devices sub 1024px the logo was a different size to every other page
+
 ## 1.0.2
 
 * bug: logo did not show correctly inside flex-based containers like vf-global-header

--- a/components/embl-logo/embl-logo.scss
+++ b/components/embl-logo/embl-logo.scss
@@ -21,11 +21,11 @@
 }
 
 .embl-logo--extreme {
-  height: 11vw;
-  max-height: 96px;
-  min-height: 32px;
+  height: 32px;
+  transition: height 400ms ease-in;
 
-  @media (min-width: 768px) {
+  @media (min-width: $vf-breakpoint--lg + 1) {
     background-image: url('../assets/embl-logo/assets/logo.svg');
+    height: 96px;
   }
 }

--- a/components/vf-logo/CHANGELOG.md
+++ b/components/vf-logo/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.1.0
+
+* adds if statement for if there is text or not so no HTML is printed if not
+* adds class if logo text is provided
+* changes what is making space between logo and text to it being the text item.
+
 # 1.0.1 (2020-01-24)
 
 * Tweaks height, adds larger "extreme" variant

--- a/components/vf-logo/vf-logo.njk
+++ b/components/vf-logo/vf-logo.njk
@@ -1,8 +1,9 @@
 <a href="{{logo_href}}"
-{# You're using an ID? Really?? That'll go here #}
 {% if id %} id="{{-id-}}"{% endif %}
-class="vf-logo {%- if override_class %} | {{override_class}}{% endif -%}">
+class="vf-logo{%- if logo_text %} | vf-logo--has-text{% endif -%}
+{%- if override_class %} | {{override_class}}{% endif -%}">
   <img class="vf-logo__image" src="{{ image }}" alt="{{ logo_text }}">
+  {% if logo_text %}
   <span class="vf-logo__text{% if hidden_text %} vf-u-sr-only{% endif %}">{{logo_text}}</span>
+  {% endif %}
 </a>
-{% if deprecated_text %}<!-- {{ deprecated_text }} -->{% endif %}

--- a/components/vf-logo/vf-logo.scss
+++ b/components/vf-logo/vf-logo.scss
@@ -18,19 +18,7 @@
 }
 
 .vf-logo__image {
-  --vf-logo-margin-right: #{map-get($vf-spacing-map, vf-spacing--sm)};
-
   height: 32px;
-  margin-right: 16px; // IE11 Fallback
-  margin-right: var(--vf-logo-margin-right);
-
-  @media (min-width: 500px) {
-    --vf-logo-margin-right: #{map-get($vf-spacing-map, vf-spacing--md)};
-  }
-
-  @media (min-width: 999px) {
-    --vf-logo-margin-right: #{map-get($vf-spacing-map, vf-spacing--md)};
-  }
 }
 
 .vf-logo--extreme {
@@ -42,6 +30,20 @@
 }
 
 .vf-logo__text {
+  --vf-logo-margin-right: #{map-get($vf-spacing-map, vf-spacing--sm)};
+
   @include set-type(text-body--3, $custom-margin-bottom: 0);
   align-self: center;
+
+  .vf-logo--has-text & {
+    margin-left: 16px; // IE11 Fallback
+    margin-left: var(--vf-logo-margin-right);
+    @media (min-width: 500px) {
+      --vf-logo-margin-right: #{map-get($vf-spacing-map, vf-spacing--md)};
+    }
+
+    @media (min-width: 999px) {
+      --vf-logo-margin-right: #{map-get($vf-spacing-map, vf-spacing--md)};
+    }
+  }
 }


### PR DESCRIPTION
this PR does a couple of things

**Firstly**:

The `embl-logo` for the homepage on embl.org resized depending on the viewport width - this is pretty neat - but on mobile the logo is bigger than sub pages so it look really odd. 

This PR stops the resize until 1025px (iPad + 1px) so only desktop viewers see it.

I've added a little transition so browser resizes can sort of see an effect.

This doesn't break anything so it's a patch change.

**Secondly**:

The `vf-logo` would print out a `<span>` if there was text or not and also the spacing between the logo and the text was on the logo so if there was no text there was still space. This update fixes that.

I don't think this is a breaking change _really_ so I've put this as a minor change.