### PR TITLE
the one that finally deprecates the vf-summary--profile variant

### DIFF
--- a/components/vf-summary/CHANGELOG.md
+++ b/components/vf-summary/CHANGELOG.md
@@ -5,7 +5,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 1.1.0
 
-* Deprecated the `vf-summary--profile` component
+* Deprecated the `vf-summary--profile` component, you should now use `vf-profile`
 
 # 1.0.4
 

--- a/components/vf-summary/CHANGELOG.md
+++ b/components/vf-summary/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.1.0
+
+* Deprecated the `vf-summary--profile` component
+
 # 1.0.4
 
 * A fix for Chrome as it displays avatar defaults as a squished circle. Replaces 100% to auto within heigh rule.

--- a/components/vf-summary/README.md
+++ b/components/vf-summary/README.md
@@ -4,13 +4,17 @@
 
 ## About
 
-Summaries in the form of text, headlines and often imagery for a range of types of content, including: articles, jobs, news and people profiles. 
+Summaries in the form of text, headlines and often imagery for a range of types of content, including: articles, jobs, news and people profiles.
+
+<h3>The <code>vf-summary--profile</code> component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="/components/detail/vf-profile"><code>vf-profile</code></a> component.</h3> 
 
 ### Publications Summary
 
 The `vf-summary--publication` can be nested inside a vf-box where it takes the vf-box colours.
 
 If the `vf-summary__author` list is truncated to a certain number of authors you will need to add vf-u-text--et-al to the `<p>` - `<p class="vf-summary__author | vf-u-text--et-al">` - for it to add et al to the end of the list.
+
+
 
 ## Install
 

--- a/components/vf-summary/README.md
+++ b/components/vf-summary/README.md
@@ -14,8 +14,6 @@ The `vf-summary--publication` can be nested inside a vf-box where it takes the v
 
 If the `vf-summary__author` list is truncated to a certain number of authors you will need to add vf-u-text--et-al to the `<p>` - `<p class="vf-summary__author | vf-u-text--et-al">` - for it to add et al to the end of the list.
 
