### PR TITLE
Enhancement: analytics, add support for not tracking the initial page view

### DIFF
--- a/components/vf-analytics-google/CHANGELOG.md
+++ b/components/vf-analytics-google/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.0-rc.5
+
+* `vfGaIndicateLoaded()` now accepts the options object `vfGaTrackOptions` with property `vfGaTrackPageLoad`. `vfGaTrackOptions.vfGaTrackPageLoad` default to true. If you set to false, the function will _not_ track the initial page view. Useful if you track the initial page view with JavaScript in your HTML.
+
 ### 1.0.0-rc.4
 
 * improve `vfGaLogMessage()` to note type of event being tracked

--- a/components/vf-analytics-google/README.md
+++ b/components/vf-analytics-google/README.md
@@ -41,9 +41,28 @@ Notes:
 
 ### JavaScript
 
-- `vfGaIndicateLoaded()` Awaits and checks to see if Google Analytics client side JS has loaded. If it does, sets `<body data-vf-google-analytics-loaded='true'>`
-- `vfGaIndicateUnloaded` Utility method to invalidate prior GA check `<body data-vf-google-analytics-loaded='false'>`
-- `vfGaTrackInteraction()` can be used to directly track events if you wish to use your own event handler
+#### `vfGaIndicateLoaded()`
+
+Awaits and checks to see if Google Analytics client side JS has loaded. If it does, sets `<body data-vf-google-analytics-loaded='true'>`
+  - `vfGaIndicateLoaded()` now accepts the options object `vfGaTrackOptions` with property `vfGaTrackPageLoad`. `vfGaTrackOptions.vfGaTrackPageLoad` default to true. If you set to false, the function will _not_ track the initial page view. Useful if you track the initial page view with JavaScript in your HTML.
+
+Example:
+
+```js
+let vfGaTrackOptions = {
+  vfGaTrackPageLoad: true
+};
+vfGaIndicateLoaded(vfGaTrackOptions);
+```
+
+#### `vfGaIndicateUnloaded`
+
+Utility method to invalidate prior GA check `<body data-vf-google-analytics-loaded='false'>`
+
+#### `vfGaTrackInteraction()`
+
+Can be used to directly track events if you wish to use your own event handler.
+
 ```js
 /**
  * This code tracks the user's clicks in various parts of the site and logs them as GA events.
@@ -73,10 +92,13 @@ $ yarn add --dev @visual-framework/vf-analytics-google
 You should import this component in `./components/vf-component-rollup/scripts.js` or your other JS process:
 
 ```js
+let vfGaTrackOptions = {
+  vfGaTrackPageLoad: true
+};
 import { vfGaIndicateLoaded } from 'vf-analytics-google/vf-analytics-google';
 // Or import directly
 // import { vfGaIndicateLoaded } from '../components/raw/vf-analytics-google/vf-analytics-google.js';
