### PR TITLE
🐛 The one that fixes bug with image height in Safari

### DIFF
--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.1.2
+
+- fixes issue with `vf-card__image` height in safari.
+- adds `object-position: center` for image.
+
 ### 2.1.1
 
 - adds alt text to examples

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -17,16 +17,17 @@
 
   background-color: var(--card-background-color);
   display: grid;
-  grid-template-rows: 216px 1fr;
+  grid-template-rows: 288px 1fr;
   position: relative;
 }
 
 .vf-card__image {
   grid-column: 1 / -1;
-  grid-row: 1 / span 3;
+  grid-row: 1;
   height: 100%;
   max-width: 100%;
   object-fit: cover;
+  object-position: center;
   width: 100%;
 }
 


### PR DESCRIPTION
🐛 fixes bug where Safari would give you a really tall image
💄 adds `object-position: center;` to always centre the image when viewport at various sizes.
📦 updates the changelog. 