### PR TITLE
The one that makes figures without a class 'fit' better in vf-content

### DIFF
--- a/components/vf-content/CHANGELOG.md
+++ b/components/vf-content/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.6
+
+* Adds CSS to remove margin from a figure inside vf-content that has no `vf-figure` class.
+
 ## 1.1.5
 
 * fixes an issue when content creators add the bold/strong tags to hedaing to make them bolder - when they shouldn't be.

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -200,7 +200,7 @@
   }
 
   // WordPress is adding a figure around tables and we get default margins
-  figure:not([class*="vf-"]) {
+  figure:not([class*='vf-']) {
     margin: 0;
   }
 

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -199,6 +199,11 @@
     margin-bottom: 32px;
   }
 
+  // WordPress is adding a figure around tables and we get default margins
+  figure:not([class*="vf-"]) {
+    margin: 0;
+  }
+
   .vf-figure--align-inline-start {
     margin-bottom: 32px;
     margin-right: 32px;


### PR DESCRIPTION
This will close #959 

on [this page](https://wwwdev.embl.org/groups/chemical-biology/) there is a `figure` element with no `vf-` class that wraps a table element. This CSS removes the margin added by the browsers user stylesheet so that the content fits the page better.
