### PR TITLE
chore: mon-repo-link

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,6 @@
 # PUBLISHING
 
-A reference guide on how to do releases of the VF [monorepo](https://gomonorepo.org)'s tools and components.
+A reference guide on how to do releases of the VF [monorepo](https://www.toptal.com/front-end/guide-to-monorepos)'s tools and components.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `vf-core` is built with:
 - [Yeoman](https://yeoman.io/) to make custom components interactively
 - [Yarn](https://yarnpkg.com/) to install components
 - [Nunjucks](https://mozilla.github.io/nunjucks/templating.html) for component templates
-- [Lerna](https://lerna.js.org/) to publish components to npm as a [mono-repo](https://gomonorepo.org/)
+- [Lerna](https://lerna.js.org/) to publish components to npm as a [mono-repo](https://www.toptal.com/front-end/guide-to-monorepos/)
 - Name-spacing for JavaScript and CSS; more on that in [the coding standards](https://visual-framework.github.io/vf-core/developing/#guidelines)
 
 ## Making use of the VF Core

--- a/tools/vf-component-library/src/site/developing/components/updating-a-component.njk
+++ b/tools/vf-component-library/src/site/developing/components/updating-a-component.njk
@@ -1,6 +1,6 @@
 ---
 title: Updating, versioning a component
-subtitle: "Like the Visual Framework 2.0, components follow [semantic versioning](https://semver.org/) by increasing their full version number every time they have breaking changes." 
+subtitle: "Like the Visual Framework 2.0, components follow [semantic versioning](https://semver.org/) by increasing their full version number every time they have breaking changes."
 intro: "However the version number of components its not tied to the version number of the Visual Framework's `vf-core`; that is:"
 date: 2019-04-09 12:24:50
 layout: layouts/developing.njk
@@ -19,7 +19,7 @@ Other notes and tips on components:
 minimum required minor version of vf-core
 - may indicate any required versions of peer-components in your component's README.md.
     - `vf-component-x`@`2.1.2` requires `vf-component-y`@`^8.1.0`
-- can live as part of the `vf-core` [monorepo](https://gomonorepo.org/)
+- can live as part of the `vf-core` [monorepo](https://www.toptal.com/front-end/guide-to-monorepos/)
     - Interested in adding a component? [Get in touch](https://join.slack.com/t/visual-framework/shared_invite/enQtNDAxNzY0NDg4NTY0LWFhMjEwNGY3ZTk3NWYxNWVjOWQ1ZWE4YjViZmY1YjBkMDQxMTNlNjQ0N2ZiMTQ1ZTZiMGM4NjU5Y2E0MjM3ZGQ) or [make an issue](https://github.com/visual-framework/vf-core/issues/new/choose)
 - read more about [component versioning in this issue](https://github.com/visual-framework/vf-core/issues/119)
 

--- a/tools/vf-core/README.md
+++ b/tools/vf-core/README.md
@@ -34,7 +34,7 @@ The `vf-core` is built with:
 - [Yeoman](https://yeoman.io/) to make custom components interactively
 - [Yarn](https://yarnpkg.com/) to install components
 - [Nunjucks](https://mozilla.github.io/nunjucks/templating.html) for component templates
-- [Lerna](https://lerna.js.org/) to publish components to npm as a [mono-repo](https://gomonorepo.org/)
+- [Lerna](https://lerna.js.org/) to publish components to npm as a [mono-repo](https://www.toptal.com/front-end/guide-to-monorepos/)
 - Name-spacing for JavaScript and CSS; more on that in [the coding standards](https://visual-framework.github.io/vf-welcome/developing/#guidelines)
 
 ## Making use of the VF Core


### PR DESCRIPTION
gomonorepo.org has expired and the project is archived https://github.com/DeprecatedPackages/gomonorepo.org/

We need a new link. In 5 minutes of googling this seemed best. Though I have no strong opinions.