### PR TITLE
💄 the one that removes inline padding on the footer

### DIFF
--- a/components/vf-footer/CHANGELOG.md
+++ b/components/vf-footer/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0
+
+- removes inline padding as it's defunct when using the `vf-body` component.
+
 ### 1.0.6
 
 - dependency bump

--- a/components/vf-footer/vf-footer.scss
+++ b/components/vf-footer/vf-footer.scss
@@ -60,7 +60,7 @@
   grid-column: main;
   margin: 0 auto;
   max-width: $vf-layout--comfortable;
-  padding: 0 1rem;
+  padding: 0;
 }
 
 .vf-footer__legal {


### PR DESCRIPTION
💄 removes the inline (left/right) padding on the footer. This is no longer needed when using the `vf-body` component. Tested on wwwdev.embl.org's new footer markup and it works. `vf-body` now takes up the slack of giving the 'page' inline padding when the viewport is below 1332px