### PR TITLE
the one that makes the profile a little more malleable.

### DIFF
--- a/components/vf-profile/CHANGELOG.md
+++ b/components/vf-profile/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.0.2
+
+* makes the `width: 100%` rather than `max-content` as some people have really long job titles
+
+
 ## 1.0.1
 
 * fixes issue where email was a link not a mailto:

--- a/components/vf-profile/vf-profile.scss
+++ b/components/vf-profile/vf-profile.scss
@@ -16,7 +16,7 @@
   color: set-color(vf-color--grey--darkest);
   display: flex;
   flex-direction: column;
-  width: 100%;
+  width: 100%; // we might not need this
 }
 
 .vf-profile__image {
@@ -54,7 +54,7 @@
 
   line-height: 1.2;
 
-  .vf-profile__job-title > & {
+  .vf-profile__job-title + & {
     margin-bottom: .25rem;
   }
 }

--- a/components/vf-profile/vf-profile.scss
+++ b/components/vf-profile/vf-profile.scss
@@ -16,7 +16,7 @@
   color: set-color(vf-color--grey--darkest);
   display: flex;
   flex-direction: column;
-  width: max-content;
+  width: 100%;
 }
 
 .vf-profile__image {
@@ -53,6 +53,10 @@
   @include set-type(text-body--2, $custom-margin-bottom: 0);
 
   line-height: 1.2;
+
+  .vf-profile__job-title > & {
+    margin-bottom: .25rem;
+  }
 }
 
 .vf-profile__email {


### PR DESCRIPTION
- replaces `width: max-content;` with `width: 100%;` for the `vf-profile` component so that long text doesn't break layout.
- adds a little bit of margin to `vf-profile__text` if it follows `vf-profile__job-title`.
