### PR TITLE
💄 the one that adds search input type and styles the cancel button

### DIFF
--- a/components/vf-form/vf-form__input/CHANGELOG.md
+++ b/components/vf-form/vf-form__input/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.1.0
+
+- adds `type="search"` form input.
+- styles the cancel button so it uses our icon set and is bigger than user agent default.
+
 ### 1.0.1
 
 - adds `webkit-appearance: none;` as needed for Safari browsers as autoprefixer is not doing this.

--- a/components/vf-form/vf-form__input/vf-form__input.njk
+++ b/components/vf-form/vf-form__input/vf-form__input.njk
@@ -10,6 +10,11 @@
   </div>
 
   <div class="vf-form__item">
+    <label class="vf-form__label" for="search">Search</label>
+    <input type="search" id="search" class="vf-form__input" placeholder="Search">
+  </div>
+
+  <div class="vf-form__item">
     <label class="vf-form__label" for="email">Disabled email</label>
     <input type="email" id="email" class="vf-form__input" disabled placeholder="disabled">
   </div>
@@ -18,7 +23,7 @@
     <p for="text" class="vf-form__label vf-form__label--required"><span class="vf-u-sr-only">field is required.</span> <span class="vf-icon vf-icon--asterick"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>asterick</title><path d="M23.555,8.729a1.505,1.505,0,0,0-1.406-.98H16.062a.5.5,0,0,1-.472-.334L13.405,1.222a1.5,1.5,0,0,0-2.81,0l-.005.016L8.41,7.415a.5.5,0,0,1-.471.334H1.85A1.5,1.5,0,0,0,.887,10.4l5.184,4.3a.5.5,0,0,1,.155.543L4.048,21.774a1.5,1.5,0,0,0,2.31,1.684l5.346-3.92a.5.5,0,0,1,.591,0l5.344,3.919a1.5,1.5,0,0,0,2.312-1.683l-2.178-6.535a.5.5,0,0,1,.155-.543l5.194-4.306A1.5,1.5,0,0,0,23.555,8.729Z"/></svg></span></p>
 
     <input type="text" id="text-invalid" class="vf-form__input" required placeholder="invalid">
-    
+
     <p class="vf-form__helper vf-form__helper--error">You need to fill this out.</p>
   </div>
 </form>

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -171,9 +171,10 @@
   border-color: set-ui-color(vf-ui-color--red);
 }
 
-::-webkit-search-cancel-button {
-  /* stylelint-disable */
-  --webkit-appearance: none;
+/* stylelint-disable */
+// needed because Safari needs the pseudo element to be scoped to the search input type.
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
   appearance: none;
   /* stylelint-enable */
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cdefs%3E%3Cstyle%3E.a%7Bfill:none;stroke:%23000;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px%7D%3C/style%3E%3C/defs%3E%3Cpath class='a' d='M.75 23.249l22.5-22.5M23.25 23.249L.75.749'/%3E%3C/svg%3E");

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -24,6 +24,7 @@
   color: set-color(vf-color--grey--dark);
   display: block;
   padding: 8px 12px;
+  position: relative;
   width: 100%;
 
   &:focus,
@@ -168,4 +169,20 @@
 
 .vf-form__input:invalid {
   border-color: set-ui-color(vf-ui-color--red);
+}
+
+::-webkit-search-cancel-button {
+  /* stylelint-disable */
+  --webkit-appearance: none;
+  appearance: none;
+  /* stylelint-enable */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cdefs%3E%3Cstyle%3E.a%7Bfill:none;stroke:%23000;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px%7D%3C/style%3E%3C/defs%3E%3Cpath class='a' d='M.75 23.249l22.5-22.5M23.25 23.249L.75.749'/%3E%3C/svg%3E");
+  background-position: center right;
+  background-repeat: no-repeat;
+  background-size: 16px;
+  content: '';
+  display: block;
+  height: 1em;
+  position: relative;
+  width: 1em;
 }


### PR DESCRIPTION
💄 adds a 'cancel' button using our icon pack to override browser defaults, where applicable.
💄 adds an example of the `vf-form__input` that is a search input.
📦 updates changelog

![Screenshot 2020-09-15 at 14 58 09](https://user-images.githubusercontent.com/925197/93220742-d163f280-f764-11ea-8474-fca90fd1efff.png)
