### PR TITLE
🎨 the one that replaces vf-grid-page with vf-body

### DIFF
--- a/components/_previews/_preview--nogrid.njk
+++ b/components/_previews/_preview--nogrid.njk
@@ -15,6 +15,7 @@
   {% if _config.project.environment.production %}
   <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
   {% endif %}
+  <style>body { margin: 0; }</style>
 </head>
 <body>
   {{ yield | safe }}

--- a/components/vf-body/.npmignore
+++ b/components/vf-body/.npmignore
@@ -1,0 +1,4 @@
+bin
+.github
+.travis.yml
+node_modules

--- a/components/vf-body/CHANGELOG.md
+++ b/components/vf-body/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 1.0.0
+
+- Initial stable release

--- a/components/vf-body/README.md
+++ b/components/vf-body/README.md
@@ -1,0 +1,38 @@
+# Body Component
+
+[![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-body.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-body)
+
+## About
+
+The Body component can be used to create a centered layout to add your content. This should be added to the `body` element in the markup.
+
+## Install
+
+This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-body` with this command.
+
+```
+$ yarn add --dev @visual-framework/vf-body
+```
+
+
+The source files included are written in [Sass](http://sass-lang.com)(`scss`). You can point your Sass `include-path` at your `node_modules` directory and import it like this.
+
+```
+@import "@visual-framework/vf-body/index.scss";
+```
+
+_Make sure you import Sass requirements along with the modules._
+
+
+### CSS
+
+```css
+.vf-body {
+  --vf-body-width: 81.25em;
+  display: block;
+  margin: 0 auto;
+  max-width: 81.25em;
+  max-width: var(--vf-body-width, 81.25em);
+  padding: 0 1em;
+}
+```

--- a/components/vf-body/index.scss
+++ b/components/vf-body/index.scss
@@ -1,0 +1,9 @@
+// setup files required
+
+@import 'vf-variables';
+@import 'vf-functions';
+@import 'vf-mixins';
+
+// component specific styles
+
+@import 'vf-grid-page.scss';

--- a/components/vf-body/package.json
+++ b/components/vf-body/package.json
@@ -1,0 +1,23 @@
+{
+  "version": "2.0.0",
+  "name": "@visual-framework/vf-body",
+  "description": "vf-body component",
+  "homepage": "https://visual-framework.github.io/vf-core/",
+  "author": "VF",
+  "license": "Apache 2.0",
+  "style": "vf-body.css",
+  "sass": "index.scss",
+  "test": "echo \"Error: no test specified\" && exit 1",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repo": "https://github.com/visual-framework/vf-core/tree/master/components/grids/vf-body",
+  "bugs": {
+    "url": "https://github.com/visual-framework/vf-core/issues/new"
+  },
+  "keywords": [
+    "fractal",
+    "component"
+  ],
+  "gitHead": "59833ad8fda69aa04c4231feb166c22e1c8121ea"
+}

--- a/components/vf-body/vf-body.config.yml
+++ b/components/vf-body/vf-body.config.yml
@@ -1,0 +1,6 @@
+title: Body
+label: Body
+preview: '@preview--nogrid'
+status: live
+context:
+  component-type: grid

--- a/components/vf-body/vf-body.njk
+++ b/components/vf-body/vf-body.njk
@@ -1,0 +1,3 @@
+<div class="vf-body">
+<div class="vf-box vf-box--normal vf-box-theme--primary"></div>
+</div>

--- a/components/vf-body/vf-body.njk
+++ b/components/vf-body/vf-body.njk
@@ -1,3 +1,5 @@
 <div class="vf-body">
-<div class="vf-box vf-box--normal vf-box-theme--primary"></div>
+  <div class="vf-box vf-box--normal vf-box-theme--primary">
+    <p class="vf-ui-color--white vf-u-margin--0 vf-u-type__text-body--2">This is for example purposes only. Please use the <code>vf-body</code> class on the <code>body</code> element only.</p>
+  </div>
 </div>

--- a/components/vf-body/vf-body.scss
+++ b/components/vf-body/vf-body.scss
@@ -12,10 +12,9 @@
 /* The Body
  * -------------- // --------------
  *
- * All content except for a few design patterns are tied into a grid with a maximum
+ * All content except for a few design patterns are tied into a layout with a maximum
  * width of 1300px. We center the `body` element to create a simple 3 column
- * grid with the central grid set to a maximum of 81.25em (1300px).
- *
+ * layout with the central grid set to a maximum of 81.25em (1300px).
  *
  */
 

--- a/components/vf-body/vf-body.scss
+++ b/components/vf-body/vf-body.scss
@@ -1,0 +1,32 @@
+// vf-body
+
+@import 'package.variables.scss';
+// Debug information from component's `package.json`:
+// ---
+/*!
+ * Component: #{map-get($componentInfo, 'name')}
+ * Version: #{map-get($componentInfo, 'version')}
+ * Location: #{map-get($componentInfo, 'location')}
+ */
+
+/* The Body
+ * -------------- // --------------
+ *
+ * All content except for a few design patterns are tied into a grid with a maximum
+ * width of 1300px. We center the `body` element to create a simple 3 column
+ * grid with the central grid set to a maximum of 81.25em (1300px).
+ *
+ *
+ */
+
+html {
+  margin: 0;
+}
+
+.vf-body {
+  display: block;
+  margin: 0 auto;
+  max-width: 81.25em;
+  max-width: var(--vf-body-width, #{$vf-layout--comfortable});
+  padding: 0 1em;
+}

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -21,7 +21,8 @@
 @import 'vf-font-plex-mono/vf-font-plex-mono.scss';
 @import 'vf-font-plex-sans/vf-font-plex-sans.scss';
 
-html, button {
+html,
+button {
   @if $use-global-typography == true {
     font-family: $vf-font-family--sans-serif;
   }
@@ -34,9 +35,10 @@ html, button {
 
 /* All Visual Framework grids */
 
+@import 'vf-body/vf-body.scss';
 @import 'vf-grid/vf-grid.scss';
 @import 'vf-inlay/vf-inlay.scss';
-@import 'vf-grid-page/vf-grid-page.scss';
+/* @import 'vf-grid-page/vf-grid-page.scss'; */
 @import 'embl-grid/embl-grid.scss';
 
 /* All Visual Framework Elements */
@@ -44,9 +46,9 @@ html, button {
 @import 'vf-badge/vf-badge.scss';
 @import 'vf-collapse/vf-collapse.scss';
 @import 'vf-link/vf-link.scss';
-  @import 'vf-link/vf-link--primary.scss';
-  @import 'vf-link/vf-link--secondary.scss';
-  @import 'vf-link/vf-link--disabled.scss';
+@import 'vf-link/vf-link--primary.scss';
+@import 'vf-link/vf-link--secondary.scss';
+@import 'vf-link/vf-link--disabled.scss';
 @import 'vf-logo/vf-logo.scss';
 @import 'vf-embed/vf-embed.scss';
 @import 'embl-logo/embl-logo.scss';
@@ -62,11 +64,11 @@ html, button {
 /* All Visual Framework Blocks */
 
 @import 'vf-box/vf-box.scss';
-  @import 'vf-box/vf-box--inlay.scss';
-  @import 'vf-box/vf-box--factoid.scss';
+@import 'vf-box/vf-box--inlay.scss';
+@import 'vf-box/vf-box--factoid.scss';
 
 @import 'vf-breadcrumbs/vf-breadcrumbs.scss';
-  @import 'vf-breadcrumbs/vf-breadcrumbs--with-related.scss';
+@import 'vf-breadcrumbs/vf-breadcrumbs--with-related.scss';
 
 @import 'vf-card/vf-card.scss';
 @import 'vf-card-container/vf-card-container.scss';
@@ -82,12 +84,12 @@ html, button {
 @import 'vf-lede/vf-lede.scss';
 
 @import 'vf-masthead/vf-masthead.scss';
-  @import 'vf-masthead/vf-masthead--supports.scss';
+@import 'vf-masthead/vf-masthead--supports.scss';
 
 @import 'vf-navigation/vf-navigation.scss';
-  @import 'vf-navigation/vf-navigation--global.scss';
-  @import 'vf-navigation/vf-navigation--main.scss';
-  @import 'vf-navigation/vf-navigation--additional.scss';
+@import 'vf-navigation/vf-navigation--global.scss';
+@import 'vf-navigation/vf-navigation--main.scss';
+@import 'vf-navigation/vf-navigation--additional.scss';
 
 @import 'vf-section-header/vf-section-header.scss';
 @import 'vf-activity-list/vf-activity-list.scss';
@@ -100,13 +102,13 @@ html, button {
 @import 'vf-social-links/vf-social-links.scss';
 
 @import 'vf-summary/vf-summary.scss';
-  @import 'vf-summary/vf-summary--article.scss';
-  @import 'vf-summary/vf-summary--job.scss';
-  @import 'vf-summary/vf-summary--profile.scss';
-  @import 'vf-summary/vf-summary--event.scss';
-  @import 'vf-summary/vf-summary--publication.scss';
-  @import 'vf-summary/vf-summary--news.scss';
-  @import 'vf-summary/vf-summary--has-image.scss';
+@import 'vf-summary/vf-summary--article.scss';
+@import 'vf-summary/vf-summary--job.scss';
+@import 'vf-summary/vf-summary--profile.scss';
+@import 'vf-summary/vf-summary--event.scss';
+@import 'vf-summary/vf-summary--publication.scss';
+@import 'vf-summary/vf-summary--news.scss';
+@import 'vf-summary/vf-summary--has-image.scss';
 
 @import 'vf-video/vf-video.scss';
 @import 'vf-video-teaser/vf-video-teaser.scss';
@@ -115,7 +117,7 @@ html, button {
 @import 'vf-table/vf-table.scss';
 @import 'embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.scss';
 @import 'vf-pagination/vf-pagination.scss';
-  @import 'vf-pagination/vf-pagination--full.scss';
+@import 'vf-pagination/vf-pagination--full.scss';
 
 /* All Visual Framework Containers */
 
@@ -124,10 +126,10 @@ html, button {
 @import 'embl-content-hub-loader/embl-content-hub-loader.scss';
 
 @import 'vf-banner/vf-banner.scss';
-  @import 'vf-banner/vf-banner--phase.scss';
-  @import 'vf-banner/vf-banner--alerts.scss';
-  @import 'vf-banner/vf-banner--fixed.scss';
-  @import 'vf-banner/vf-banner--gdpr.scss';
+@import 'vf-banner/vf-banner--phase.scss';
+@import 'vf-banner/vf-banner--alerts.scss';
+@import 'vf-banner/vf-banner--fixed.scss';
+@import 'vf-banner/vf-banner--gdpr.scss';
 
 @import 'vf-news-container/vf-news-container.scss';
 @import 'vf-video-container/vf-video-container.scss';

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -35,10 +35,11 @@ button {
 
 /* All Visual Framework grids */
 
+// vf-grid-page is deprecated, use vf-body instead
+// @import 'vf-grid-page/vf-grid-page.scss';
 @import 'vf-body/vf-body.scss';
 @import 'vf-grid/vf-grid.scss';
 @import 'vf-inlay/vf-inlay.scss';
-/* @import 'vf-grid-page/vf-grid-page.scss'; */
 @import 'embl-grid/embl-grid.scss';
 
 /* All Visual Framework Elements */

--- a/components/vf-design-tokens/CHANGELOG.md
+++ b/components/vf-design-tokens/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0
+
+- Adds some basic layout (width) tokens
+
 ### 1.0.5
 
 - Updates the z-index to separate any banner or hero from banner

--- a/components/vf-design-tokens/dist/sass/vf-layout.variables.scss
+++ b/components/vf-design-tokens/dist/sass/vf-layout.variables.scss
@@ -1,0 +1,8 @@
+// This file has been dynamically generated from design tokens
+// Please do NOT edit directly.
+
+// Source: variables/vf-layout.yml
+
+$vf-layout--comfortable: 81.25em;
+$vf-layout--cozy: 75em;
+$vf-layout--compact: 62.5em;

--- a/components/vf-design-tokens/src/variables/vf-layout.yml
+++ b/components/vf-design-tokens/src/variables/vf-layout.yml
@@ -1,0 +1,15 @@
+global:
+  category: radius
+
+props:
+  - name: vf-layout--comfortable
+    value: 81.25em
+    type: number
+
+  - name: vf-layout--cozy
+    value: 75em
+    type: number
+
+  - name: vf-layout--compact
+    value: 62.5em
+    type: number

--- a/components/vf-grid-page/CHANGELOG.md
+++ b/components/vf-grid-page/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.0.0
+
+- Deprecated for `vf-body` component
+
 ### 2.0.0
 
 - removes the CSS grid that generated a central column for content, now it's working across all browsers with less code.

--- a/components/vf-grid-page/README.md
+++ b/components/vf-grid-page/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-grid-page.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-grid-page)
 
-## About
+<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="#"new</a> component.</h2>
 
 ## Install
 

--- a/components/vf-grid-page/README.md
+++ b/components/vf-grid-page/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-grid-page.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-grid-page)
 
-<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="#"new</a> component.</h2>
+<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="https://www.npmjs.com/package/@visual-framework/vf-body">new `vf-body` component</a>.</h2>
 
 ## Install
 

--- a/components/vf-grid-page/vf-grid-page.config.yml
+++ b/components/vf-grid-page/vf-grid-page.config.yml
@@ -1,6 +1,7 @@
 title: Page Grid
 label: Page Grid
 preview: '@preview--nogrid'
-status: live
+status: deprecated
 context:
-  component-type: grid
+  component-type: deprecated
+  hidden: true

--- a/components/vf-grid-page/vf-grid-page.scss
+++ b/components/vf-grid-page/vf-grid-page.scss
@@ -22,13 +22,19 @@
  *
  */
 
-html {
-  margin: 0;
-}
 
-.vf-body {
-  display: block;
-  margin: 0 auto;
-  max-width: 76.5em;
-  padding: 0 1em;
+// Begin deprecated classes and styles
+html:not(.vf-disable-deprecated) {
+
+  html {
+    margin: 0;
+  }
+
+  .vf-body {
+    display: block;
+    margin: 0 auto;
+    max-width: 76.5em;
+    padding: 0 1em;
+  }
+  
 }

--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.3.0
+
+- adds a width css custom property for `vf-body` component.
+- reorganises the order variables are used.
+
 ### 1.2.0
 
 - creates mixin for grid column and row gap

--- a/components/vf-sass-config/index.scss
+++ b/components/vf-sass-config/index.scss
@@ -1,5 +1,5 @@
+@import 'variables/vf-variables.scss';
 @import 'variables/vf-global-custom-properties.scss';
 @import 'variables/vf-global-variables.scss';
-@import 'variables/vf-variables.scss';
 @import 'functions/vf-functions.scss';
 @import 'mixins/vf-mixins.scss';

--- a/components/vf-sass-config/variables/vf-global-custom-properties.scss
+++ b/components/vf-sass-config/variables/vf-global-custom-properties.scss
@@ -1,9 +1,13 @@
 // Native CSS properties, currently limited to document spacing.
 :root {
-  --page-grid-gap: 16px;
+  --vf-body-width: #{$vf-layout--comfortable};
+
+  --page-grid-gap: 1em;
+
   --embl-grid-module--prime: 200px;
   --embl-grid-spacing-normaliser: 6px;
-  @media (min-width: 1200px) {
-    --page-grid-gap: 30px;
+
+  @media (min-width: 75em) {
+    --page-grid-gap: 2em;
   }
 }

--- a/components/vf-sass-config/variables/vf-variables.scss
+++ b/components/vf-sass-config/variables/vf-variables.scss
@@ -5,6 +5,7 @@
 @import '../../vf-design-tokens/dist/sass/maps/vf-breakpoints.map.scss';
 @import '../../vf-design-tokens/dist/sass/maps/vf-colors.map.scss';
 @import '../../vf-design-tokens/dist/sass/maps/vf-ui-colors.map.scss';
+@import '../../vf-design-tokens/dist/sass/vf-layout.variables.scss';
 @import '../../vf-design-tokens/dist/sass/vf-font--monospace.scss';
 @import '../../vf-design-tokens/dist/sass/vf-font--sans.scss';
 @import '../../vf-design-tokens/dist/sass/vf-font-families.variables.scss';
@@ -14,6 +15,4 @@
 
 @import '../../vf-design-tokens/dist/sass/custom-properties/vf-colors.custom-properties.scss';
 @import '../../vf-design-tokens/dist/sass/custom-properties/vf-ui-colors.custom-properties.scss';
-
-@import 'vf-global-variables.scss';
 /* stylelint-enable */


### PR DESCRIPTION
🎨 adds `vf-body` component
🗑 deprecates `vf-grid-page`
♻️ reorders `vf-sass-config` variable import order
💄 adds some basic 'layout width' design tokens