### PR TITLE
fixes for intense variation

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.4
+
+* fixes issue with `--intense` variant so parallax image is full width
+
 # 1.4.3
 
 * replaces margin shorthand so it doesn't remove bottom margin when using `--inlay` modifier

--- a/components/vf-hero/vf-hero.njk
+++ b/components/vf-hero/vf-hero.njk
@@ -25,7 +25,9 @@
   </div>
 
   {% if modifier_class === "vf-hero--intense" %}
-  <script defer="defer" src="../../assets/vf-hero/assets/jarallax.js"></script>
+  {# <script defer="defer" src="../assets/vf-hero/assets/jarallax.js"></script> #}
+  {# <script src="{{ '/assets/vf-hero/assets/jarallax.js' | path }}"></script> #}
+  <script src="../../assets/vf-hero/assets/jarallax.js"></script>
   <script>
     document.addEventListener("DOMContentLoaded", function(){
       jarallax(document.querySelectorAll('.vf-hero--intense'), {

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -262,8 +262,9 @@
   background-repeat: no-repeat;
   background-size: cover;
   grid-template-rows: auto;
-
+  margin-left: calc(50% - 50vw);
   padding: 80px 0 64px 0;
+  width: 100vw;
 
   .vf-hero__content {
     grid-row: 1;
@@ -312,6 +313,10 @@
         color: set-color(vf-color--blue) !important;
         transform: translate(2px, 4px);
       }
+    }
+
+    & ~ [id*='#jarallax-container'] > div {
+      left: calc(50% - 50vw);
     }
   }
 


### PR DESCRIPTION
With changes to `vf-hero` in `1.4.2`and `1.4.3` we had an issue where the `--intense` variant didn't work correctly.

This fixes that. 