### PR TITLE
🎨 the one that improves `vf-summary--has-image`

### DIFF
--- a/components/vf-summary/CHANGELOG.md
+++ b/components/vf-summary/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.3.1
+
+- adds 'grid-template-areas' CSS for `--has-image` variant so you can use it with a `-thumbnail` class.
+
 ### 1.3.0
 
 - adds loading="lazy" to the img element for better performance

--- a/components/vf-summary/vf-summary--has-image.scss
+++ b/components/vf-summary/vf-summary--has-image.scss
@@ -5,7 +5,8 @@
   grid-template-columns: minmax($vf-summary--has-image-width, auto) 1fr;
   @include margin--block(bottom, 48px);
 
-  & > .vf-summary__link {
+  & > .vf-summary__link,
+  & > .vf-summary__image {
     grid-area: image;
   }
   .vf-summary__image {

--- a/components/vf-summary/vf-summary--has-image.scss
+++ b/components/vf-summary/vf-summary--has-image.scss
@@ -1,13 +1,14 @@
 .vf-summary--has-image {
 
   column-gap: 18px;
+  grid-template-areas: 'image text' 'image text' 'image text';
   grid-template-columns: minmax($vf-summary--has-image-width, auto) 1fr;
-  grid-template-rows: auto;
   @include margin--block(bottom, 48px);
 
+  & > .vf-summary__link {
+    grid-area: image;
+  }
   .vf-summary__image {
-    grid-column: 1 / span 1;
-    grid-row: 1 / span 4;
     width: 180px;
   }
 
@@ -20,7 +21,6 @@
   }
 
   .vf-summary__text {
-    align-items: center;
     display: block;
     grid-column: 2 / -1;
   }


### PR DESCRIPTION
There is a need to use the `--has-image` variant but without the `vf-summary__image--thumbnail` on the image.

This adds `grid-template-areas` so we can a apply the area `img` to the image of the component so it 'fills the space'.

note: I think `vf-summary` is due a rewrite now it's being used a lot more.