### PR TITLE
🎨 the one that refactors the `embl-grid` code and gives columns a little more space

### DIFF
--- a/components/embl-grid/CHANGELOG.md
+++ b/components/embl-grid/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 1.1.0
+
+- removes unused `--alt` version (use a utility class for background colour).
+- adds more space for content in initial (prime) column and sidebar column (if used).
+- tidies up CSS by using css custom properties for variants.
+- removes weird margin that was used beforehand.
+- takes the hairline out of `--has-sidebar` and gives it it's own modifier class.
+
+
 ### 1.0.4
 
 - The one where we make our CSS grid-gaps gaps

--- a/components/embl-grid/CHANGELOG.md
+++ b/components/embl-grid/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.1.0
+### 2.0.0
 
 - removes unused `--alt` version (use a utility class for background colour).
 - adds more space for content in initial (prime) column and sidebar column (if used).

--- a/components/embl-grid/embl-grid.njk
+++ b/components/embl-grid/embl-grid.njk
@@ -3,17 +3,6 @@
     <div></div>
     <div></div>
   </div>
-  <div class="embl-grid">
-    <div></div>
-    <div></div>
-    <div></div>
-  </div>
-  <div class="embl-grid">
-    <div></div>
-    <div></div>
-    <div></div>
-    <div></div>
-  </div>
   <div class="embl-grid embl-grid--has-sidebar">
     <div></div>
     <div></div>
@@ -29,8 +18,7 @@
 <style>
 .embl-grid > div {
   /* For illustrative use on component demo page */
-  background-color: rgb(41, 141, 211);
+  background-color: var(--vf-color--blue);
   min-height: 5em;
-  margin-bottom: 1em;
 }
 </style>

--- a/components/embl-grid/embl-grid.njk
+++ b/components/embl-grid/embl-grid.njk
@@ -8,6 +8,11 @@
     <div></div>
     <div></div>
   </div>
+  <div class="embl-grid embl-grid--has-sidebar embl-grid-has-sidebar--hairline">
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
   <div class="embl-grid embl-grid--has-centered-content">
     <div></div>
     <div></div>

