### PR TITLE
chore: vf-banner-log-cleanup

### DIFF
--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.5.1
+
+- removes leftover `console.log`
+
 ### 1.5.0
 
 - centralises logic to "close" a banner

--- a/components/vf-banner/vf-banner.js
+++ b/components/vf-banner/vf-banner.js
@@ -41,7 +41,6 @@ function vfBannerClose(targetBanner) {
     }
     if (targetBanner.classList.contains("vf-banner--bottom")) {
       var pagePadding = document.body.style.paddingBottom.replace(/\D/g,'') || 0;
-      console.log(pagePadding, height)
       pagePadding = pagePadding - height;
       document.body.style.paddingBottom = pagePadding+'px';
     }


### PR DESCRIPTION
removes leftover `console.log`