### PR TITLE
the one that gets the Sass starter working 'as expected'

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.2
+
+* changes filepaths so they're relative where needed
+
 ## 1.1.1
 
 * Adds missing global custom properties

--- a/components/vf-sass-config/variables/vf-global-variables.scss
+++ b/components/vf-sass-config/variables/vf-global-variables.scss
@@ -2,7 +2,7 @@
 // deprecated component text, if normalisations should be included.
 
 // typography variables
-@import 'vf-design-tokens/dist/sass/vf-font-families.variables.scss';
+@import '../../vf-design-tokens/dist/sass/vf-font-families.variables.scss';
 $use-global-typography: true !default;
 $global-font-family: $vf-font-family--sans-serif !default;
 $vf-text-margin--bottom: 16px !default;

--- a/components/vf-sass-config/variables/vf-variables.scss
+++ b/components/vf-sass-config/variables/vf-variables.scss
@@ -1,19 +1,19 @@
 // Rollup of global Sass variables.
 /* stylelint-disable */
-@import 'vf-design-tokens/dist/sass/vf-border-radius.variables.scss';
-@import 'vf-design-tokens/dist/sass/vf-breakpoints.variables.scss';
-@import 'vf-design-tokens/dist/sass/maps/vf-breakpoints.map.scss';
-@import 'vf-design-tokens/dist/sass/maps/vf-colors.map.scss';
-@import 'vf-design-tokens/dist/sass/maps/vf-ui-colors.map.scss';
-@import 'vf-design-tokens/dist/sass/vf-font--monospace.scss';
-@import 'vf-design-tokens/dist/sass/vf-font--sans.scss';
-@import 'vf-design-tokens/dist/sass/vf-font-families.variables.scss';
-@import 'vf-design-tokens/dist/sass/vf-links.variables.scss';
-@import 'vf-design-tokens/dist/sass/maps/vf-spacing.map.scss';
-@import 'vf-design-tokens/dist/sass/maps/vf-zindex.map.scss';
+@import '../../vf-design-tokens/dist/sass/vf-border-radius.variables.scss';
+@import '../../vf-design-tokens/dist/sass/vf-breakpoints.variables.scss';
+@import '../../vf-design-tokens/dist/sass/maps/vf-breakpoints.map.scss';
+@import '../../vf-design-tokens/dist/sass/maps/vf-colors.map.scss';
+@import '../../vf-design-tokens/dist/sass/maps/vf-ui-colors.map.scss';
+@import '../../vf-design-tokens/dist/sass/vf-font--monospace.scss';
+@import '../../vf-design-tokens/dist/sass/vf-font--sans.scss';
+@import '../../vf-design-tokens/dist/sass/vf-font-families.variables.scss';
+@import '../../vf-design-tokens/dist/sass/vf-links.variables.scss';
+@import '../../vf-design-tokens/dist/sass/maps/vf-spacing.map.scss';
+@import '../../vf-design-tokens/dist/sass/maps/vf-zindex.map.scss';
 
-@import 'vf-design-tokens/dist/sass/custom-properties/vf-colors.custom-properties.scss';
-@import 'vf-design-tokens/dist/sass/custom-properties/vf-ui-colors.custom-properties.scss';
+@import '../../vf-design-tokens/dist/sass/custom-properties/vf-colors.custom-properties.scss';
+@import '../../vf-design-tokens/dist/sass/custom-properties/vf-ui-colors.custom-properties.scss';
 
 @import 'vf-global-variables.scss';
 /* stylelint-enable */

--- a/components/vf-sass-starter/CHANGELOG.md
+++ b/components/vf-sass-starter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.1.0
+
+* updates package.json to dependencies rather than devDependencies
+* updates relative paths of index.scss to target installed packages in node_modules
+
 ## 0.0.3
 
 Initial version

--- a/components/vf-sass-starter/index.scss
+++ b/components/vf-sass-starter/index.scss
@@ -1,13 +1,13 @@
 // Import Sass Variables, Mixins, and Functions from @visual-framework/vf-sass-config
-@import 'vf-sass-config/index.scss';
+@import './node_modules/@visual-framework/vf-sass-config/index.scss';
 
 // Include all Utility Classes from @visual-framework/vf-utility-classes
