### PR TITLE
Update legacy EBI Header to use full bleed

### DIFF
--- a/components/_previews/_preview.njk
+++ b/components/_previews/_preview.njk
@@ -15,11 +15,6 @@
   {% if _config.project.environment.production %}
   <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
   {% endif %}
-  <style>
-    .vf-component__container {
-      margin: 2em 0;
-    }
-  </style>
 </head>
 <body class="vf-body">
   <div class="vf-grid">

--- a/components/ebi-header-footer/CHANGELOG.md
+++ b/components/ebi-header-footer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.0
+
+* EBI Header is once again fullbleed after changes in vf-grid-page 2.0.0
+
 ## 1.0.0-beta.2
 
-* Resolves changes in other VF components, spacing, links, etc. 
+* Resolves changes in other VF components, spacing, links, etc.

--- a/components/ebi-header-footer/ebi-header-footer--embl-selector.scss
+++ b/components/ebi-header-footer/ebi-header-footer--embl-selector.scss
@@ -12,10 +12,30 @@
   .embl-bar {
     background-color: var(--vf-ui-color--off-white);
     color: var(--vf-color--grey--darkest);
+    position: relative; /* 2 */
+
+    // a copy of vf-u-fullbleed code,
+    // but we duplicate it as we're not able to insert classes into the legacy html import
+    &::before {
+      background-color: inherit; /* 3 */
+      background-image: inherit;
+      background-position: inherit;
+      background-repeat: inherit;
+      background-size: cover;
+      content: '';
+      grid-column: 1 / -1; /* 4 */
+      height: 100%; /* 5 */
+      margin-left: calc(50% - 50vw); /* 6 */
+      position: absolute;
+      top: 0; /* 7 */
+      width: 100vw; /* 8 */
+      z-index: set-layer(vf-z-index--negative); /* 9 */
+    }
+
     a {
       color: var(--vf-color--grey--darkest);
     }
-    a:hover { 
+    a:hover {
       border-bottom: 1px solid var(--vf-ui-color--white);
     }
   }

--- a/components/ebi-header-footer/ebi-header-footer.config.yml
+++ b/components/ebi-header-footer/ebi-header-footer.config.yml
@@ -9,7 +9,7 @@ status: beta
 # variants:
   # - name: default
   #   hidden: true
-preview: '@preview--nogrid'
+# preview: '@preview--nogrid'
 context:
   component-type: container
   # custom-values: passed as {{custom-values}}

--- a/components/ebi-header-footer/ebi-header-footer.njk
+++ b/components/ebi-header-footer/ebi-header-footer.njk
@@ -5,7 +5,7 @@
 {% endif %}
 <link rel="stylesheet" href="https://dev.ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
 
-<header id="masthead-black-bar" class="clearfix masthead-black-bar | ebi-header-footer vf-content">
+<header id="masthead-black-bar" class="clearfix masthead-black-bar | ebi-header-footer vf-content vf-u-fullbleed">
 </header>
 
 Your content here.

--- a/components/ebi-header-footer/package.json
+++ b/components/ebi-header-footer/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "name": "@visual-framework/ebi-header-footer",
   "description": "ebi-header-footer component",
   "homepage": "https://visual-framework.github.io/vf-core",

--- a/tools/vf-frctl-theme/dist/css/default.css
+++ b/tools/vf-frctl-theme/dist/css/default.css
@@ -11,7 +11,7 @@
   border: 1px solid rgba(0, 0, 0, .1);
   border-left: 0;
   border-right: 0;
-  padding: 0;
+  padding: 2rem 0;
 }
 .Frame-body {
   grid-column: 2 / -2;


### PR DESCRIPTION
With the changes in vf-body, the legacy EBI Header is no longer full width. This makes it work as expected.