### PR TITLE
the one that updates max-width in a few places and sets context for logos

### DIFF
--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.2.3
+
+- updates max-width of component
+
 ### 1.2.2
 
 - updates max-width of component

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -50,7 +50,7 @@
 
   box-sizing: border-box;
   margin: 0 auto;
-  max-width: 78.5em;
+  max-width: $vf-layout--comfortable;
   padding: 0 1rem;
 
   @supports (display: grid) {

--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,7 +1,8 @@
-### 2.1.0
+### 3.0.0
 
 - updates max-width of component
 - adds 'context' for the logo
+- removes `text` as you can make use of including text with the `vf-logo`
 
 ### 2.0.2
 

--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.1.0
+
+- updates max-width of component
+- adds 'context' for the logo
+
 ### 2.0.2
 
 - fixes layout issue so a logo will take the space it needs.

--- a/components/vf-global-header/vf-global-header.config.yml
+++ b/components/vf-global-header/vf-global-header.config.yml
@@ -6,4 +6,7 @@ status: live
 context:
   component-type: block
 
-  text: Visual Framework for Life Science websites
+  global_logo:
+    logo_href: /
+    image: ../../assets/vf-logo/assets/logo.svg
+    logo_text: Visual Framework for Life Science websites

--- a/components/vf-global-header/vf-global-header.njk
+++ b/components/vf-global-header/vf-global-header.njk
@@ -1,8 +1,11 @@
+{% if context %}
+  {% set global_logo = context.global_logo %}
+{% endif %}
+
+
 <header class="vf-global-header">
 
-    {% render '@vf-logo' %}
-
-    <p class="vf-global-header__site-name">{{ text }}</p>
+    {% render '@vf-logo', { 'context': global_logo } %}
 
     {% render '@vf-navigation--global' %}
 

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -22,7 +22,7 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
   grid-column: 1 / -1;
   height: auto;
   margin: 0 auto;
-  max-width: 78.5rem;
+  max-width: $vf-layout--comfortable;
   padding: .5rem 0;
   width: 100%;
 

--- a/components/vf-intro/CHANGELOG.md
+++ b/components/vf-intro/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.3.1
+
+- updates max-width of component
+
 ### 1.3.0
 
 - adds ability for `vf-badge` to be customised with it's variants

--- a/components/vf-intro/vf-intro.scss
+++ b/components/vf-intro/vf-intro.scss
@@ -41,7 +41,7 @@
   grid-template-rows: 1fr repeat(10, min-content);
   margin-left: auto;
   margin-right: auto;
-  max-width: 78.5em;
+  max-width: $vf-layout--comfortable;
   padding-left: 1em;
   padding-right: 1em;
 }

--- a/components/vf-logo/CHANGELOG.md
+++ b/components/vf-logo/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.2.0
+
+- adds 'context' for the logo
+
 ### 1.1.0
 
 - adds if statement for if there is text or not so no HTML is printed if not

--- a/components/vf-logo/vf-logo.njk
+++ b/components/vf-logo/vf-logo.njk
@@ -1,3 +1,10 @@
+{% if context %}
+  {% set logo_href = context.logo_href %}
+  {% set image = context.image %}
+  {% set logo_text = context.logo_text %}
+  {% set hidden_text = context.hidden_text %}
+{% endif %}
+
 <a href="{{logo_href}}"
 {% if id %} id="{{-id-}}"{% endif %}
 class="vf-logo{%- if logo_text %} | vf-logo--has-text{% endif -%}

--- a/components/vf-navigation/CHANGELOG.md
+++ b/components/vf-navigation/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.2.5
+
+- updates max-width of component variants
+
 ### 1.2.4
 
 - updates max-width of component

--- a/components/vf-navigation/vf-navigation--additional.scss
+++ b/components/vf-navigation/vf-navigation--additional.scss
@@ -6,8 +6,8 @@
   box-sizing: border-box;
   display: flex;
   margin: 0 auto;
-  max-width: 78.5em;
-  padding: 4px 1rem;
+  max-width: $vf-layout--comfortable;
+  padding: 4px 0;
   position: relative;
   text-transform: uppercase;
   width: 100%;

--- a/components/vf-navigation/vf-navigation--main.scss
+++ b/components/vf-navigation/vf-navigation--main.scss
@@ -90,8 +90,8 @@
     flex-wrap: wrap;
     margin-left: auto;
     margin-right: auto;
-    max-width: 78.5em;
-    padding: .75rem 1rem;
+    max-width: $vf-layout--comfortable;
+    padding: .75rem 0;
     width: 100%;
   }
 
@@ -107,7 +107,7 @@
     @media (min-width: $vf-breakpoint--md) {
       margin-bottom: initial;
     }
-    
+
   }
 
   .vf-navigation__link {

--- a/tools/vf-frctl-theme/CHANGELOG.md
+++ b/tools/vf-frctl-theme/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.2
+
+- adds 'context' for the logo
+
 ### 1.0.1
 
 - Makes use of 'full width' which is useful for componets using `vf-u-fullbleed` or similar.

--- a/tools/vf-frctl-theme/dist/css/default.css
+++ b/tools/vf-frctl-theme/dist/css/default.css
@@ -34,8 +34,7 @@
 }
 
 .Pen {
-  box-sizing: border-box;
   margin: 0 auto;
-  max-width: 78.5em;
-  padding: 0 1em;
+  max-width: var(--vf-body-width);
+  padding: 0;
 }


### PR DESCRIPTION
It seems I missed a couple of changes to `max-width` on some components and their variants. This fixes that.

It also makes use of `{% if context %}` to allow the `vf-logo` that's rendered in `vf-global-header` to be 'whatever you want it to be' using `.yml`.

💄 updates max-width value
🎨 adds context options so vf-logo can be used properly
📦 updates changelogs

