### PR TITLE
the one that brings relative paths back 

### DIFF
--- a/components/vf-componenet-rollup/CHANGELOG.md
+++ b/components/vf-componenet-rollup/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.0.8
+
+* replaces all imports for Sass variables, mixins and functions with vf-sass-config
+* moves utility classes mixins closer to where vf-utility classes are called
+
 ## 1.0.7
 
 * add `'vf-banner/vf-banner--alerts.scss';`

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -13,33 +13,7 @@
  * VF Core version in use: #{map-get($componentInfo, 'vfCoreVersion')}
  */
 
-@import 'vf-global-custom-properties.scss';
-
-@import 'vf-global-variables.scss';
-@import 'vf-border-radius.variables.scss';
-@import 'vf-breakpoints.variables.scss';
-@import 'vf-breakpoints.map.scss';
-@import 'vf-colors.map.scss';
-@import 'vf-ui-colors.map.scss';
-@import 'vf-font--monospace.scss';
-@import 'vf-font--sans.scss';
-@import 'vf-font-families.variables.scss';
-@import 'vf-links.variables.scss';
-@import 'vf-spacing.map.scss';
-@import 'vf-zindex.map.scss';
-
-@import 'vf-colors.custom-properties.scss';
-@import 'vf-ui-colors.custom-properties.scss';
-
-@import 'vf-functions.scss';
-@import 'vf-mixins.scss';
-
-
-@import 'vf-sass-utilities/vf-sass-utilities.scss';
-
-/* Visual Framework Utility Class Mixins */
-
-@import 'vf-utility-mixins.scss';
+@import 'vf-sass-config/index.scss';
 
 /* All Visual Framework Font components */
 @import 'vf-font-plex-mono/vf-font-plex-mono.scss';