-vfGaIndicateLoaded();
+vfGaIndicateLoaded(vfGaTrackOptions);
 ```
 
 ### Sass/CSS installation

--- a/components/vf-analytics-google/vf-analytics-google.js
+++ b/components/vf-analytics-google/vf-analytics-google.js
@@ -44,7 +44,7 @@ var lastGaEventTime = Date.now();
  */
 function vfGaIndicateLoaded(vfGaTrackOptions,numberOfGaChecksLimit,numberOfGaChecks,checkTimeout) {
   var vfGaTrackOptions = vfGaTrackOptions || {};
-  vfGaTrackOptions.vfGaTrackPageLoad = vfGaTrackOptions.vfGaTrackPageLoad || true;
+  if (vfGaTrackOptions.vfGaTrackPageLoad == null) vfGaTrackOptions.vfGaTrackPageLoad = true;
   var numberOfGaChecks = numberOfGaChecks || 0;
   var numberOfGaChecksLimit = numberOfGaChecksLimit || 5;
   var checkTimeout = checkTimeout || 900;
@@ -109,7 +109,7 @@ function vfGetMeta(metaName) {
  */
 function vfGaInit(vfGaTrackOptions) {
   var vfGaTrackOptions = vfGaTrackOptions || {};
-  vfGaTrackOptions.vfGaTrackPageLoad = vfGaTrackOptions.vfGaTrackPageLoad || true;
+  if (vfGaTrackOptions.vfGaTrackPageLoad == null) vfGaTrackOptions.vfGaTrackPageLoad = true;
 
   // Need help
   // How to add dimension to your property
@@ -131,7 +131,7 @@ function vfGaInit(vfGaTrackOptions) {
   }
 
   // standard google analytics bootstrap
-  if (vfGaTrackPageLoad) {
+  if (vfGaTrackOptions.vfGaTrackPageLoad) {
     ga('send', 'pageview');
   }
 

--- a/components/vf-analytics-google/vf-analytics-google.js
+++ b/components/vf-analytics-google/vf-analytics-google.js
@@ -32,10 +32,19 @@ var lastGaEventTime = Date.now();
 /**
  * We poll the document until we find GA has loaded, or we've tried a few times.
  * Port of https://github.com/ebiwd/EBI-Framework/blob/v1.3/js/foundationExtendEBI.js#L4
+ * @param {object} [vfGaTrackOptions]
+ * @param {binary} [vfGaTrackOptions.vfGaTrackPageLoad=true] If true, the function will track the initial page view. Set this to false if you track the page view in your HTML.
  * @param {number} [numberOfGaChecksLimit=2]
  * @param {number} [checkTimeout=900]
+ * @example
+ * let vfGaTrackOptions = {
+ *  vfGaTrackPageLoad: true
+ * };
+ * vfGaIndicateLoaded(vfGaTrackOptions);
  */
-function vfGaIndicateLoaded(numberOfGaChecksLimit,numberOfGaChecks,checkTimeout) {
+function vfGaIndicateLoaded(vfGaTrackOptions,numberOfGaChecksLimit,numberOfGaChecks,checkTimeout) {
+  var vfGaTrackOptions = vfGaTrackOptions || {};
+  vfGaTrackOptions.vfGaTrackPageLoad = vfGaTrackOptions.vfGaTrackPageLoad || true;
   var numberOfGaChecks = numberOfGaChecks || 0;
   var numberOfGaChecksLimit = numberOfGaChecksLimit || 5;
   var checkTimeout = checkTimeout || 900;
@@ -53,18 +62,18 @@ function vfGaIndicateLoaded(numberOfGaChecksLimit,numberOfGaChecks,checkTimeout)
 
     if (ga && ga.loaded) {
       el.setAttribute('data-vf-google-analytics-loaded', 'true');
-      vfGaInit();
+      vfGaInit(vfGaTrackOptions);
     } else {
       if (numberOfGaChecks <= numberOfGaChecksLimit) {
         setTimeout(function () {
-          vfGaIndicateLoaded(numberOfGaChecksLimit,numberOfGaChecks,checkTimeout);
+          vfGaIndicateLoaded(vfGaTrackOptions,numberOfGaChecksLimit,numberOfGaChecks,checkTimeout);
         }, 900); // give a second check if GA was slow to load
       }
     }
   } catch (err) {
     if (numberOfGaChecks <= numberOfGaChecksLimit) {
       setTimeout(function () {
-        vfGaIndicateLoaded(numberOfGaChecksLimit,numberOfGaChecks,checkTimeout);
+        vfGaIndicateLoaded(vfGaTrackOptions,numberOfGaChecksLimit,numberOfGaChecks,checkTimeout);
       }, 900); // give a second check if GA was slow to load
     }
   }
@@ -95,8 +104,12 @@ function vfGetMeta(metaName) {
 
 /**
  * Hooks into common analytics tracking
+ * @param {object} [vfGaTrackOptions]
+ * @param {binary} [vfGaTrackOptions.vfGaTrackPageLoad=true] If true, the function will track the initial page view. Set this to false if you track the page view in your HTML.
  */
-function vfGaInit() {
+function vfGaInit(vfGaTrackOptions) {
+  var vfGaTrackOptions = vfGaTrackOptions || {};
+  vfGaTrackOptions.vfGaTrackPageLoad = vfGaTrackOptions.vfGaTrackPageLoad || true;
 
   // Need help
   // How to add dimension to your property
@@ -118,8 +131,9 @@ function vfGaInit() {
   }
 
   // standard google analytics bootstrap
-  // @todo: add conditional
-  ga('send', 'pageview');
+  if (vfGaTrackPageLoad) {
+    ga('send', 'pageview');
+  }
 
   // If we want to send metrics in one go
   // ga('set', {

--- a/components/vf-componenet-rollup/scripts.js
+++ b/components/vf-componenet-rollup/scripts.js
@@ -14,7 +14,10 @@ import { vfMastheadSetStyle } from 'vf-masthead/vf-masthead';
 vfMastheadSetStyle();
 
 import { vfGaIndicateLoaded } from 'vf-analytics-google/vf-analytics-google';
-vfGaIndicateLoaded();
+let vfGaTrackOptions = {
+  vfGaTrackPageLoad: true
+};
+vfGaIndicateLoaded(vfGaTrackOptions);
 
 import { vfTabs } from 'vf-tabs/vf-tabs';
 vfTabs();


### PR DESCRIPTION
`vfGaIndicateLoaded()` now accepts the options object `vfGaTrackOptions` with property `vfGaTrackPageLoad`. `vfGaTrackOptions.vfGaTrackPageLoad` default to true. If you set to false, the function will _not_ track the initial page view. Useful if you track the initial page view with JavaScript in your HTML.

Particuarly of use for WP sites where plugins try to manage the inital page load.