### PR TITLE
🐛 the one that fixes layout issue with vf-logo inside of vf-global-header

### DIFF
--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.2
+
+- fixes layout issue so a logo will take the space it needs.
+
 ### 2.0.1
 
 - add support for backwards compatibility with .vf-global-header 1.x's vf-global-header__inner

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -26,8 +26,8 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
   padding: .5rem 0;
   width: 100%;
 
-  .vf-logo {
-    flex: 1; // necessary for when embl-logo is inside flex-based containers like vf-global-header
+  & > [class*='logo'] {
+    flex: 1; // necessary for when a logo is inside flex-based containers like vf-global-header
   }
 }
 

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -25,6 +25,10 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
   max-width: 78.5rem;
   padding: .5rem 0;
   width: 100%;
+
+  .vf-logo {
+    flex: 1; // necessary for when embl-logo is inside flex-based containers like vf-global-header
+  }
 }
 
 .vf-global-header__site-name {


### PR DESCRIPTION
This already fixed in `embl-logo`

What we've done here is specify that any direct child of `vf-global-header` that has a class which contains `logo` will have `flex: 1;` so that it fills the space it needs.