### PR TITLE
Fix: generate per-component CSS with `vf-css:generate-component-css`

### DIFF
--- a/tools/vf-component-library/CHANGELOG.md
+++ b/tools/vf-component-library/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.1
+
+* Also generate per-component CSS with `vf-css:generate-component-css`
+
 ### 1.0.0
 
-- Initial release to be used with vf-core 2.2.0
+* Initial release to be used with vf-core 2.2.0

--- a/tools/vf-component-library/gulpfile.js
+++ b/tools/vf-component-library/gulpfile.js
@@ -19,7 +19,8 @@ gulp.task('watch', function() {
 // Let's build this sucker.
 gulp.task('build', gulp.series(
   'vf-clean',
-  gulp.parallel('vf-css','vf-scripts','vf-component-assets:everything'),
+  gulp.parallel('vf-css','vf-scripts','vf-css:generate-component-css'),
+  'vf-component-assets:everything',
   'fractal:build',
   'fractal',
   'eleventy:init',


### PR DESCRIPTION
Assets like /ebi-header-footer/ebi-header-footer.css weren't being deployed