### PR TITLE
the one that adds contextual data option to vf-hero

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.5
+
+* adds an if statement for contextual data if applicable 
+
 # 1.4.4
 
 * fixes issue with `--intense` variant so parallax image is full width

--- a/components/vf-hero/vf-hero.njk
+++ b/components/vf-hero/vf-hero.njk
@@ -34,13 +34,13 @@
       {%- if vf_hero_href %}
       <a class="vf-link" href="{{ vf_hero_href }}">{{ vf_hero_text }}<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="" fill-rule="nonzero"></path></svg></a>
       {% else %}
-      {{ vf_hero_text }}
+      {{ vf_hero_text | safe }}
       {% endif %}
     </p>
     {% else %}
     {% asyncEach hero_text in vf_hero_text -%}
     <p class="vf-hero__text">
-      {{ hero_text }}
+      {{ hero_text | safe }}
     </p>
     {% endeach %}
     {% endif %}

--- a/components/vf-hero/vf-hero.njk
+++ b/components/vf-hero/vf-hero.njk
@@ -1,3 +1,25 @@
+{%- if context %}
+  {% set card_href = context.card_href %}
+  {% set vf_hero__initial_row = context.vf_hero__initial_row %}
+
+  {% set vf_hero_heading = context.vf_hero_heading %}
+  {% set vf_hero_summary_title = context.vf_hero_summary_title %}
+  {% set vf_hero_subheading = context.vf_hero_subheading %}
+  {% set vf_hero_image = context.vf_hero_image %}
+
+  {% set vf_hero_href = context.vf_hero_href %}
+  {% set vf_hero_text = context.vf_hero_text %}
+  {% set hero_text = context.hero_text %}
+
+  {% set theme = context.theme %}
+  {% set variant = context.variant %}
+
+  {% set id = context.id %}
+  {% set modifier_class = context.modifier_class %}
+  {% set override_class = context.override_class %}
+{% endif %}
+
+
 <section
   class="vf-hero {{ modifier_class }}"
   style="


### PR DESCRIPTION
I've added 

```
{%- if context %}
  {% set card_href = context.card_href %}
  {% set vf_hero__initial_row = context.vf_hero__initial_row %}

  {% set vf_hero_heading = context.vf_hero_heading %}
  {% set vf_hero_summary_title = context.vf_hero_summary_title %}
  {% set vf_hero_subheading = context.vf_hero_subheading %}
  {% set vf_hero_image = context.vf_hero_image %}

  {% set vf_hero_href = context.vf_hero_href %}
  {% set vf_hero_text = context.vf_hero_text %}
  {% set hero_text = context.hero_text %}

  {% set theme = context.theme %}
  {% set variant = context.variant %}

  {% set id = context.id %}
  {% set modifier_class = context.modifier_class %}
  {% set override_class = context.override_class %}
{% endif %}
```

to the top of `vf-hero.njk` so we can make use of `{% include %}` rather than `{% render %}` in 11ty

If there's no `context` - like there is not in `vf-core` then it is ignored. 

If there is a context that has been `{% set %}` then it will pass through to the components. 

Making cleaner `.njk` files and better separation of data and markup -- meaning better improvements will be easier to update in the future

Once merged - my plan is to edit all of the `vf-hero` that are used in the embl.org repo to use this and `.yml` files before moving onto the next components … and so on and so on and so on.