### PR TITLE
enhancement: add support for the autofocus attribute

### DIFF
--- a/components/vf-search-client-side/CHANGELOG.md
+++ b/components/vf-search-client-side/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 
-# 1.0.0-alpha.2
+## 1.0.0-alpha.3
+
+* adds support for `autofocus` on search input
+
+## 1.0.0-alpha.2
 
 * Improve documentation
 
-# 1.0.0-alpha.1
+## 1.0.0-alpha.1
 
 * Initial prototype

--- a/components/vf-search-client-side/README.md
+++ b/components/vf-search-client-side/README.md
@@ -66,6 +66,7 @@ And you should build that search index after updating your html pages, a la:
 
 - You can pass a query to the search page with `?search_query=myQuery`
 - The search will live update as the user enters text
+- You can enable `autofocus` on the search element, but should only do so if most users intend to search on the page
 
 ## Install
 

--- a/components/vf-search-client-side/vf-search-client-side.config.yml
+++ b/components/vf-search-client-side/vf-search-client-side.config.yml
@@ -18,7 +18,7 @@ context:
   search_client_action: /vf-core/components/vf-search-client-side/
   search_client_script: /search_index.js
   search_client_results: true
-  search_client_autofocus: true
+  search_client_autofocus: false
   # title: Title text
   # text: String of text
   # image: ../../assets/vf-component-name/assets/vf-component-name.png

--- a/components/vf-search-client-side/vf-search-client-side.config.yml
+++ b/components/vf-search-client-side/vf-search-client-side.config.yml
@@ -1,7 +1,7 @@
 # The title shown on the component page
-title: vf-search-client-side
+title: Search Client Side
 # Label shown on index pages
-label: vf-search-client-side
+label: Search Client Side
 status: alpha
 # The template used from /components/_previews
 #
@@ -18,6 +18,7 @@ context:
   search_client_action: /vf-core/components/vf-search-client-side/
   search_client_script: /search_index.js
   search_client_results: true
+  search_client_autofocus: true
   # title: Title text
   # text: String of text
   # image: ../../assets/vf-component-name/assets/vf-component-name.png

--- a/components/vf-search-client-side/vf-search-client-side.njk
+++ b/components/vf-search-client-side/vf-search-client-side.njk
@@ -2,6 +2,7 @@
   {% set search_client_prompt = context.search_client_prompt %}
   {% set search_client_action = context.search_client_action %}
   {% set search_client_results = context.search_client_results %}
+  {% set search_client_autofocus = context.search_client_autofocus %}
   {% set search_client_button = context.search_client_button %}
   {% set search_client_button_text = context.search_client_button_text %}
   {% set search_client_script = context.search_client_script %}
@@ -15,7 +16,7 @@
 <div class="vf-grid">
   <form action="{{ search_client_action }}" method="GET" class="vf-form | vf-search vf-search--inline">
     <div class="vf-form__item | vf-search__item">
-      <input type="search" id="search" placeholder="{{ search_client_prompt }}" name="search_query" class="vf-form__input | vf-search__input" data-vf-search-client-side-input>
+      <input type="search" id="search" placeholder="{{ search_client_prompt }}" name="search_query" class="vf-form__input | vf-search__input" {%- if search_client_autofocus %} autofocus{%- endif %} data-vf-search-client-side-input>
     </div>
     {%- if search_client_button -%}
     <button type="submit" class="vf-search__button | vf-button vf-button--primary">

--- a/components/vf-search/CHANGELOG.md
+++ b/components/vf-search/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.2
+
+- adds support for `autofocus` on search input
+
 ### 1.1.1
 
 - adds support for default search value

--- a/components/vf-search/README.md
+++ b/components/vf-search/README.md
@@ -2,6 +2,8 @@
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-search.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-search)
 
+- You can enable `autofocus` on the search element, but should only do so if most users intend to search on the page
+
 ## Install
 
 This repository is distributed with [npm][npm]. After [installing npm][install-npm], you can install `primer-buttons` with this command.

--- a/components/vf-search/vf-search.config.yml
+++ b/components/vf-search/vf-search.config.yml
@@ -14,6 +14,7 @@ variants:
     context:
       variant: default
       search_action: '#'
+      search_autofocus: true
       search_button: Search
       search_label: Search
       search_placeholder: Enter your search terms
@@ -25,6 +26,7 @@ variants:
     context:
       variant: inline
       search_action: '#'
+      search_autofocus: true
       search_button: Search
       search_label: Inline search
       search_placeholder: Enter your search terms

--- a/components/vf-search/vf-search.config.yml
+++ b/components/vf-search/vf-search.config.yml
@@ -14,7 +14,7 @@ variants:
     context:
       variant: default
       search_action: '#'
-      search_autofocus: true
+      search_autofocus: false
       search_button: Search
       search_label: Search
       search_placeholder: Enter your search terms
@@ -26,7 +26,7 @@ variants:
     context:
       variant: inline
       search_action: '#'
-      search_autofocus: true
+      search_autofocus: false
       search_button: Search
       search_label: Inline search
       search_placeholder: Enter your search terms

--- a/components/vf-search/vf-search.njk
+++ b/components/vf-search/vf-search.njk
@@ -2,6 +2,7 @@
   {% set search_label = context.search_label %}
   {% set search_button = context.search_button %}
   {% set search_placeholder = context.search_placeholder %}
+  {% set search_autofocus = context.search_autofocus %}
   {% set search_action = context.search_action %}
   {% set search_id = context.search_id %}
   {% set search_value_default = context.search_value_default %}
@@ -19,7 +20,7 @@
   class="vf-form | vf-search{% if variant == 'inline' %} vf-search--inline{% endif %} {%- if override_class %} | {{override_class}}{% endif -%}">
   <div class="vf-form__item | vf-search__item">
     <label class="vf-form__label vf-u-sr-only | vf-search__label" for="{{ search_id }}">{{ search_label }}</label>
-    <input type="search" placeholder="{{ search_placeholder }}" id="{{ search_id }}" {% if search_value_default %} value="{{ search_value_default }}"{% endif %} class="vf-form__input | vf-search__input">
+    <input type="search" placeholder="{{ search_placeholder }}" id="{{ search_id }}" {% if search_value_default %} value="{{ search_value_default }}"{% endif %} class="vf-form__input | vf-search__input"{%- if search_autofocus %} autofocus{%- endif %}>
   </div>
   <button type="submit" class="vf-search__button | vf-button vf-button--primary"> {{ search_button }}</button>
 </form>


### PR DESCRIPTION
For things like embl.org/search it's nice if a user doesn't have to click on the search box. 

Adds support for both vf-search and vf-search-clientside. 

https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/autofocus