### PR TITLE
🐛 the one where we add `-webkit-appearance: none;` as needed

### DIFF
--- a/components/ebi-header-footer/CHANGELOG.md
+++ b/components/ebi-header-footer/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.1
+
+- adds `webkit-appearance: none;` as needed for Safari browsers as autoprefixer is not doing this.
+
 ### 1.0.0
 
 - EBI Header is once again fullbleed after changes in vf-grid-page 2.0.0

--- a/components/ebi-header-footer/ebi-header-footer--form.scss
+++ b/components/ebi-header-footer/ebi-header-footer--form.scss
@@ -1,83 +1,105 @@
 // ebi-header-footer--footer
 fieldset {
+  border: 0;
   margin: 0;
   padding: 0;
-  border: 0;
 }
 .input-group {
   display: table;
-  width: 100%;
   margin-bottom: 1rem;
-}
-
-[type='text'] { 
-  box-sizing: border-box;
   width: 100%;
-  height: 2.4375rem;
-  padding: 0.5rem;
-  border: 1px solid #777;
-  transition: box-shadow 0.5s, border-color 0.25s ease-in-out;
-  appearance: none;
 }
 
-.input-group-button a, .input-group-button input, .input-group-button button, .input-group-button label {
+[type='text'] {
+  /* stylelint-disable */
+  -webkit-appearance: none;
+  /* stylelint-enable */
+  appearance: none;
+  border: 1px solid #777;
+  box-sizing: border-box;
   height: 2.4375rem;
-  padding-top: 0;
-  padding-bottom: 0;
+  padding: .5rem;
+  transition: box-shadow .5s, border-color .25s ease-in-out;
+  width: 100%;
 }
-.input-group-label, .input-group-field, .input-group-button, .input-group-button a, .input-group-button input, .input-group-button button, .input-group-button label {
-  margin: 0;
-  white-space: nowrap;
+
+.input-group-button a,
+.input-group-button input,
+.input-group-button button,
+.input-group-button label {
+  height: 2.4375rem;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+.input-group-label,
+.input-group-field,
+.input-group-button,
+.input-group-button a,
+.input-group-button input,
+.input-group-button button,
+.input-group-button label {
   display: table-cell;
+  margin: 0;
   vertical-align: middle;
+  white-space: nowrap;
 }
 .input-group-button {
-  padding-top: 0;
+  height: 100%;
   padding-bottom: 0;
+  padding-top: 0;
   text-align: center;
   width: 1%;
-  height: 100%;
 }
-.menu .active > a, .tag, .tabs-title > a:hover, .button, .button.primary {
-  background-color: rgb(0,124,130);
+.menu .active > a,
+.tag,
+.tabs-title > a:hover,
+.button,
+.button.primary {
+  background-color: rgb(0, 124, 130);
 }
 
-.menu a, .menu .button {
-  line-height: 1;
-  text-decoration: none;
+.menu a,
+.menu .button {
   display: block;
-  padding: 0.6rem 1rem;
+  line-height: 1;
+  padding: .6rem 1rem;
+  text-decoration: none;
 }
 
 .button {
-  display: inline-block;
-  vertical-align: middle;
-  padding: 0.85em 1em;
-  border: 1px solid transparent;
-  transition: background-color 0.25s ease-out, color 0.25s ease-out;
-  cursor: pointer;
   background-color: var(--vf-color--blue);
+  border: 1px solid transparent;
   color: var(--vf-ui-color--off-white);
+  cursor: pointer;
+  display: inline-block;
+  padding: .85em 1em;
+  transition: background-color .25s ease-out, color .25s ease-out;
+  vertical-align: middle;
 }
 
-button, input, optgroup, select, textarea {
+button,
+input,
+optgroup,
+select,
+textarea {
   font-family: inherit;
   font-size: 100%;
   line-height: 1.15;
   margin: 0;
 }
 
-.close-button, .close-button.medium {
-  right: 1rem;
-  top: 0.5rem;
+.close-button,
+.close-button.medium {
   font-size: 2em;
   line-height: 1;
+  right: 1rem;
+  top: .5rem;
 }
 
 .close-button {
-  position: absolute;
-  color: #8a8a8a;
-  cursor: pointer;
   background: none;
   border: none;
+  color: #8a8a8a;
+  cursor: pointer;
+  position: absolute;
 }

--- a/components/vf-button/CHANGELOG.md
+++ b/components/vf-button/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.2
+
+- adds `webkit-appearance: none;` as needed for Safari browsers as autoprefixer is not doing this.
+
 ### 1.1.1
 
 - removes the `:hover` text color rule so that it doesn't to white on hover.

--- a/components/vf-button/vf-button.scss
+++ b/components/vf-button/vf-button.scss
@@ -20,7 +20,10 @@ $button-hover-fix: -5px -5px rgba(0, 0, 0, 0);
   @include set-type(text-button--1);
 
   align-self: center;
+  /* stylelint-disable */
+  -webkit-appearance: none;
   appearance: none;
+  /* stylelint-enable */
   backface-visibility: hidden;
   background-color: set-ui-color(vf-ui-color--black);
   background-color: var(--vf-button-background-color, var(--vf-button__color__background--default));

--- a/components/vf-form/vf-form__input/CHANGELOG.md
+++ b/components/vf-form/vf-form__input/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.1
+
+- adds `webkit-appearance: none;` as needed for Safari browsers as autoprefixer is not doing this.
+
 ### 1.0.0
 
 - removes `vf-u-sr-only` as not needed with removal of floatLabel.js

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -12,7 +12,10 @@
 .vf-form__input:not([type='file']) {
   @include set-type(text-body--3, $custom-margin-bottom: 4px);
 
+  /* stylelint-disable */
+  -webkit-appearance: none;
   appearance: none;
+  /* stylelint-enable */
   border-color: set-ui-color(vf-ui-color--grey--light);
   border-radius: 0;
   border-style: solid;
@@ -80,7 +83,10 @@
 }
 
 .vf-form__input .vf-form__select {
+  /* stylelint-disable */
+  ---webkit-appearance: none;
   appearance: none;
+  /* stylelint-enable */
   color: set-color(vf-color--grey--light);
   cursor: pointer;
   position: relative;

--- a/components/vf-form/vf-form__select/CHANGELOG.md
+++ b/components/vf-form/vf-form__select/CHANGELOG.md
@@ -1,10 +1,10 @@
+### 1.0.1
+
+- adds `webkit-appearance: none;` as needed for Safari browsers as autoprefixer is not doing this.
+
 ### 1.0.0-alpha.8
 
 - Version bump only for package @visual-framework/vf-form__select
-
-
-
-
 
 ### 1.0.0-alpha.7
 

--- a/components/vf-form/vf-form__select/vf-form__select.scss
+++ b/components/vf-form/vf-form__select/vf-form__select.scss
@@ -12,7 +12,10 @@
 .vf-form__select {
   @include set-type(text-body--3);
 
+  /* stylelint-disable */
+  --webkit-appearance: none;
   appearance: none;
+  /* stylelint-enable */
   background-color: set-ui-color(vf-ui-color--white);
   background-image: url("data:image/svg+xml,%3Csvg width='12' height='18' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23707372' fill-rule='evenodd'%3E%3Cpath d='M6 0l6 8H0zM6 18l6-8H0z'/%3E%3C/g%3E%3C/svg%3E");
   background-position: right .7em top 50%, 0 0;

--- a/components/vf-form/vf-form__textarea/CHANGELOG.md
+++ b/components/vf-form/vf-form__textarea/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.1
+
+- adds `webkit-appearance: none;` as needed for Safari browsers as autoprefixer is not doing this.
+
 ### 1.0.0
 
 - removes unrequired `vf-u-sr-only` class

--- a/components/vf-form/vf-form__textarea/vf-form__textarea.scss
+++ b/components/vf-form/vf-form__textarea/vf-form__textarea.scss
@@ -12,7 +12,10 @@
 .vf-form__textarea {
   @include set-type(text-body--3);
 
+  /* stylelint-disable */
+  -webkit-appearance: none;
   appearance: none;
+  /* stylelint-enable */
   border: 3px solid set-ui-color(vf-ui-color--grey--light);
   border-radius: 0;
   box-sizing: border-box;

--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.3
+
+- adds `webkit-appearance: none;` as needed for Safari browsers as autoprefixer is not doing this.
+
 ### 1.4.2
 
 - updates the `$global-page-max-width` variable so that it's consistent with the page width across components - set to `81.25rem`.

--- a/components/vf-sass-config/mixins/_button.scss
+++ b/components/vf-sass-config/mixins/_button.scss
@@ -2,7 +2,10 @@
 // @include vf-button();
 
 @mixin vf-button() {
+  /* stylelint-disable */
+  -webkit-appearance: none;
   appearance: none;
+  /* stylelint-enable */
   border: 0;
   cursor: pointer;
   display: inline-block;


### PR DESCRIPTION
There's an issue I cannot get around with autoprefixer not adding the `-webkit` prefix to the `appearance` CSS. This fails on the homepage of the `vf-core` documentation because the browser user agent gives it an `appearance: searchField` so we lose all styling.

💄 adds `-webkit-appearance: none;`
📦 updates relevant changlogs 