### PR TITLE
the one that tidies the `vf-banner` up a little bit

### DIFF
--- a/components/vf-banner/README.md
+++ b/components/vf-banner/README.md
@@ -6,10 +6,6 @@
 
 Informs visitors about important changes or persistent conditions. Use this component if you need to communicate to visitors in a prominent way. Banners are placed at the top of the page or section they apply to, and below the page or section header.
 
-### Exceptions
-
-The GDPR Banner, is the `--fixed` variant which needs to be 'sticky' to the bottom of the browser viewport
-
 ## Reflecting status
 
 - General notice `vf-banner vf-banner--notice`

--- a/components/vf-banner/README.md
+++ b/components/vf-banner/README.md
@@ -2,6 +2,14 @@
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-banner.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-banner)
 
+## Usage Guidelines
+
+Informs visitors about important changes or persistent conditions. Use this component if you need to communicate to visitors in a prominent way. Banners are placed at the top of the page or section they apply to, and below the page or section header.
+
+### Exceptions
+
+The GDPR Banner, is the `--fixed` variant which needs to be 'sticky' to the bottom of the browser viewport
+
 ## Reflecting status
 
 - General notice `vf-banner vf-banner--notice`
@@ -11,7 +19,11 @@
 - Alert `vf-banner vf-banner--alert vf-banner--alert`
 - Warning `vf-banner vf-banner--alert vf-banner--warning`
 
-<strong>note:</strong> The `vf-banner--alert` variants include the option to dismiss the banner. This is currently a 'bring your own JavaScript' button.
+<strong>note:</strong> The `vf-banner--alert` variants include the option to dismiss the banner. This is currently a 'bring your own JavaScript' button. To include a close button in the markup you need to make sure you have the variable `banner__dismissable` set to `true`:
+
+```
+banner__dismissable: true
+```
 
 ## JS Documentation for `--modal` variant
 

--- a/components/vf-banner/vf-banner--alerts.scss
+++ b/components/vf-banner/vf-banner--alerts.scss
@@ -1,7 +1,6 @@
 .vf-banner--alert {
   .vf-banner__content {
     display: flex;
-    align-items: center;
   }
   .vf-banner__text,
   [class*='vf-text'] {

--- a/components/vf-banner/vf-banner--alerts.scss
+++ b/components/vf-banner/vf-banner--alerts.scss
@@ -1,6 +1,7 @@
 .vf-banner--alert {
   .vf-banner__content {
     display: flex;
+    align-items: center;
   }
   .vf-banner__text,
   [class*='vf-text'] {
@@ -26,7 +27,7 @@
 
 .vf-banner--info {
   background-color: set-ui-color(vf-ui-color--yellow);
-  color: set-color(vf-color--grey--dark);
+  color: set-color(vf-color--grey--darkest);
 }
 
 
@@ -37,12 +38,13 @@
 
 
 .vf-banner__button {
+  display: inherit;
   margin-left: auto;
-  padding: 2px 6px 4px;
 
   svg {
     fill: currentColor;
-    height: 14px;
+    height: .75rem;
+    width: .75rem;
   }
 
   &:focus {

--- a/components/vf-banner/vf-banner.njk
+++ b/components/vf-banner/vf-banner.njk
@@ -9,7 +9,7 @@
     <p class="vf-banner__text">{{banner__message}}</p>
 
     {% if banner__dismissable == true %}
-    <button class="vf-button vf-button--icon vf-button--dismiss | vf-banner__button">
+    <button role="button" aria-label="close notification banner" class="vf-button vf-button--icon vf-button--dismiss | vf-banner__button">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>dismiss banner</title><path d="M14.3,12.179a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.442L12.177,9.7a.25.25,0,0,1-.354,0L2.561.442A1.5,1.5,0,0,0,.439,2.563L9.7,11.825a.25.25,0,0,1,0,.354L.439,21.442a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,0,0,2.122-2.121Z"/></svg>
     </button>
     {% endif %}

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -16,7 +16,12 @@
   padding: .75rem;
 
   .vf-badge {
-    margin-right: 16px;
+    margin-right: 1rem;
+  }
+
+  .vf-content ~ &,
+  .vf-inlay__content ~ & {
+    margin-bottom: 1rem;
   }
 }
 
@@ -90,8 +95,8 @@
   .vf-banner__text,
   .vf-text { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal
     color: $vf-notice-banner-color--text;
-    margin-bottom: 24px;
-    max-width: 64em;
+    margin-bottom: 1.5rem;
+    max-width: 64rem;
 
     & .vf-banner__link,
     & .vf-link {

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -13,7 +13,7 @@
 
 .vf-banner {
   box-sizing: border-box;
-  padding: 16px;
+  padding: .75rem;
 
   .vf-badge {
     margin-right: 16px;
@@ -69,6 +69,7 @@
   @include set-type(text-body--3, $custom-margin-bottom: 0);
 
   flex-grow: 4;
+  line-height: 1.2;
 }
 .vf-banner__text--lg {
   @include set-type(text-body--2, $custom-margin-bottom: 0);


### PR DESCRIPTION
This PR

- reduces the size of the alert banner by reducing padding
- makes the dismissible button accesible
- adds some more documentation
- makes the icon in the dismissible button a little smaller
- changes the `--grey-dark` to `--grey--darkest` so it has more contrast on the `--info` variant.