### PR TITLE
💄 the one that helps make cards look like cards on a page with a little box shadow.

### DIFF
--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.2.0
+
+- adds a slight box shadow to all card variants to denote that it's something on the page, not 'of the page'.
+- updates the hover box shadow so that it fits with the new box shadow on all cards.
+
 ### 2.1.2
 
 - fixes issue with `vf-card__image` height in safari.

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -16,6 +16,8 @@
   --card-background-color: var(--vf-card-theme-color--background , #{set-ui-color(vf-ui-color--white)});
 
   background-color: var(--card-background-color);
+  /* border: 1px solid var(--vf-card-theme-color--border, var(--card-border-color, #{set-color(vf-grey--lightest)})); */
+  box-shadow: 0 2px 4px rgba(set-color(vf-color--grey--light), .5);
   display: grid;
   grid-template-rows: 288px 1fr;
   position: relative;

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -17,7 +17,7 @@
 
   background-color: var(--card-background-color);
   /* border: 1px solid var(--vf-card-theme-color--border, var(--card-border-color, #{set-color(vf-grey--lightest)})); */
-  box-shadow: 0 2px 4px rgba(set-color(vf-color--grey--light), .5);
+  box-shadow: 0 .125rem .25rem rgba(set-color(vf-color--grey--dark), .5);
   display: grid;
   grid-template-rows: 288px 1fr;
   position: relative;
@@ -67,8 +67,7 @@
       color: currentColor;
       text-decoration: none;
       &::after {
-        box-shadow: 0 0 4px 4px rgba(0, 0, 0, .2);
-        transition-duration: 250ms;
+        box-shadow: 0 0 .125rem .125rem rgba(set-color(vf-color--grey), .75);
       }
     }
   }


### PR DESCRIPTION
- 💄 adds a blurred grey box shadow to all `vf-card` components.
- 💄 updates the box shadow when the card has a link so it matches nicely with the default.
- 📦 updates changelog. 