### PR TITLE
the one that lets background images work with full bleed

### DIFF
--- a/components/vf-u-fullbleed/CHANGELOG.md
+++ b/components/vf-u-fullbleed/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.0
+
+* adds functionality that makes it possible to use background images in fullbleeds
+
 ## 1.0.0
 
 * adds specific use case CSS for vf-footer

--- a/components/vf-u-fullbleed/vf-u-fullbleed.scss
+++ b/components/vf-u-fullbleed/vf-u-fullbleed.scss
@@ -28,10 +28,18 @@
 .vf-u-fullbleed {
   $vf-u-fullbleed-parent: body !default; /* 1 */
 
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 0 0;
+
   position: relative; /* 2 */
 
   &::before {
     background-color: inherit; /* 3 */
+    background-image: inherit;
+    background-position: inherit;
+    background-repeat: inherit;
+    background-size: cover;
     content: '';
     grid-column: 1 / -1; /* 4 */
     height: 100%; /* 5 */


### PR DESCRIPTION
When looking through the repo for embl.org static pages I noticed that there's a use case for background images that need to be full bleed of the page.

This adds the relevant CSS to allow for that.