### PR TITLE
The one that doesn't squish the default avatar.

### DIFF
--- a/components/vf-summary/CHANGELOG.md
+++ b/components/vf-summary/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.4
+
+* A fix for Chrome as it displays avatar defaults as a squished circle. Replaces 100% to auto within heigh rule.
+
 # 1.0.3
 
 * fixes the size of avatars to be consistnet.

--- a/components/vf-summary/vf-summary--profile.scss
+++ b/components/vf-summary/vf-summary--profile.scss
@@ -8,7 +8,7 @@
     align-self: start;
     grid-column: 1 / span 1;
     grid-row: 1 / span 6;
-    height: 100%;
+    height: auto;
     margin-right: 30px;
     max-height: var(--vf-icon--avatar-width);
     max-width: var(--vf-icon--avatar-width);


### PR DESCRIPTION
Chrome liked to make `height: 100%` not look the same as it does in Firefox and Safari.

Switching `100%` to `auto` fixes this - and gives the same, correct, result in Firefox, Chrome, and Safari. 