### PR TITLE
Enhanchement: Backwards compatibility with vf-global-header 1.x HTML

### DIFF
--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2.0.1
+
+* add support for backwards compatibility with .vf-global-header 1.x's vf-global-header__inner
+* will be removed in vf-global-header 3.0
+
 ## 2.0.0
 
 * making a breaking change because of the HTML alterations

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -38,3 +38,17 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
     margin-right: .5rem;
   }
 }
+
+// backwards compatibility with .vf-global-header 1.x vf-global-header__inner
+// will be removed in vf-global-header 3.0
+html:not(.vf-disable-deprecated) {
+  .vf-global-header__inner {
+    align-items: center;
+    box-sizing: border-box;
+    display: flex;
+    flex-wrap: wrap;
+    grid-column: 1 / -1;
+    padding: .5rem 0;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Add support for backwards compatibility with .vf-global-header 1.x's vf-global-header__inner

Because the EMBL global header comes from the contentHub we can't switch over everything in one go. This allows projects to update to vf-global-header 2.x and the contentHub to continue to have 1.x HTML with vf-global-header__inner.

I note that it will be removed in vf-global-header 3.0