### PR TITLE
💄 the one that makes the sidebar in `embl-grid` a sidebar sooner. 

### DIFF
--- a/components/embl-grid/CHANGELOG.md
+++ b/components/embl-grid/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.0.2
+
+- changes breakpoint for sidebar to be a sidebar from 1024px
+- makes the sidebar smaller until it hits 1300px
+
 ### 2.0.1
 
 - fixes issue where `embl-grid` didn't allow for more 'main content' items.

--- a/components/embl-grid/embl-grid.njk
+++ b/components/embl-grid/embl-grid.njk
@@ -5,12 +5,16 @@
   </div>
   <div class="embl-grid embl-grid--has-sidebar">
     <div></div>
-    <div></div>
+    <div>
+      <p style="color: var(--vf-ui-color--white);">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatum autem hic accusamus suscipit id, et dolorum officiis, cum possimus, enim amet. Officiis sunt eum cum qui, impedit, magni quasi esse.</p>
+    </div>
     <div></div>
   </div>
   <div class="embl-grid embl-grid--has-sidebar embl-grid-has-sidebar--hairline">
     <div></div>
-    <div></div>
+    <div>
+      <p style="color: var(--vf-ui-color--white);">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatum autem hic accusamus suscipit id, et dolorum officiis, cum possimus, enim amet. Officiis sunt eum cum qui, impedit, magni quasi esse.</p>
+    </div>
     <div></div>
   </div>
   <div class="embl-grid embl-grid--has-centered-content">

--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -68,7 +68,7 @@
     minmax(21em, 1fr);
   /* stylelint-enable */
 
-  @media (min-width: 846px) and (max-width: 1299px) {
+  @media (min-width: 846px) and (max-width: 1023px) {
     & > *:first-child {
       grid-column: 1 / 2;
     }
@@ -76,10 +76,18 @@
       grid-column: 2 / -1;
     }
   }
+  @media (min-width: 1024px) and (max-width: 1299px) {
+    --embl-grid:
+      var(--embl-grid-module--prime)
+      [main-start]
+      auto
+      [main-end]
+      minmax(18em, 1fr);
+  }
 }
 
 .embl-grid-has-sidebar--hairline {
-  @media (min-width: 1300px) {
+  @media (min-width: $vf-breakpoint--lg) {
     & > *:last-child {
       position: relative;
     }


### PR DESCRIPTION
With `embl-grid--has-sidebar` the sidebar didn't become a thing until the viewport hit 1300px. This left us with rather long content so we have moved this back to 1024px. In doing so - we have made the sidebar smaller from when it his 1024px to when it gets to 1300px. 

This one is for @filipe-dias 