### PR TITLE
bug: vf-breadcrumbs with related url

### DIFF
--- a/components/vf-breadcrumbs/CHANGELOG.md
+++ b/components/vf-breadcrumbs/CHANGELOG.md
@@ -14,6 +14,6 @@
 
 - removes left and right padding so we rely on the parent for horizontal spacing for better alignment
 
-### 1.0.0 (2019-12-17)
+### 1.0.0
 
 - Initial stable release

--- a/components/vf-breadcrumbs/CHANGELOG.md
+++ b/components/vf-breadcrumbs/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.0.4
+
+- fix: links in the with-related variant weren't coming through as the parent object wasn't mapped
+
+### 1.0.3
+
+- dependency bump
+
 ### 1.0.2
 
 - updates max-width of component

--- a/components/vf-breadcrumbs/vf-breadcrumbs--with-related.njk
+++ b/components/vf-breadcrumbs/vf-breadcrumbs--with-related.njk
@@ -4,7 +4,7 @@
     {% for breadcrumb in breadcrumbs %}
     <li class="vf-breadcrumbs__item">
       {% if breadcrumb.breadcrumb_href %}
-      <a href="{{ breadcrumb_href }}" class="vf-breadcrumbs__link">{{ breadcrumb.text }}</a>
+      <a href="{{ breadcrumb.breadcrumb_href }}" class="vf-breadcrumbs__link">{{ breadcrumb.text }}</a>
       {% else %}
       {{ breadcrumb.text }}
       {% endif %}


### PR DESCRIPTION
Links in the with-related weren't coming through as the parent object wasn't mapped.