### PR TITLE
The one that makes the GDRP banner work in IE 11 better

### DIFF
--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.2.1
+
+* Adds !default to all Sass variables for easier overrideing
+* gives the banner a better look in IE11
+
 ## 1.2.0
 
 * Makes the alert style banner the default .njk

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -48,7 +48,7 @@
   max-width: 78.5em;
   padding: 0 1rem;
 
-  @supports(display: grid) {
+  @supports (display: grid) {
     box-sizing: unset;
     margin: unset;
     max-width: unset;

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -84,7 +84,6 @@
 
 .vf-banner--notice {
   background-color: $vf-notice-banner-color--background;
-  background-color: var(--vf-banner--notice-bg, #{$vf-notice-banner-color--background});
   border-top: 1px solid $vf-notice-banner-color--border;
 
   .vf-banner__text,

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -43,17 +43,32 @@
   align-content: center;
   align-items: center;
 
+  box-sizing: border-box;
+  margin: 0 auto;
+  max-width: 78.5em;
+  padding: 0 1rem;
+
+  @supports(display: grid) {
+    box-sizing: unset;
+    margin: unset;
+    max-width: unset;
+    padding: unset;
+  }
+
   @media (max-width: 63.9375em) {
     display: block; // overrideing the .emlb-grid code
   }
 
   @media (min-width: $vf-breakpoint--lg) {
     grid-column: main;
+
   }
 }
 
 .vf-banner__text {
   @include set-type(text-body--3, $custom-margin-bottom: 0);
+
+  flex-grow: 4;
 }
 .vf-banner__text--lg {
   @include set-type(text-body--2, $custom-margin-bottom: 0);
@@ -69,6 +84,7 @@
 
 .vf-banner--notice {
   background-color: $vf-notice-banner-color--background;
+  background-color: var(--vf-banner--notice-bg, #{$vf-notice-banner-color--background});
   border-top: 1px solid $vf-notice-banner-color--border;
 
   .vf-banner__text,

--- a/components/vf-banner/vf-banner.variables.scss
+++ b/components/vf-banner/vf-banner.variables.scss
@@ -1,14 +1,14 @@
-$vf-gdpr-banner-color--background: set-color(vf-color--grey);
-$vf-gdpr-banner-color--text: set-ui-color(vf-ui-color--white);
-$vf-gdpr-banner-padding: map-get($vf-spacing-map, vf-spacing--md);
+$vf-gdpr-banner-color--background: set-color(vf-color--grey) !default;
+$vf-gdpr-banner-color--text: set-ui-color(vf-ui-color--white) !default;
+$vf-gdpr-banner-padding: map-get($vf-spacing-map, vf-spacing--md) !default;
 
-$vf-notice-banner-color--background: set-color(vf-color--grey);
-$vf-notice-banner-color--border: set-color(vf-color--grey--darkest);
+$vf-notice-banner-color--background: set-color(vf-color--grey) !default;
+$vf-notice-banner-color--border: set-color(vf-color--grey--darkest) !default;
 
-$vf-notice-banner-color--text: set-ui-color(vf-ui-color--white);
-$vf-notice-banner-padding: map-get($vf-spacing-map, vf-spacing--md);
+$vf-notice-banner-color--text: set-ui-color(vf-ui-color--white) !default;
+$vf-notice-banner-padding: map-get($vf-spacing-map, vf-spacing--md) !default;
 
-$vf-phase-banner-color--background: set-ui-color(vf-ui-color--yellow);
-$vf-phase-banner-color--text: set-color(vf-color--grey--dark);
+$vf-phase-banner-color--background: set-ui-color(vf-ui-color--yellow) !default;
+$vf-phase-banner-color--text: set-color(vf-color--grey--dark) !default;
 
 $vf-banner-color--link: inherit;


### PR DESCRIPTION
This PR defaults to a little bit of flexbox when using IE11. As well as setting the max-width of the content so it's not 'silly'.

We also add `!default` to all of the Sass variables used in `vf-banner` so they can be easily overriden. This means it is easier for teams to use they own colours if needed for `vf-banner`.

Teams using this that want to change the colour could also update `$vf-notice-banner-color--background` after the `vf-core` variables are called but before the `vf-banner` component is called in the roll-up file.


This will close #901 
