### PR TITLE
bug: vf-box specificity

### DIFF
--- a/components/vf-box/CHANGELOG.md
+++ b/components/vf-box/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.1
+
+- margin reset on `.vf-box :last-child` now has more specificity as `.vf-box > :last-child`
+
 ### 2.0.0
 
 - removed bottom margin from component. You should now make use of `vf-stack` in a parent element to create vertical spacing between multiple components.
@@ -7,8 +11,6 @@
 - removed `box` from `.yml` and `.njk` for setting context as it was an additional step.
 - adds `variant` and `theme` options to replace `vf-box__modifier` (`vf-box__modifier` will be removed in `v3,0`).
 - removes previously deprecated variants `vf-box--inlay` and `vf-box--factoid`.
-
-
 
 ### 1.1.1
 

--- a/components/vf-box/vf-box.scss
+++ b/components/vf-box/vf-box.scss
@@ -25,7 +25,7 @@
   width: 100%;
 
   // the last element within the component shouldn't have a bottom margin
-  & :last-child {
+  & > :last-child {
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
margin reset on `.vf-box :last-child` needs more specificity as `.vf-box > :last-child` affects the last child of every nested element, not just the last child of `<div class="vf-box">`