### PR TITLE
the one that removes wrapper from global-header in fractal theme

### DIFF
--- a/tools/vf-frctl-theme/views/partials/header.njk
+++ b/tools/vf-frctl-theme/views/partials/header.njk
@@ -1,28 +1,23 @@
 <header class="vf-header">
   <div class="vf-global-header">
+    {% if frctl.env.server %}
+    {% render '@vf-logo', {logo_href: path('/', request), logo_text: frctl.get('project.title'), image: path('../../assets/vf-logo/assets/logo.svg',request) } %}
+    {% else %}
+    {% render '@vf-logo', {logo_href: path('/', request), logo_text: frctl.get('project.title'), image: 'https://dev.assets.emblstatic.net/vf/develop/assets/vf-logo/assets/logo.svg' } %}
+    {% endif %}
 
-    <div class="vf-global-header__inner">
-      {% if frctl.env.server %}
-      {% render '@vf-logo', {logo_href: path('/', request), logo_text: frctl.get('project.title'), image: path('../../assets/vf-logo/assets/logo.svg',request) } %}
-      {% else %}
-      {% render '@vf-logo', {logo_href: path('/', request), logo_text: frctl.get('project.title'), image: 'https://dev.assets.emblstatic.net/vf/develop/assets/vf-logo/assets/logo.svg' } %}
-      {% endif %}
-
-      <nav class="vf-navigation vf-navigation--global">
-        <ul class="vf-navigation__list | vf-list--inline">
-          <li class="vf-navigation__item">
-            <a href="https://visual-framework.github.io/vf-welcome/" class="vf-navigation__link">About the Visual Framework</a>
-          </li>
-          <li class="vf-navigation__item">
-            <a href="https://visual-framework.github.io/vf-welcome/developing" class="vf-navigation__link">Documentation</a>
-          </li>
-          <li class="vf-navigation__item">
-            <a href="https://join.slack.com/t/visual-framework/shared_invite/enQtNDAxNzY0NDg4NTY0LWFhMjEwNGY3ZTk3NWYxNWVjOWQ1ZWE4YjViZmY1YjBkMDQxMTNlNjQ0N2ZiMTQ1ZTZiMGM4NjU5Y2E0MjM3ZGQ" class="vf-navigation__link">Help, chat</a>
-          </li>
-        </ul>
-      </nav>
-
-    </div>
-
+    <nav class="vf-navigation vf-navigation--global">
+      <ul class="vf-navigation__list | vf-list--inline">
+        <li class="vf-navigation__item">
+          <a href="https://visual-framework.github.io/vf-welcome/" class="vf-navigation__link">About the Visual Framework</a>
+        </li>
+        <li class="vf-navigation__item">
+          <a href="https://visual-framework.github.io/vf-welcome/developing" class="vf-navigation__link">Documentation</a>
+        </li>
+        <li class="vf-navigation__item">
+          <a href="https://join.slack.com/t/visual-framework/shared_invite/enQtNDAxNzY0NDg4NTY0LWFhMjEwNGY3ZTk3NWYxNWVjOWQ1ZWE4YjViZmY1YjBkMDQxMTNlNjQ0N2ZiMTQ1ZTZiMGM4NjU5Y2E0MjM3ZGQ" class="vf-navigation__link">Help, chat</a>
+        </li>
+      </ul>
+    </nav>    
   </div>
 </header>


### PR DESCRIPTION
with changes to `vf-global-header` markup in v1.0.2 there is no need for the inner wrapper. This PR removes it from the fractal theme.