@@ -177,8 +151,11 @@ html, button {
 
 @import 'vf-heading/vf-heading.scss';
 @import 'vf-text/vf-text.scss';
-@import 'vf-utility-classes/vf-utility-classes.scss';
 @import 'vf-u-fullbleed/vf-u-fullbleed.scss';
+
+/* Visual Framework Utility Class Mixins */
+@import 'vf-sass-config/mixins/vf-utility-mixins.scss';
+@import 'vf-utility-classes/vf-utility-classes.scss';
 
 // This is a demonstration of vf-core's ability to warn and proceed on missing
 // sass imports

--- a/components/vf-font-plex-mono/vf-font-plex-mono.scss
+++ b/components/vf-font-plex-mono/vf-font-plex-mono.scss
@@ -10,7 +10,7 @@
  */
 
 $vf-font-plex-mono-prefix: '../assets/vf-font-plex-mono/assets' !default;
-@import 'vf-font-plex-mono/assets/scss/ibm-plex.scss';
+@import 'assets/scss/ibm-plex.scss';
 
 .vf-font-plex-mono {
   @include set-type(text-body--1, $vf-font-family--monospace, $custom-margin-bottom: 0);

--- a/components/vf-font-plex-sans/vf-font-plex-sans.scss
+++ b/components/vf-font-plex-sans/vf-font-plex-sans.scss
@@ -10,7 +10,7 @@
  */
 
 $vf-font-plex-sans-prefix: '../assets/vf-font-plex-sans/assets' !default;
-@import 'vf-font-plex-sans/assets/scss/ibm-plex.scss';
+@import 'assets/scss/ibm-plex.scss';
 
 .vf-font-plex-sans {
   @include set-type(text-body--3, $vf-font-family--sans-serif, $custom-margin-bottom: 0);

--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.1.0
+
+* Adds the relative paths to @import for files rather for when the index.scss is used in other projects
+* Adds stylelint dis/enabled wrapper so it doesn't shout about design tokens
+* Adds @visual-framework/vf-design-tokens as a dependency
+
 ## 1.0.3
 
 * Breakpoint map was missing from vf-variables.scss

--- a/components/vf-sass-config/index.scss
+++ b/components/vf-sass-config/index.scss
@@ -1,4 +1,4 @@
-@import 'vf-global-variables';
-@import 'vf-variables';
-@import 'vf-functions';
-@import 'vf-mixins';
+@import 'variables/vf-global-variables.scss';
+@import 'variables/vf-variables.scss';
+@import 'functions/vf-functions.scss';
+@import 'mixins/vf-mixins.scss';

--- a/components/vf-sass-config/package.json
+++ b/components/vf-sass-config/package.json
@@ -17,5 +17,8 @@
     "fractal",
     "component"
   ],
-  "gitHead": "7bb3e8605bb5e604a55e7480e8e0d7620cee1b7f"
+  "gitHead": "7bb3e8605bb5e604a55e7480e8e0d7620cee1b7f",
+  "dependencies": {
+    "@visual-framework/vf-design-tokens": "~1.0.0"
+  }
 }

--- a/components/vf-sass-config/variables/vf-global-variables.scss
+++ b/components/vf-sass-config/variables/vf-global-variables.scss
@@ -2,7 +2,7 @@
 // deprecated component text, if normalisations should be included.
 
 // typography variables
-@import 'vf-font-families.variables.scss';
+@import 'vf-design-tokens/dist/sass/vf-font-families.variables.scss';
 $use-global-typography: true !default;
 $global-font-family: $vf-font-family--sans-serif !default;
 $vf-text-margin--bottom: 16px !default;

--- a/components/vf-sass-config/variables/vf-variables.scss
+++ b/components/vf-sass-config/variables/vf-variables.scss
@@ -1,18 +1,19 @@
 // Rollup of global Sass variables.
+/* stylelint-disable */
+@import 'vf-design-tokens/dist/sass/vf-border-radius.variables.scss';
+@import 'vf-design-tokens/dist/sass/vf-breakpoints.variables.scss';
+@import 'vf-design-tokens/dist/sass/maps/vf-breakpoints.map.scss';
+@import 'vf-design-tokens/dist/sass/maps/vf-colors.map.scss';
+@import 'vf-design-tokens/dist/sass/maps/vf-ui-colors.map.scss';
+@import 'vf-design-tokens/dist/sass/vf-font--monospace.scss';
+@import 'vf-design-tokens/dist/sass/vf-font--sans.scss';
+@import 'vf-design-tokens/dist/sass/vf-font-families.variables.scss';
+@import 'vf-design-tokens/dist/sass/vf-links.variables.scss';
+@import 'vf-design-tokens/dist/sass/maps/vf-spacing.map.scss';
+@import 'vf-design-tokens/dist/sass/maps/vf-zindex.map.scss';
 
-@import 'vf-border-radius.variables.scss';
-@import 'vf-breakpoints.variables.scss';
-@import 'vf-breakpoints.map.scss';
-@import 'vf-colors.map.scss';
-@import 'vf-ui-colors.map.scss';
-@import 'vf-font--monospace.scss';
-@import 'vf-font--sans.scss';
-@import 'vf-font-families.variables.scss';
-@import 'vf-links.variables.scss';
-@import 'vf-spacing.map.scss';
-@import 'vf-zindex.map.scss';
-
-@import 'vf-colors.custom-properties.scss';
-@import 'vf-ui-colors.custom-properties.scss';
+@import 'vf-design-tokens/dist/sass/custom-properties/vf-colors.custom-properties.scss';
+@import 'vf-design-tokens/dist/sass/custom-properties/vf-ui-colors.custom-properties.scss';
 
 @import 'vf-global-variables.scss';
+/* stylelint-enable */

--- a/components/vf-sass-utilities/CHANGELOG.md
+++ b/components/vf-sass-utilities/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.1
+
+* Removes .no-js from the screen-reader utility 
+
 # 1.0.0 (2019-12-17)
 
 * Initial stable release

--- a/components/vf-sass-utilities/_vf-screen-reader.scss
+++ b/components/vf-sass-utilities/_vf-screen-reader.scss
@@ -1,4 +1,4 @@
-html.vf-js:not(.vf-disable-deprecated) {
+html:not(.vf-disable-deprecated) {
   // Some things should only be show to screen readers
   .vf-sr-only {
     position: absolute;

--- a/tools/gulp-tasks/_gulp_rollup.js
+++ b/tools/gulp-tasks/_gulp_rollup.js
@@ -23,7 +23,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   require(path.resolve('.', __dirname + '/vf-watch.js'))(gulp, path, componentPath, reload);
   require(path.resolve('.', __dirname + '/vf-templates-precompile.js'))(gulp, path, componentPath);
   require(path.resolve('.', __dirname + '/vf-build.js'))(gulp, buildDestionation);
-  
+
   // -----------------------------------------------------------------------------
   // Main tasks
   // -----------------------------------------------------------------------------
@@ -33,7 +33,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   ));
 
   gulp.task('vf-prepush-test', gulp.parallel(
-    'vf-lint:scss-hard-fail', 'vf-css'
+    'vf-lint:scss-softs-fail', 'vf-css'
   ));
 
   return gulp;

--- a/tools/gulp-tasks/_gulp_rollup.js
+++ b/tools/gulp-tasks/_gulp_rollup.js
@@ -33,7 +33,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   ));
 
   gulp.task('vf-prepush-test', gulp.parallel(
-    'vf-lint:scss-soft-fail', 'vf-css'
+    'vf-lint:scss-hard-fail', 'vf-css'
   ));
 
   return gulp;

--- a/tools/gulp-tasks/_gulp_rollup.js
+++ b/tools/gulp-tasks/_gulp_rollup.js
@@ -33,7 +33,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   ));
 
   gulp.task('vf-prepush-test', gulp.parallel(
-    'vf-lint:scss-softs-fail', 'vf-css'
+    'vf-lint:scss-soft-fail', 'vf-css'
   ));
 
   return gulp;

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -220,7 +220,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
 
   // Sass Lint
   // For stylelint config rules see .stylelinrc
