### PR TITLE
the one that refactors vf-card so it works better in vf-11ty

### DIFF
--- a/components/vf-card-container/CHANGELOG.md
+++ b/components/vf-card-container/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.0.0-alpha.2 
+## 2.0.0
+
+* makes better use of using .yml for data rather than having to inline it in a `vf-card`
+* better default spacing
+
+## 1.0.0-alpha.2
 
 * Tweaks layout centring
 

--- a/components/vf-card-container/vf-card-container.config.yml
+++ b/components/vf-card-container/vf-card-container.config.yml
@@ -24,24 +24,19 @@ context:
     - card_type: easy
       card_title: One card
       card_href: "JavaScript:Void(0);"
-      modifier: vf-card--easy
+      variant: easy
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
     - card_type: normal
       card_title: A card here
       card_href: "JavaScript:Void(0);"
-      modifier: vf-card--normal
+      variant: normal
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
     - card_type: normal
       card_title: Another card
       card_href: "JavaScript:Void(0);"
-      modifier: vf-card--normal vf-card-theme--primary
+      theme: primary
+      variant: normal
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
-  # custom-values: passed as {{custom-values}}
-  # title: Title text
-  # text: String of text
-  # image: ../../assets/vf-component-name/assets/vf-component-name.png
-  # - note on paths: be sure to prefix with `../../`
-  # - Why? https://github.com/visual-framework/vf-core/issues/364

