### PR TITLE
💄 the moves the inline padding around so it matches layout

### DIFF
--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.4.0
+
+- removes inline padding on `vf-banner` class
+- replaces inline padding on `vf-banner__content` class
+- removes inline padding from `vf-banner__content` if parent has `vf-u-fullbleed` class
+
 ### 1.2.3
 
 - updates max-width of component

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -13,7 +13,7 @@
 
 .vf-banner {
   box-sizing: border-box;
-  padding: .75rem;
+  padding: .75rem 0;
 
   .vf-badge {
     margin-right: 1rem;
@@ -53,11 +53,14 @@
   max-width: $vf-layout--comfortable;
   padding: 0 1rem;
 
+  .vf-u-fullbleed & {
+    padding: 0;
+  }
+
   @supports (display: grid) {
     box-sizing: unset;
     margin: unset;
     max-width: unset;
-    padding: unset;
   }
 
   @media (max-width: 63.9375em) {

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -53,6 +53,8 @@
   max-width: $vf-layout--comfortable;
   padding: 0 1rem;
 
+  // If the vf-banner also has a vf-u-fullbleed class we remove the padding from the vf-banner__content class.
+  // This makes any content in the vf-banner line up with the maximum width as defined with the vf-body class.
   .vf-u-fullbleed & {
     padding: 0;
   }


### PR DESCRIPTION
There's cases where `vf-banner` looks odd.

If it has a class of `vf-u-fullbleed` on it, the additional padding on the `vf-banner` class screws up the alignment of the `vf-u-fullbleed` pseudo-class. 
If it has a class of `vf-u-fullbleed`, the additional padding 'looks wrong' as it's added additional inline spacing rather than lining up with the maximum width that the `vf-body` allows.

This PR fixes that by

💄 removing the  inline padding on `vf-banner` class completely.
💄 replacing inline padding on `vf-banner__content` class, by removing the `padding: unset` rule.
💄 removing inline padding from `vf-banner__content` if parent has `vf-u-fullbleed` class