### PR TITLE
the one that removes word-spacing from the author-name

### DIFF
--- a/components/vf-article-meta-information/CHANGELOG.md
+++ b/components/vf-article-meta-information/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.1
+
+* removes word-spacing: 100vw so names wrap
+
 ## 1.0.0-beta.3
 
 * Capitalisation of `On this page`

--- a/components/vf-article-meta-information/vf-article-meta-information.scss
+++ b/components/vf-article-meta-information/vf-article-meta-information.scss
@@ -33,7 +33,6 @@
     align-self: center;
     line-height: 1.3;
     margin: 0 0 0 8px;
-    word-spacing: 100vw; // so first name and surname split
   }
 
   .vf-author__title {


### PR DESCRIPTION
This will close #961 

From the original designs there was a design need to have the authors first name and surname on separate lines. This broke if the author had more than one word in their surname.

Removing `word-spacing: 100vw` fixes this. Now the author names just 'wrap' like CSS intended. 