### PR TITLE
💄 the one that makes `vf-divider` a little more malleable.

### DIFF
--- a/components/_previews/_preview--body.njk
+++ b/components/_previews/_preview--body.njk
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en" class="vf-no-js">
+<head>
+  {% render '@vf-no-js' %}
+  <title>{{ _target.title }} | {{ _config.project.title }}</title>
+
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1, minimum-scale=1" name="viewport">
+
+  {% render '@vf-favicon' %}
+
+  {% if _config.project.environment.local %}
+  <link rel="stylesheet" href="{{ '/css/styles.css' | path }}">
+  {% endif %}
+  {% if _config.project.environment.production %}
+  <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
+  {% endif %}
+  <style>
+  body {
+    padding-top: 1rem !important;
+  }
+  </style>
+</head>
+<body class="vf-body">
+  {{ yield | safe }}
+
+  <script src="{{ '/scripts/scripts.js' | path }}"></script>
+</body>
+</html>

--- a/components/vf-divider/CHANGELOG.md
+++ b/components/vf-divider/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.0.0
+
+- removes the `grid-column: 1 / -1;` rule
+- moves the margin into the `@mixin` available in `vf-sass-config`.
+- adds `--vf-divider--margin-block-end` custom property to allow the overriding the block end margin as needed.
+
 ### 1.0.0 (2019-12-17)
 
 - Initial stable release

--- a/components/vf-divider/README.md
+++ b/components/vf-divider/README.md
@@ -4,7 +4,7 @@
 
 ## About
 
-The `vf-divider` component creates a horizontal dividing line to help separate content into their own container chunks.
+The `vf-divider` component creates a horizontal dividing rule that can help separate containers of content or content inside of their containers.
 
 ## Install
 
@@ -24,4 +24,24 @@ _Make sure you import Sass requirements along with the modules._
 
 ## Usage
 
-The `vf-divider` does not have to be implemented inside it's own grid container and should rely on the parent `vf-body` to fill the width of the page.
+The `vf-divider` component will be the width of if's container. So inside of `<body>` of your page it will be a maximum of 1300px.
+
+```
+<body class="vf-body">
+  <hr class="vf-divider">
+</body>
+```
+
+If you wish to have your `vf-divider` fit the whole width of the screen you can add the `vf-u-fullbleed` utility class along side it:
+
+```
+<hr class="vf-divider | vf-u-fullbleed">
+```
+
+This fills the width of the viewport but gives a inline (left and right) margin.
+
+You can customise the inline (left and right) margin if you wish by using the CSS custom property `--context-margin--inline` on the element:
+
+```
+<hr class="vf-divider | vf-u-fullbleed" style="--context-margin--inline: 2rem;">
+```

--- a/components/vf-divider/vf-divider.config.yml
+++ b/components/vf-divider/vf-divider.config.yml
@@ -1,5 +1,17 @@
 title: Visual Framework Divider
 label: Divider
 status: live
+preview: '@preview--body'
 context:
   component-type: element
+
+
+variants:
+  - name: default
+  - name: fullbleed
+    context:
+      override_class: vf-u-fullbleed
+  - name: fullbleed custom
+    context:
+      override_class: vf-u-fullbleed
+      context_margin__inline: 3rem

--- a/components/vf-divider/vf-divider.njk
+++ b/components/vf-divider/vf-divider.njk
@@ -1,6 +1,10 @@
+{% if context %}
+  {% set id = context.id %}
+  {% set override_class = context.override_class %}
+{% endif %}
+
 <hr
