### PR TITLE
💄 the one that fixes the text color on hover when the button has secondary theming

### DIFF
--- a/components/vf-button/CHANGELOG.md
+++ b/components/vf-button/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.1
+
+- removes the `:hover` text color rule so that it doesn't to white on hover.
+
 ### 1.1.0
 
 - makes theme variant naming and decisions consistent.

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -48,7 +48,6 @@ $button-hover-fix: -5px -5px rgba(0, 0, 0, 0);
   &:focus,
   &:hover {
     box-shadow: 4px 4px 0 var(--vf-button-shadow-background-color, var(--vf-button__color__background--default-dark)), 2px 2px 4px rgba(set-ui-color(vf-ui-color--black), .25), $button-hover-fix;
-    color: set-ui-color(vf-ui-color--white);
     transform: translate(4px, 4px);
     transition: all linear 125ms;
   }


### PR DESCRIPTION
💄 removes the `:hover` rule that sets `color` to white from the `vf-button`.
📦 updates the changelog.