--- a/components/vf-card-container/vf-card-container.scss
+++ b/components/vf-card-container/vf-card-container.scss
@@ -21,7 +21,7 @@
 .vf-card-container {
   grid-column: 1 / -1;
   margin: 0 0 3rem 0;
-  padding: 0;
+  padding: 2rem 0;
 }
 
 .vf-card-container__inner {
@@ -29,7 +29,6 @@
   flex-wrap: wrap;
   justify-content: space-between;
   max-width: 76.5em;
-  padding: 2rem 0;
 
   @supports (display: grid) {
     --vf-card-container__grid--size: 18rem;

--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 2.0.0
+
+* gives title option to have a link that fills 'card'
+* makes links in text have a higher z-index than the whole card link
+* fundamental .yml and .njk changes
+
+
 ## 1.0.4 (2020-03-20)
 
 * Flattens Nunjucks template variables for more portability https://github.com/visual-framework/vf-core/pull/805

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -113,4 +113,4 @@ variants:
       variant: normal
       card_href: "https://www.alwaystwisted.com"
       card_image: ../../assets/vf-card/assets/vf-card-example.png
-      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_text: Lorem ipsum dolor sit amet, <a href="#">consectetur</a> adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -111,6 +111,6 @@ variants:
       card_title: A Normal Primary Card with Link
       theme: primary
       variant: normal
-      card_href: "JavaScript:Void(0);"
+      card_href: "https://www.alwaystwisted.com"
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -20,7 +20,6 @@ variants:
     hidden: false
     context:
       card_title: A Easy Card Title 1
-      card_href: "JavaScript:Void(0);"
       variant: very-easy
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
@@ -29,7 +28,6 @@ variants:
     hidden: false
     context:
       card_title: A Easy Card Title 2
-      card_href: "JavaScript:Void(0);"
       variant: easy
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
@@ -37,7 +35,6 @@ variants:
     label: Easy (primary)
     context:
       card_title: Easy Card with primary accent
-      card_href: "JavaScript:Void(0);"
       theme: primary
       variant: easy
       card_image: ../../assets/vf-card/assets/vf-card-example.png
@@ -70,15 +67,13 @@ variants:
     label: Normal
     context:
       card_title: A Normal Card
-      card_href: "JavaScript:Void(0);"
       variant: normal
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
-  - name: normal--primairy
+  - name: normal--primary
     label: Normal (primary)
     context:
-      card_title: A Normal Card with primairy accent
-      card_href: "JavaScript:Void(0);"
+      card_title: A Normal Card with primary accent
       theme: primary
       variant: normal
       card_image: ../../assets/vf-card/assets/vf-card-example.png
@@ -110,12 +105,12 @@ variants:
       card_title: A Normal Card with quaternary accent
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
-  # section_title: Missions
-  # href: www.test. com
-  # section__subheading: To promote molecular biology across Europe
-  # custom-values: passed as {{custom-values}}
-  # title: Title text
-  # text: String of text
-  # image: ../../assets/vf-component-name/assets/vf-component-name.png
-  # - note on paths: be sure to prefix with `../../`
-  # - Why? https://github.com/visual-framework/vf-core/issues/364
+  - name: normal--primary--with-link
+    label: Normal (primary) link
+    context:
+      card_title: A Normal Primary Card with Link
+      theme: primary
+      variant: normal
+      card_href: "JavaScript:Void(0);"
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -111,6 +111,6 @@ variants:
       card_title: A Normal Primary Card with Link
       theme: primary
       variant: normal
-      card_href: "https://www.alwaystwisted.com"
+      card_href: "JavaScript:Void(0);"
       card_image: ../../assets/vf-card/assets/vf-card-example.png
-      card_text: Lorem ipsum dolor sit amet, <a href="#">consectetur</a> adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_text: Lorem ipsum dolor sit amet, <a class="vf-card__link" href="JavaScript:Void(0);">consectetur</a> adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -19,104 +19,100 @@ variants:
     label: Very Easy
     hidden: false
     context:
-      card:
-        card_title: A Easy Card Title 1
-        card_href: "JavaScript:Void(0);"
-        modifier: vf-card--very-easy
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_title: A Easy Card Title 1
+      card_href: "JavaScript:Void(0);"
+      variant: very-easy
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: easy
     label: Easy
     hidden: false
     context:
-      card:
-        card_title: A Easy Card Title 1
-        card_href: "JavaScript:Void(0);"
-        modifier: vf-card--easy
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_title: A Easy Card Title 2
+      card_href: "JavaScript:Void(0);"
+      variant: easy
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: easy--primary
     label: Easy (primary)
     context:
-      card:
-        card_title: Easy Card with primary accent
-        card_href: "JavaScript:Void(0);"
-        modifier: vf-card--easy vf-card-theme--primary
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_title: Easy Card with primary accent
+      card_href: "JavaScript:Void(0);"
+      theme: primary
+      variant: easy
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: easy--secondary
     label: Easy (secondary)
     context:
-      card:
-        modifier: vf-card--easy vf-card-theme--secondary
-        card_title: A Easy Card with secondary accent
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      theme: secondary
+      variant: easy
+      card_title: A Easy Card with secondary accent
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: easy--tertiary
     label: Easy (tertiary)
     context:
-      card:
-        modifier: vf-card--easy vf-card-theme--tertiary
-        card_title: A Easy Card with tertiary accent
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      theme: tertiary
+      variant: easy
+      card_title: A Easy Card with tertiary accent
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: easy--quaternary
     label: Easy (quaternary)
     context:
-      card:
-        modifier: vf-card--easy vf-card-theme--quaternary
-        card_title: A Easy Card with quaternary accent
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      theme: quaternary
+      variant: easy
+      card_title: A Easy Card with quaternary accent
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal
     label: Normal
     context:
-      card:
-        card_title: A Normal Card
-        card_href: "JavaScript:Void(0);"
-        modifier: vf-card--normal
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_title: A Normal Card
+      card_href: "JavaScript:Void(0);"
+      variant: normal
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal--primairy
     label: Normal (primary)
     context:
-      card:
-        card_title: A Normal Card with primairy accent
-        card_href: "JavaScript:Void(0);"
-        modifier: vf-card--normal vf-card-theme--primary
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_title: A Normal Card with primairy accent
+      card_href: "JavaScript:Void(0);"
+      theme: primary
+      variant: normal
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal--secondary
     label: Normal (secondary)
     hidden: false
     context:
-      card:
-        modifier: vf-card--normal vf-card-theme--secondary
-        card_title: A Normal Card with secondary accent
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      theme: secondary
+      variant: normal
+      card_title: A Normal Card with secondary accent
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal--tertiary
     label: Normal (tertiary)
     hidden: false
     context:
-      card:
-        modifier: vf-card--normal vf-card-theme--tertiary
-        card_title: A Normal Card with tertiary accent
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      theme: tertiary
+      variant: normal
+      card_title: A Normal Card with tertiary accent
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: normal--quaternary
     label: Normal (quaternary)
     hidden: false
     context:
-      card:
-        modifier: vf-card--normal vf-card-theme--quaternary
-        card_title: A Normal Card with quaternary accent
-        card_image: ../../assets/vf-card/assets/vf-card-example.png
-        card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      theme: quaternary
+      variant: normal
+      card_title: A Normal Card with quaternary accent
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   # section_title: Missions
   # href: www.test. com
   # section__subheading: To promote molecular biology across Europe
-  # card:
   # custom-values: passed as {{custom-values}}
   # title: Title text
   # text: String of text

--- a/components/vf-card/vf-card.njk
+++ b/components/vf-card/vf-card.njk
@@ -15,13 +15,7 @@
   {% set override_class = context.override_class %}
 {% endif %}
 
-{% if card_href %}
-  {% set tags = 'a' %}
-{% else %}
-  {% set tags = 'div' %}
-{% endif %}
-
-<{{ tags }}
+<article
   {% if tags == 'a' %}href="{{ card_href if card_href else '#' }}"{%- endif -%}
   {%- if id %} id="{{-id-}}"{% endif %}
 
@@ -40,13 +34,20 @@
   {% endif %}
 
   <div class="vf-card__content">
-    <h3 class="vf-card__title">{{- card_title -}}</h3>
+
+    <h3 class="vf-card__title">
+    {%- if card_href %}<a class="vf-card__link" href="{{ card_href if card_href else '#' }}">{% endif -%}
+      {{ card_title }}
+    {%- if card_href %}</a>{% endif -%}
+    </h3>
+
     {% if card_subtitle %}
     <p class="vf-card__subtitle" role="doc-subtitle">{{- card_subtitle -}}</p>
     {% endif %}
+
     {% if card_text %}
     <p class="vf-card__text">{{- card_text -}}</p>
     {% endif %}
   </div>
 
-</{{tags}}>
+</article>

--- a/components/vf-card/vf-card.njk
+++ b/components/vf-card/vf-card.njk
@@ -20,7 +20,6 @@
   {%- if id %} id="{{-id-}}"{% endif %}
 
   class="vf-card
-  {%- if card_href %} vf-card--is-link{% endif %}
 
   {%- if theme %} vf-card-theme--{{theme}}{% endif -%}
   {%- if variant %} vf-card--{{variant}}{% endif %}

--- a/components/vf-card/vf-card.njk
+++ b/components/vf-card/vf-card.njk
@@ -1,16 +1,18 @@
-{# if we're being passed "context" from a parent template, use it as "card" #}
 {%- if context %}
-  {% set card = context %}
-{% endif %}
+  {% set card_href = context.card_href %}
 
-{%- if card %}
-  {% set card_href = card.card_href %}
-  {% set id = card.id %}
-  {% set modifier = card.modifier %}
-  {% set override_class = card.override_class %}
-  {% set card_image = card.card_image %}
-  {% set card_title = card.card_title %}
-  {% set card_text = card.card_text %}
+  {% set card_title = context.card_title %}
+  {% set card_subtitle = context.card_subtitle %}
+  {% set card_text = context.card_text %}
+  {% set card_image = context.card_image %}
+  {% set card_image__alt = context.card_image__alt %}
+
+  {% set theme = context.theme %}
+  {% set variant = context.variant %}
+
+  {% set id = context.id %}
+  {% set modifiers = context.modifiers %}
+  {% set override_class = context.override_class %}
 {% endif %}
 
 {% if card_href %}
@@ -19,32 +21,32 @@
   {% set tags = 'div' %}
 {% endif %}
 
-
-{# Decide upon which 'style' the badge has #}
-<{{tags}}
-{# If there's an href put it here #}
-{%- if tags == 'a' %}
- href="{{ card_href if card_href else '#' }}"
-{%- endif %}
-
-  {# You're using an ID? Really?? That'll go here #}
+<{{ tags }}
+  {% if tags == 'a' %}href="{{ card_href if card_href else '#' }}"{%- endif -%}
   {%- if id %} id="{{-id-}}"{% endif %}
 
-  {# Here is where we are adding any modifier #}
   class="vf-card
   {%- if card_href %} vf-card--is-link{% endif %}
-  {%- if modifier %} {{modifier}}{% endif -%}
 
-  {# You want a snowflake of a classname for something, here you go #}
+  {%- if theme %} vf-card-theme--{{theme}}{% endif -%}
+  {%- if variant %} vf-card--{{variant}}{% endif %}
+
+  {%- if modifier %} | {{modifier}}{% endif -%}
   {%- if override_class %} | {{override_class}}{% endif %}
 ">
-  <img src="{{ card_image }}" alt="" class="vf-card__image">
+
+  {% if card_image %}
+  <img src="{{ card_image }}" alt="{{ card_image__alt }}" class="vf-card__image">
+  {% endif %}
+
   <div class="vf-card__content">
-    <h3 class="vf-card__title">
-      {{ card_title }}
-    </h3>
-    <p class="vf-card__text">
-      {{ card_text }}
-    </p>
+    <h3 class="vf-card__title">{{- card_title -}}</h3>
+    {% if card_subtitle %}
+    <p class="vf-card__subtitle" role="doc-subtitle">{{- card_subtitle -}}</p>
+    {% endif %}
+    {% if card_text %}
+    <p class="vf-card__text">{{- card_text -}}</p>
+    {% endif %}
   </div>
+
 </{{tags}}>

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -18,16 +18,6 @@
   background-color: var(--card-background-color);
   display: grid;
   grid-template-rows: 216px 1fr;
-  transition-duration: 250ms;
-  transition-property: box-shadow;
-  transition-timing-function: ease-in-out;
-
-  &:hover {
-    box-shadow: 0 0 4px 4px rgba(0, 0, 0, .2);
-    transition-duration: 250ms;
-    transition-property: box-shadow;
-    transition-timing-function: ease-in-out;
-  }
 }
 
 .vf-card--is-link {
@@ -108,6 +98,33 @@
     margin-top: 2px; // because reasons
     padding: 16px 24px;
     text-transform: uppercase;
+
+    .vf-card__link {
+      color: currentColor;
+      text-decoration: none;
+
+      &::after {
+        bottom: 0;
+        content: '';
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+        transition-duration: 300ms;
+        transition-property: box-shadow;
+        transition-timing-function: ease-in-out;
+        z-index: 512;
+      }
+
+      &:hover {
+        color: currentColor;
+        text-decoration: none;
+        &::after {
+          box-shadow: 0 0 4px 4px rgba(0, 0, 0, .2);
+          transition-duration: 250ms;
+        }
+      }
+    }
   }
 
   .vf-card__text {

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -18,6 +18,7 @@
   background-color: var(--card-background-color);
   display: grid;
   grid-template-rows: 216px 1fr;
+  position: relative;
 }
 
 .vf-card--is-link {
@@ -46,6 +47,39 @@
   color: set-ui-color(vf-ui-color--black);
   color: var( --card-text-color, #{set-ui-color(vf-ui-color--black)} );
   text-decoration: none;
+
+  .vf-card__link {
+    color: inherit;
+    text-decoration: none;
+
+    &::after {
+      bottom: 0;
+      content: 'deee';
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      transition-duration: 300ms;
+      transition-property: box-shadow;
+      transition-timing-function: ease-in-out;
+      z-index: 512;
+    }
+
+    &:hover {
+      color: currentColor;
+      text-decoration: none;
+      &::after {
+        box-shadow: 0 0 4px 4px rgba(0, 0, 0, .2);
+        transition-duration: 250ms;
+      }
+    }
+  }
+
+  .vf-card__link:hover,
+  .vf-card__link:visited,
+  .vf-card__link:visited:hover {
+    color: currentColor;
+  }
 }
 
 .vf-card__text {
@@ -95,40 +129,18 @@
     display: inline-block;
     margin-bottom: 0;
     margin-left: -24px;
-    margin-top: 2px; // because reasons
+    margin-top: 2px;
     padding: 16px 24px;
     text-transform: uppercase;
-
-    .vf-card__link {
-      color: currentColor;
-      text-decoration: none;
-
-      &::after {
-        bottom: 0;
-        content: '';
-        left: 0;
-        position: absolute;
-        right: 0;
-        top: 0;
-        transition-duration: 300ms;
-        transition-property: box-shadow;
-        transition-timing-function: ease-in-out;
-        z-index: 512;
-      }
-
-      &:hover {
-        color: currentColor;
-        text-decoration: none;
-        &::after {
-          box-shadow: 0 0 4px 4px rgba(0, 0, 0, .2);
-          transition-duration: 250ms;
-        }
-      }
-    }
   }
 
   .vf-card__text {
     padding-top: 16px;
+
+    .vf-card__link {
+      position: relative;
+      z-index: 1984;
+    }
   }
 }
 

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -21,11 +21,6 @@
   position: relative;
 }
 
-.vf-card--is-link {
-  cursor: pointer;
-  text-decoration: none;
-}
-
 .vf-card__image {
   grid-column: 1 / -1;
   grid-row: 1 / span 3;
@@ -54,7 +49,7 @@
 
     &::after {
       bottom: 0;
-      content: 'deee';
+      content: '';
       left: 0;
       position: absolute;
       right: 0;
@@ -87,6 +82,12 @@
 
   color: set-ui-color(vf-ui-color--black);
   color: var( --card-text-color, #{set-ui-color(vf-ui-color--black)} );
+
+  a,
+  .vf-card__link {
+    position: relative;
+    z-index: 1984;
+  }
 }
 
 .vf-card__link {
@@ -148,6 +149,12 @@
 
 [class*='ary'].vf-card--easy {
   --vf-card-theme-color--background: #{set-ui-color(vf-ui-color--white)};
+}
+[class*='ary'] {
+  .vf-card__text .vf-card__link {
+    color: inherit;
+    text-decoration: underline;
+  }
 }
 
 .vf-card-theme--primary {


### PR DESCRIPTION
Lots of changes in this one as we shift to moving towards having 'content' and component decisions inside of a `.yml` file rather than inline in a `.njk` file.

- makes the link on the title, but also creates pseudo element so whole card is clickable
- only hover effect if card is link
- allows for inline `vf-card__link` inside of `vf-card__text` and make sure it's clickable over the card (using z-index)
- complete change in how the `.njk` variables are implemented

- gives `vf-card-container` and update for new `vf-card` component
- adds some default spacing to `vf-card-container

probably more things


this will close #910 