-{# You're using an ID? Really?? That'll go here #}
 {% if id %} id="{{-id-}}"{% endif %}
-{# Here is where we are adding the vf-text--body modifier #}
 class="vf-divider
-{%- if override_class %} | {{override_class}}{% endif -%}">
+{%- if override_class %} | {{override_class}}{% endif -%}"
+{%- if context_margin__inline %} style="--context-margin--inline: {{context_margin__inline}};"{% endif -%}>

--- a/components/vf-divider/vf-divider.scss
+++ b/components/vf-divider/vf-divider.scss
@@ -11,8 +11,4 @@
 
 .vf-divider {
   @include divider;
-
-  grid-column: 1 / -1;
-
-  margin-bottom: 24px;
 }

--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.0.0
+
+- removes the inline margin from the component.
+- adds the block end margin an creates a Sass variable for `$margin--block-end`.
+- adds `width: 100%;` as it was defaulting to `width: auto;`.
+
 ### 1.4.3
 
 - adds `webkit-appearance: none;` as needed for Safari browsers as autoprefixer is not doing this.

--- a/components/vf-sass-config/mixins/_divider.scss
+++ b/components/vf-sass-config/mixins/_divider.scss
@@ -1,9 +1,14 @@
 // Reusable styling for divider elements and styling
 // @include vf-divider;
 
-@mixin divider() {
+@mixin divider($margin--block-end: 1.5rem, $margin--inline: 1rem) {
+  // This custom property is set up ready for you to use if you are using it with
+  // vf-u-fullbleed.
+  --context-margin--inline: #{$margin--inline};
+
   background-color: set-ui-color(vf-ui-color--grey);
-  margin: 0 map-get($vf-spacing-map, vf-spacing--sm);
-  height: 1px;
   border: none;
+  height: 1px;
+  margin-block: 0 var(--vf-divider-margin--block-end, $margin--block-end);
+  width: 100%;
 }

--- a/components/vf-u-fullbleed/CHANGELOG.md
+++ b/components/vf-u-fullbleed/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.2.0
+
+- adds a CSS custom property for when a component with `vf-u-fullbleed` needs inline margins.
+
 ### 1.1.0
 
 - adds functionality that makes it possible to use background images in fullbleeds

--- a/components/vf-u-fullbleed/vf-u-fullbleed.scss
+++ b/components/vf-u-fullbleed/vf-u-fullbleed.scss
@@ -43,10 +43,10 @@
     content: '';
     grid-column: 1 / -1; /* 4 */
     height: 100%; /* 5 */
-    margin-left: calc(50% - 50vw); /* 6 */
+    margin-left: calc(50% - calc(50vw - var(--context-margin--inline, 0px))); /* 6 */
     position: absolute;
     top: 0; /* 7 */
-    width: 100vw; /* 8 */
+    width: calc(100vw - (var(--context-margin--inline, 0px) * 2));
     z-index: set-layer(vf-z-index--negative); /* 9 */
   }
 

--- a/components/vf-u-fullbleed/vf-u-fullbleed.scss
+++ b/components/vf-u-fullbleed/vf-u-fullbleed.scss
@@ -14,10 +14,11 @@
  *  4. if we can a full bleed background inline with other content we need to reset
  *     the grid to fill all that space.
  *  5. make the pseudo element 100% of the element so we can see it.
- *  6. push the pseudo element away from the left of the viewport.
+ *  6. push the pseudo element away from the left of the viewport but allows for potential
+ *     'context customisation'.
  *  7. If the component has vertical padding we need to make sure the pseudo element
  *     is set to the top of the containing box.
- *  8. make the pseudo element full-width.
+ *  8. make the pseudo element full-width but allows for potential 'context customisation'.
  *  9. put the pseudo element 'underneath' the element so it doesn't block.
  * 10. Because Windows always shows scrollbars this technique creats a horizontal
  *     scroll bar, we need to apply position: relative; to a parent element.
@@ -46,7 +47,7 @@
     margin-left: calc(50% - calc(50vw - var(--context-margin--inline, 0px))); /* 6 */
     position: absolute;
     top: 0; /* 7 */
-    width: calc(100vw - (var(--context-margin--inline, 0px) * 2));
+    width: calc(100vw - (var(--context-margin--inline, 0px) * 2)); /* 8 */
     z-index: set-layer(vf-z-index--negative); /* 9 */
   }
 


### PR DESCRIPTION
💄 updates `vf-divider` so it can allow for use alongside `vf-u-fullbleed`.
♻️ refactors `vf-u-fullbleed` so it can work 'as expected' but allow for 'context customisation' as needed from associated components. 
♻️ refactors the `_divider` Sass `@mixin` to allow customisation for inline (left and right) and block end (bottom) margins.
📝 updates `vf-divider` documentation to explain the possibilities `v2.0.0` allows.
📦 updates all the changelogs required. 