-  const vfScssLintPaths = [componentPath+'/**/embl-*.scss', componentPath+'/**/vf-*.scss', '!'+componentPath+'/**/index.scss', '!assets/**/*.scss', '!'+componentPath+'/vf-design-tokens/dist/**/*.scss', '!'+componentPath+'/vf-sass-config/**/*.scss'];
+  const vfScssLintPaths = [componentPath+'/**/embl-*.scss', componentPath+'/**/vf-*.scss', '!'+componentPath+'/**/index.scss', '!assets/**/*.scss', '!'+componentPath+'/vf-design-tokens/**/*.scss'];
   gulp.task('vf-lint:scss-soft-fail', function() {
     return gulp
       .src(vfScssLintPaths)

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -233,7 +233,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
     return gulp
       .src(vfScssLintPaths)
       .pipe(gulpStylelint({
-        failAfterError: true,
+        failAfterError: false,
         reporters: [{formatter: 'string', console: true}]
       }));
   });

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -220,7 +220,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
 
   // Sass Lint
   // For stylelint config rules see .stylelinrc
-  const vfScssLintPaths = [componentPath+'/**/embl-*.scss', componentPath+'/**/vf-*.scss', '!'+componentPath+'/**/index.scss', '!assets/**/*.scss', '!'+componentPath+'/vf-design-tokens/dist/**/*.scss'];
+  const vfScssLintPaths = ['!'+componentPath+'/vf-design-tokens/dist/**/*.scss', '!'+componentPath+'/vf-sass-config/**/*.scss', componentPath+'/**/embl-*.scss', componentPath+'/**/vf-*.scss', '!'+componentPath+'/**/index.scss', '!assets/**/*.scss'];
   gulp.task('vf-lint:scss-soft-fail', function() {
     return gulp
       .src(vfScssLintPaths)

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -220,8 +220,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
 
   // Sass Lint
   // For stylelint config rules see .stylelinrc
-  const vfScssLintPaths = [componentPath+'/**/embl-*.scss', componentPath+'/**/vf-*.scss', '!'+componentPath+'/**/index.scss', '!assets/**/*.scss', '!'+componentPath+'/vf-design-tokens/**/*.scss'];
-
+  const vfScssLintPaths = [componentPath+'/**/embl-*.scss', componentPath+'/**/vf-*.scss', '!'+componentPath+'/**/index.scss', '!assets/**/*.scss', '!'+componentPath+'/vf-design-tokens/dist/**/*.scss'];
   gulp.task('vf-lint:scss-soft-fail', function() {
     return gulp
       .src(vfScssLintPaths)
@@ -234,11 +233,10 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
     return gulp
       .src(vfScssLintPaths)
       .pipe(gulpStylelint({
-        failAfterError: false,
+        failAfterError: true,
         reporters: [{formatter: 'string', console: true}]
       }));
   });
-
 
 
   // -----------------------------------------------------------------------------

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -221,6 +221,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   // Sass Lint
   // For stylelint config rules see .stylelinrc
   const vfScssLintPaths = [componentPath+'/**/embl-*.scss', componentPath+'/**/vf-*.scss', '!'+componentPath+'/**/index.scss', '!assets/**/*.scss', '!'+componentPath+'/vf-design-tokens/**/*.scss'];
+
   gulp.task('vf-lint:scss-soft-fail', function() {
     return gulp
       .src(vfScssLintPaths)
@@ -237,6 +238,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
         reporters: [{formatter: 'string', console: true}]
       }));
   });
+
 
 
   // -----------------------------------------------------------------------------

--- a/tools/gulp-tasks/vf-css.js
+++ b/tools/gulp-tasks/vf-css.js
@@ -220,7 +220,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
 
   // Sass Lint
   // For stylelint config rules see .stylelinrc
-  const vfScssLintPaths = ['!'+componentPath+'/vf-design-tokens/dist/**/*.scss', '!'+componentPath+'/vf-sass-config/**/*.scss', componentPath+'/**/embl-*.scss', componentPath+'/**/vf-*.scss', '!'+componentPath+'/**/index.scss', '!assets/**/*.scss'];
+  const vfScssLintPaths = [componentPath+'/**/embl-*.scss', componentPath+'/**/vf-*.scss', '!'+componentPath+'/**/index.scss', '!assets/**/*.scss', '!'+componentPath+'/vf-design-tokens/dist/**/*.scss', '!'+componentPath+'/vf-sass-config/**/*.scss'];
   gulp.task('vf-lint:scss-soft-fail', function() {
     return gulp
       .src(vfScssLintPaths)


### PR DESCRIPTION
These updates will

- adds relative paths where appropriate
- allow us to site creators to import Sass modules without needing to rely on our gulp tasks
- doesn't break existing gulp task usage that uses include paths
- tidies up rollup. 