### PR TITLE
enhancement: catch cases where content-hub has nothing to do

### DIFF
--- a/components/embl-content-hub-loader/CHANGELOG.md
+++ b/components/embl-content-hub-loader/CHANGELOG.md
@@ -1,19 +1,23 @@
+### 1.0.6
+
+* invoke `emblContentHubSignalFinished()` even in cases where there was nothing to load
+
 ### 1.0.5
 
-- Fix detection of no response from the contentHub for `embl-js-content-hub-loader-no-content` and `embl-js-content-hub-loader-no-content-hide`
+* Fix detection of no response from the contentHub for `embl-js-content-hub-loader-no-content` and `embl-js-content-hub-loader-no-content-hide`
 
 ### 1.0.4 (2020-03-20)
 
-- adds support to load embl-notifications component
+* adds support to load embl-notifications component
 
 ### 1.0.2
 
-- adds features for when no content is returned. Supply "no content found" text or hide a region.
+* adds features for when no content is returned. Supply "no content found" text or hide a region.
 
 ### 1.0.1 (2019)
 
-- adds CSS for times when the `*-content-hub-html` is a direct child of `vf-body`.
+* adds CSS for times when the `*-content-hub-html` is a direct child of `vf-body`.
 
 ### 1.0.0 (2019-12-17)
 
-- Initial stable release
+* Initial stable release

--- a/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
@@ -57,6 +57,11 @@ function emblContentHubFetch() {
     }());
   }
 
+  // If nothing to import
+  if (emblContentHubLinks.length == 0) {
+    emblContentHubSignalFinished();
+  }
+
   // Add a class to the body once the last item has been processed
   function emblContentHubSignalFinished() {
     // @todo, shouldn't require the body element


### PR DESCRIPTION
invoke `emblContentHubSignalFinished()` even in cases where there was nothing to load