-@import 'vf-sass-config/mixins/vf-utility-mixins.scss';
-@import 'vf-utility-classes/vf-utility-classes.scss';
+@import './node_modules/@visual-framework/vf-sass-config/mixins/vf-utility-mixins.scss';
+@import './node_modules/@visual-framework/vf-utility-classes/vf-utility-classes.scss';
 
 // Include all SCSS Utilities from @visual-framework/vf-sass-utilities
-@import 'vf-sass-utilities/vf-sass-utilities.scss';
+@import './node_modules/@visual-framework/vf-sass-utilities/vf-sass-utilities.scss';
 
 // Include the relevant IBM Plex typefaces
-@import 'vf-font-plex-mono/vf-font-plex-mono.scss';
-@import 'vf-font-plex-sans/vf-font-plex-sans.scss';
+@import './node_modules/@visual-framework/vf-font-plex-mono/vf-font-plex-mono.scss';
+@import './node_modules/@visual-framework/vf-font-plex-sans/vf-font-plex-sans.scss';

--- a/components/vf-sass-starter/index.scss
+++ b/components/vf-sass-starter/index.scss
@@ -1,13 +1,13 @@
 // Import Sass Variables, Mixins, and Functions from @visual-framework/vf-sass-config
-@import './node_modules/@visual-framework/vf-sass-config/index.scss';
+@import '../vf-sass-config/index.scss';
 
 // Include all Utility Classes from @visual-framework/vf-utility-classes
-@import './node_modules/@visual-framework/vf-sass-config/mixins/vf-utility-mixins.scss';
-@import './node_modules/@visual-framework/vf-utility-classes/vf-utility-classes.scss';
+@import '../vf-sass-config/mixins/vf-utility-mixins.scss';
+@import '../vf-utility-classes/vf-utility-classes.scss';
 
 // Include all SCSS Utilities from @visual-framework/vf-sass-utilities
-@import './node_modules/@visual-framework/vf-sass-utilities/vf-sass-utilities.scss';
+@import '../vf-sass-utilities/vf-sass-utilities.scss';
 
 // Include the relevant IBM Plex typefaces
-@import './node_modules/@visual-framework/vf-font-plex-mono/vf-font-plex-mono.scss';
-@import './node_modules/@visual-framework/vf-font-plex-sans/vf-font-plex-sans.scss';
+@import '../vf-font-plex-mono/vf-font-plex-mono.scss';
+@import '../vf-font-plex-sans/vf-font-plex-sans.scss';

--- a/components/vf-sass-starter/package.json
+++ b/components/vf-sass-starter/package.json
@@ -1,17 +1,17 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.5",
   "name": "@visual-framework/vf-sass-starter",
   "description": "vf-sass-starter component",
   "homepage": "https://visual-framework.github.io/vf-core",
   "author": "VF",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "style": "vf-sass-starter.css",
   "sass": "index.scss",
   "test": "echo \"Error: no test specified\" && exit 1",
   "publishConfig": {
     "access": "public"
   },
-  "repo": "https://github.com/visual-framework/vf-core/tree/develop/components/vf-sass-starter",
+  "repository": "https://github.com/visual-framework/vf-core/tree/develop/components/vf-sass-starter",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues"
   },
@@ -19,7 +19,7 @@
     "fractal",
     "component"
   ],
-  "Dependencies": {
+  "dependencies": {
     "@visual-framework/vf-design-tokens": "^1.0.0",
     "@visual-framework/vf-font-plex-mono": "^1.1.0",
     "@visual-framework/vf-font-plex-sans": "^1.1.0",

--- a/components/vf-sass-starter/package.json
+++ b/components/vf-sass-starter/package.json
@@ -19,7 +19,7 @@
     "fractal",
     "component"
   ],
-  "devDependencies": {
+  "Dependencies": {
     "@visual-framework/vf-design-tokens": "^1.0.0",
     "@visual-framework/vf-font-plex-mono": "^1.1.0",
     "@visual-framework/vf-font-plex-sans": "^1.1.0",


### PR DESCRIPTION
I missed a few things when publishing this package at first.

We now install sub packages as `dependencies` rather than `devDependencies`.

We also use relative paths for importing the other packages Sass–y CSS. 