### PR TITLE
💄 the one that updates :visited colour for links in text

### DIFF
--- a/components/vf-box/CHANGELOG.md
+++ b/components/vf-box/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.1
+
+- fixes issue with links in `vf-box__text` being visited and purple.
+
 ### 1.1.0
 
 - makes theme variant naming and decisions consistent.

--- a/components/vf-box/vf-box.scss
+++ b/components/vf-box/vf-box.scss
@@ -58,7 +58,9 @@
   a {
     color: currentColor;
     text-decoration: underline;
-    &:hover {
+    &:visited,
+    &:hover,
+    &:focus {
       color: currentColor;
     }
   }


### PR DESCRIPTION
If you added a link inside of `vf-box__text` it would inherit the browser styles if the link had been `:visited`.

This PR makes the `:visited` class stay the same colour.

💄 adds `:visited` to the list of pseudo-classes that inherit the `currentColor` of the node.
📦 updates changelog