--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -28,6 +28,7 @@
   }
 
   @media (min-width: $vf-breakpoint--sm) {
+    /* stylelint-disable declaration-colon-space-after */
     --embl-grid:
       var(--embl-grid-module--prime)
       [main-start]
@@ -36,33 +37,42 @@
 
     display: grid;
     gap: var(--page-grid-gap);
-    grid-template-columns: var(--embl-grid);
+    grid-template-columns: var(--vf-custom-grid-layout, var(--embl-grid));
   }
 
 }
 
 .embl-grid--has-centered-content {
 
+  & > *:last-child {
+    grid-column-start: 2;
+  }
+
   @media (min-width: $vf-breakpoint--lg) {
-    /* stylelint-disable declaration-colon-space-after */
     --embl-grid:
       var(--embl-grid-module--prime)
       auto
       var(--embl-grid-module--prime);
-    /* stylelint-enable */
+    & > *:last-child {
+      grid-column-start: unset;
+    }
   }
 }
 
 .embl-grid--has-sidebar {
-  --embl-grid: var(--embl-grid-module--prime) [main-start] 1fr [main-end] minmax(21em, auto);
+  --embl-grid:
+    var(--embl-grid-module--prime)
+    [main-start]
+    1fr
+    [main-end]
+    minmax(21em, auto);
+  /* stylelint-enable */
 
-  @media (max-width: 845px){
-    & > *:last-child {
-      grid-column: 1 / -1;
-    }
-  }
   @media (min-width: 846px) and (max-width: 1299px) {
-    & > *:last-child {
+    & > *:first-child {
+      grid-column: 1 / 2;
+    }
+    & > * {
       grid-column: 2 / -1;
     }
   }

--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -11,12 +11,10 @@
 
 
 .embl-grid {
-  grid-column: main;
   margin-bottom: 48px;
 
   & > :first-child {
     grid-column: 1 / -1;
-    margin-right: var(--embl-grid-spacing-normaliser);
 
     @media (min-width: 846px) {
       grid-column: span 1;
@@ -28,30 +26,26 @@
       grid-column: 1 / -1;
     }
   }
+
   @media (min-width: $vf-breakpoint--sm) {
-    column-gap: var(--page-grid-gap);
-    display: grid;
-    /* stylelint-disable declaration-colon-space-after */
-    grid-template-columns:
-      calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser))
+    --embl-grid:
+      var(--embl-grid-module--prime)
       [main-start]
-      repeat(auto-fit, minmax(288px, 1fr))
-      [main-end]
-    ;
-    /* stylelint-enable */
+      repeat(auto-fit, minmax(18.75em, 1fr))
+      [main-end];
+
+    display: grid;
+    gap: var(--page-grid-gap);
+    grid-template-columns: var(--embl-grid);
   }
 
 }
 
 .embl-grid--has-centered-content {
-  --embl-grid-spacing-normaliser: 0; // removes margin from first child
-  --page-grid-gap: 0; //
 
   @media (min-width: $vf-breakpoint--lg) {
-    --page-grid-gap: 36px;
-
     /* stylelint-disable declaration-colon-space-after */
-    grid-template-columns:
+    --embl-grid:
       var(--embl-grid-module--prime)
       auto
       var(--embl-grid-module--prime)
@@ -62,21 +56,20 @@
 
 .embl-grid--has-sidebar {
 
-  & > *:nth-child(3n+2) {
-    grid-column: span 2;
-  }
-
   @media (max-width: 845px) {
     & > *:last-child {
       grid-column: 1 / -1;
     }
   }
-  @media (min-width: 846px) and (max-width: 1219px) {
+  @media (min-width: 846px) and (max-width: 1299px) {
     & > *:last-child {
       grid-column: 2 / -1;
     }
   }
-  @media (min-width: 1220px) {
+}
+
+.embl-grid-has-sidebar--hairline {
+  @media (min-width: 1300px) {
     & > *:last-child {
       position: relative;
     }
@@ -99,7 +92,7 @@
   /* stylelint-disable declaration-colon-space-after */
   grid-template-columns:
     minmax(1em, auto)
-    calc(var(--embl-grid-module--prime) + var(--embl-grid-spacing-normaliser))
+    var(--embl-grid-module--prime)
     minmax(288px, calc(76.5em - 206px))
     minmax(1em, auto)
   ;

--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -4,10 +4,10 @@
 // Debug information from component's `package.json`:
 // ---
 /*!
- * Component: #{map-get($componentInfo, 'name')}
- * Version: #{map-get($componentInfo, 'version')}
- * Location: #{map-get($componentInfo, 'location')}
- */
+* Component: #{map-get($componentInfo, 'name')}
+* Version: #{map-get($componentInfo, 'version')}
+* Location: #{map-get($componentInfo, 'location')}
+*/
 
 
 .embl-grid {
@@ -31,7 +31,7 @@
     --embl-grid:
       var(--embl-grid-module--prime)
       [main-start]
-      repeat(auto-fit, minmax(18.75em, 1fr))
+      1fr
       [main-end];
 
     display: grid;
@@ -48,15 +48,15 @@
     --embl-grid:
       var(--embl-grid-module--prime)
       auto
-      var(--embl-grid-module--prime)
-    ;
+      var(--embl-grid-module--prime);
     /* stylelint-enable */
   }
 }
 
 .embl-grid--has-sidebar {
+  --embl-grid: var(--embl-grid-module--prime) [main-start] 1fr [main-end] minmax(21em, auto);
 
-  @media (max-width: 845px) {
+  @media (max-width: 845px){
     & > *:last-child {
       grid-column: 1 / -1;
     }
@@ -82,48 +82,4 @@
       width: 1px;
     }
   }
-}
-
-.embl-grid--alt {
-  --page-grid-gap: 0;
-  background-color: set-ui-color(vf-ui-color--black);
-  color: set-ui-color(vf-ui-color--white);
-  grid-column: 1 / -1;
-  /* stylelint-disable declaration-colon-space-after */
-  grid-template-columns:
-    minmax(1em, auto)
-    var(--embl-grid-module--prime)
-    minmax(288px, calc(76.5em - 206px))
-    minmax(1em, auto)
-  ;
-  /* stylelint-enable */
-  justify-content: center;
-  position: relative;
-
-  & > :first-child {
-    grid-column: 2 / -2;
-  }
-  & > :last-child {
-    grid-column: 2 / -2;
-  }
-
-  @media (min-width: $vf-breakpoint--md) {
-    & > :first-child {
-      grid-column: 2 / span 1;
-    }
-    & > :last-child {
-      grid-column: 3;
-      margin-left: 16px;
-    }
-  }
-  @media (min-width: 1200px) {
-    & > :last-child {
-      margin-left: 30px;
-    }
-  }
-
-  // HACK: put here for now
-  /* stylelint-disable order/properties-alphabetical-order, order/order  */
-  padding-top: 1.5rem;
-  /* stylelint-enable */
 }

--- a/components/vf-sass-config/variables/vf-global-custom-properties.scss
+++ b/components/vf-sass-config/variables/vf-global-custom-properties.scss
@@ -4,10 +4,10 @@
 
   --page-grid-gap: 1em;
 
-  --embl-grid-module--prime: 200px;
-  --embl-grid-spacing-normaliser: 6px;
+  --embl-grid-module--prime: 238px;
+  --embl-grid-spacing-normaliser: 0px;
 
   @media (min-width: 75em) {
-    --page-grid-gap: 2em;
+    --page-grid-gap: 1.5em;
   }
 }


### PR DESCRIPTION
- 🔥 removes unused `--alt` version (use a utility class for background colour).
- 🔥 removes weird margin that was used beforehand.
- 🎨 adds more space for content in initial (prime) column and sidebar column (if used).
- 💄 tidies up CSS by using css custom properties for variants.
- ✨ takes the hairline out of `--has-sidebar` and gives it it's own modifier class.