### PR TITLE
💄 the one that resets the custom property for the gap rule

### DIFF
--- a/components/vf-intro/CHANGELOG.md
+++ b/components/vf-intro/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.3.2
+
+- resets the custom property used for `gap` in `embl-grid` so it only worries about the column gap.
+
 ### 1.3.1
 
 - updates max-width of component

--- a/components/vf-intro/vf-intro.scss
+++ b/components/vf-intro/vf-intro.scss
@@ -35,6 +35,7 @@
 
 .vf-intro {
   --vf-intro-spacing: 200px;
+  --page-grid-gap: 0 1em;
   box-sizing: border-box;
   display: grid;
   grid-column: main;
@@ -48,7 +49,7 @@
 
 @media (min-width: $vf-breakpoint--lg) {
   .vf-intro {
-    column-gap: var(--page-grid-gap);
+    --page-grid-gap: 0 1.5em;
     grid-template-areas: '... header header' '... ...    links';
     grid-template-columns: var(--embl-grid-module--prime) auto var(--embl-grid-module--prime);
   }


### PR DESCRIPTION
As `embl-grid` now supports both column and row `gap` by default this led to `vf-intro` having more space because CSS was providing a gap for each row defined in `vf-intro`.

This resets the CSS custom property for `--page-grid-gap` and ties it to `vf-intro` (I'm assuming source order is helping the cascade here).

