### PR TITLE
bug: vf-hero css typo

### DIFF
--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -25,7 +25,7 @@
   grid-column: 1 / -1;
 
   display: grid;
-  grid-template-columns: minmax(var(--page-grid-gap), auto) [hero-start] minmax(288px, $vf-layout--comfortable)) [hero-end] minmax(var(--page-grid-gap), auto);
+  grid-template-columns: minmax(var(--page-grid-gap), auto) [hero-start] minmax(288px, $vf-layout--comfortable) [hero-end] minmax(var(--page-grid-gap), auto);
   grid-template-rows: calc(var(--vf-hero-grid__row--initial, var(--vf-hero-grid__row--initial, 260px)) * var(--vf-hero-grid-row--multiplier, .4)) max-content;
   margin-bottom: 2rem;
   position: relative;


### PR DESCRIPTION
@sturobson one for your review looks like there's an extra `)` in this bit of CSS. Was stopping the `gulp vf-core:prepare-deploy` and I suspect not doing what was intended.

No need for new changelog as we've not yet push to npm