### PR TITLE
🐛 the one that updates the $global-page-max-width variable so it matches the max-width of 81.25rem

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.1
+
+- updates the `$global-page-max-width` variable so that it's consistent with the page width across components - set to `81.25rem`.
+
 ### 1.4.0
 
 - creates supporting Sass files for new theming design tokens to be used.

--- a/components/vf-sass-config/variables/vf-global-variables.scss
+++ b/components/vf-sass-config/variables/vf-global-variables.scss
@@ -9,7 +9,7 @@ $vf-text-margin--bottom: 16px !default;
 
 // grid variables
 $global-grid-column-gap: 1em !default;
-$global-page-max-width: 76.5em !default;
+$global-page-max-width: 81.25em !default;
 
 // deprecation variables
 $vf-deprecation-warning: 'This component has been deprecated. Consult the component\'s README.md for migration tips.' !default;


### PR DESCRIPTION
When we deprecated `vf-grid-page` and updated the max-width for the 'pages' of a site to 1300px (`81.25rem`) we missed updating this variable that is used in the EBI header and footer widths. 

This changes that. 