### PR TITLE
the one that hides some files from the documentation for a component.

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -85,6 +85,7 @@ module.exports = {
     /* build destination */
     var vfBuilderPath = global.vfBuilderPath || __dirname + '/build';
     fractal.web.set('builder.dest', vfBuilderPath);
+    fractal.set('components.resources.assets.match',  ['**/*.njk', '**/*.config.yml', '**/*.scss', '**/*.js','**/*.css', '!**/*.precompiled.js', '!**/package.variables.scss', '!**/index.scss'])
 
     /* configure web */
     var vfStaticPath = global.vfStaticPath || __dirname + '/temp/build-files';
@@ -170,7 +171,7 @@ module.exports = {
         server.stop();
         fractal.unwatch(); // exit fractal
       });
-      
+
     }
   }
 }

--- a/fractal.js
+++ b/fractal.js
@@ -85,7 +85,7 @@ module.exports = {
     /* build destination */
     var vfBuilderPath = global.vfBuilderPath || __dirname + '/build';
     fractal.web.set('builder.dest', vfBuilderPath);
-    fractal.set('components.resources.assets.match',  ['**/*.njk', '**/*.config.yml', '**/*.scss', '**/*.js','**/*.css', '!**/*.precompiled.js', '!**/package.variables.scss', '!**/index.scss'])
+    fractal.set('components.resources.assets.match',  ['**/*.njk', '**/*.config.yml', '**/*.scss', '**/CHANGELOG.md', '**/*.js','**/*.css', '!**/*.precompiled.js', '!**/package.variables.scss', '!**/index.scss'])
 
     /* configure web */
     var vfStaticPath = global.vfStaticPath || __dirname + '/temp/build-files';


### PR DESCRIPTION
this tidies up the 'files in the folder shown' list to only be:

- `*.scss`
- `*.js`
- `*.config.yml` - because of the template for the fractal docs this isn't included in the tabs, but good to keep here
- `*.njk` - because of the template for the fractal docs this isn't included in the tabs, but good to keep here