### PR TITLE
bug: race condition in vf-build

### DIFF
--- a/tools/vf-core/gulp-tasks/vf-build.js
+++ b/tools/vf-core/gulp-tasks/vf-build.js
@@ -40,8 +40,7 @@ module.exports = function(gulp, buildDestionation) {
       'vf-clean',
       'vf-css:package-info',
       gulp.parallel (
-        'vf-css:generate-component-css',
-        gulp.series('vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
+        gulp.series('vf-css:generate-component-css', 'vf-css:build', 'vf-css:production', 'vf-component-assets', 'vf-scripts'),
         gulp.series(gulpFractalBuildTask, 'vf-templates-precompile')
       )
   ));


### PR DESCRIPTION
Avoids a race condition that resulted in some assets like https://dev.assets.emblstatic.net/vf/develop/assets/ebi-header-footer/ebi-header-footer.css not always being present on the CDN