### PR TITLE
🐛 the one that simplifies and fixes bug in `embl-grid--has-sidebar`

### DIFF
--- a/components/embl-grid/CHANGELOG.md
+++ b/components/embl-grid/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.0.4
+
+- fixes issue with `auto` and `1fr` doing the opposite with the sidebar.
+
+
 ### 2.0.3
 
 - changes breakpoint for sidebar to be a sidebar from 1024px

--- a/components/embl-grid/embl-grid.scss
+++ b/components/embl-grid/embl-grid.scss
@@ -63,9 +63,9 @@
   --embl-grid:
     var(--embl-grid-module--prime)
     [main-start]
-    auto
+    1fr
     [main-end]
-    minmax(21em, 1fr);
+    21em;
   /* stylelint-enable */
 
   @media (min-width: 846px) and (max-width: 1023px) {
@@ -80,9 +80,9 @@
     --embl-grid:
       var(--embl-grid-module--prime)
       [main-start]
-      auto
+      1fr
       [main-end]
-      minmax(18em, 1fr);
+      18em;
   }
 }
 


### PR DESCRIPTION
There was an issue with the rewrite where we used `auto` and `1fr` in the wrong places which left the 'central' grid column taking only the space of the content -- so if there were few words - it would be really small.

This fixes that 