-
-
 ## Install
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-summary` with this command.

--- a/components/vf-summary/vf-summary--profile.scss
+++ b/components/vf-summary/vf-summary--profile.scss
@@ -1,114 +1,116 @@
-.vf-summary--profile {
-  column-gap: 16px;
-  grid-template-columns: minmax( 0, var(--vf-icon--avatar-width) ) 1fr;
-  grid-template-rows: auto;
-  margin-bottom: 48px;
+html:not(.vf-disable-deprecated) {
+  .vf-summary--profile {
+    column-gap: 16px;
+    grid-template-columns: minmax( 0, var(--vf-icon--avatar-width) ) 1fr;
+    grid-template-rows: auto;
+    margin-bottom: 48px;
 
-  .vf-summary__image{
-    align-self: start;
-    grid-column: 1 / span 1;
-    grid-row: 1 / span 6;
-    height: auto;
-    margin-right: 30px;
-    max-height: var(--vf-icon--avatar-width);
-    max-width: var(--vf-icon--avatar-width);
-    width: 100%;
+    .vf-summary__image{
+      align-self: start;
+      grid-column: 1 / span 1;
+      grid-row: 1 / span 6;
+      height: auto;
+      margin-right: 30px;
+      max-height: var(--vf-icon--avatar-width);
+      max-width: var(--vf-icon--avatar-width);
+      width: 100%;
+    }
+
+    .vf-summary__title {
+      --vf-text-margin--bottom: 0;
+
+      font-size: 19px;
+      grid-column: 2 / -1;
+      line-height: 1.5;
+    }
+
+    .vf-summary__text {
+      --vf-text-margin--bottom: 0;
+    }
   }
 
-  .vf-summary__title {
-    --vf-text-margin--bottom: 0;
-
-    font-size: 19px;
-    grid-column: 2 / -1;
-    line-height: 1.5;
+  .vf-summary__link {
+    @include inline-link;
+  }
+  .vf-summary__link--secondary {
+    @include inline-link(set-color(vf-color--grey--darkest), set-ui-color(vf-ui-color--black), set-color(vf-color--grey--darkest), $vf-include-normalisations: true);
   }
 
-  .vf-summary__text {
-    --vf-text-margin--bottom: 0;
+  .vf-summary__image--avatar {
+    border-radius: 50%;
   }
-}
 
-.vf-summary__link {
-  @include inline-link;
-}
-.vf-summary__link--secondary {
-  @include inline-link(set-color(vf-color--grey--darkest), set-ui-color(vf-ui-color--black), set-color(vf-color--grey--darkest), $vf-include-normalisations: true);
-}
-
-.vf-summary__image--avatar {
-  border-radius: 50%;
-}
-
-
-.vf-summary__email {
-  --vf-text-margin--bottom: 24px;
-
-  @include set-type($vf-summary__body-typography);
-  word-break: break-all;
-}
-
-
-.vf-summary__phone {
-  --vf-text-margin--bottom: 0;
-
-  @include set-type($vf-summary__body-typography);
-
-  & + & {
-    --vf-text-margin--bottom: 8px;
-  }
-}
-
-.vf-summary--mobile {
-  position: relative;
-
-  &::after {
-    content: '(mobile)';
-    margin-left: 4px;
-    position: absolute;
-  }
-}
-
-
-.vf-summary__uuid {
-  @include set-type(text-body--5);
-  color: set-color(color-grey-dark);
-}
-
-// variants
-
-.vf-summary--profile-l {
-  --vf-icon--avatar-width: 128px;
 
   .vf-summary__email {
-    --vf-text-margin--bottom: 8px;
-  }
-}
+    --vf-text-margin--bottom: 24px;
 
-.vf-summary--profile-r {
-  --vf-icon--avatar-width: 80px;
-
-  .vf-summary__title {
-    --vf-text-margin--bottom: 8px;
+    @include set-type($vf-summary__body-typography);
+    word-break: break-all;
   }
-  .vf-summary__text {
+
+
+  .vf-summary__phone {
+    --vf-text-margin--bottom: 0;
+
+    @include set-type($vf-summary__body-typography);
+
+    & + & {
+      --vf-text-margin--bottom: 8px;
+    }
+  }
+
+  .vf-summary--mobile {
+    position: relative;
+
+    &::after {
+      content: '(mobile)';
+      margin-left: 4px;
+      position: absolute;
+    }
+  }
+
+
+  .vf-summary__uuid {
     @include set-type(text-body--5);
+    color: set-color(color-grey-dark);
   }
-  .vf-summary__email {
-    @include set-type(text-body--5, $custom-margin-bottom: 0);
+
+  // variants
+
+  .vf-summary--profile-l {
+    --vf-icon--avatar-width: 128px;
+
+    .vf-summary__email {
+      --vf-text-margin--bottom: 8px;
+    }
   }
-  .vf-summary__image {
-    margin-right: 16px;
+
+  .vf-summary--profile-r {
+    --vf-icon--avatar-width: 80px;
+
+    .vf-summary__title {
+      --vf-text-margin--bottom: 8px;
+    }
+    .vf-summary__text {
+      @include set-type(text-body--5);
+    }
+    .vf-summary__email {
+      @include set-type(text-body--5, $custom-margin-bottom: 0);
+    }
+    .vf-summary__image {
+      margin-right: 16px;
+    }
   }
-}
 
 
-.vf-summary--profile-s {
-  --vf-icon--avatar-width: 60px;
+  .vf-summary--profile-s {
+    --vf-icon--avatar-width: 60px;
 
-  .vf-summary__image {
-    margin-right: 8px;
-  }
-  .vf-summary__title {
-    @include set-type(text-body--5);
+    .vf-summary__image {
+      margin-right: 8px;
+    }
+    .vf-summary__title {
+      @include set-type(text-body--5);
+    }
   }
 }

--- a/components/vf-summary/vf-summary.config.yml
+++ b/components/vf-summary/vf-summary.config.yml
@@ -11,6 +11,7 @@ context:
   summary__href: 'JavaScript:Void(0);'
 variants:
   - name: profile
+    hidden: true
     context:
       email: contact@persons.com
       phone: +49 6221 387 8443
@@ -18,12 +19,15 @@ variants:
       text: EMBL Press Office
       uuid: 0000 - 1234 - 4326 - XX03
   - name: large
+    hidden: true
     context:
       size: l
   - name: regular
+    hidden: true
     context:
       size: r
       email: contact@persons.com
   - name: small
+    hidden: true
     context:
       size: s


### PR DESCRIPTION
- adds relevant code for deprecation
- points to `vf-profile` as needed
- hides from component previews
- updates version to `1.1.0` as I think it's more a 'minor' change because it's not totally removed, yet. 