### PR TITLE
bug: css nano aggressive grid optimizations

### DIFF
--- a/tools/vf-core/CHANGELOG.md
+++ b/tools/vf-core/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.2.4
+
+* bug: css nano aggressive grid optimizations #1073
+  * https://github.com/visual-framework/vf-core/pull/1073
+
 ### 2.2.3
 
 * move vf-component-generator gulp tasks into the vf-component-generator

--- a/tools/vf-core/gulp-tasks/vf-css.js
+++ b/tools/vf-core/gulp-tasks/vf-css.js
@@ -187,7 +187,7 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
       .src(SassOutput + '/styles.css')
       .pipe(autoprefixer(autoprefixerOptions))
       .pipe(gulp.dest(SassOutput))
-      .pipe(cssnano())
+      .pipe(cssnano({reduceIdents: {gridTemplate: false}}))
       .pipe(gulp.dest(SassOutput))
       .on('end', function() {
         done();


### PR DESCRIPTION
what was `.vf-inlay__content--main {grid-area: inlay--main;`
was becoming `.vf-inlay__content--main{grid-area:a;`

related: https://twitter.com/jonsuh/status/849689928934010880?lang=en

ping @meladawy