### PR TITLE
the one that updates the version number in vf-global-header

### DIFF
--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.0.0
+
+* making a breaking change because of the HTML alterations
+
 ## 1.0.2
 
 * makes content wrap with `flex-wrap`


### PR DESCRIPTION
I missed that the `vf-global-header` has a breaking change that needs to be addressed when using the latest version

This just bumps it from `1.2.1` to `2.0.0`