### PR TITLE
feature: vf-ga network support

### DIFF
--- a/components/vf-analytics-google/CHANGELOG.md
+++ b/components/vf-analytics-google/CHANGELOG.md
@@ -1,6 +1,10 @@
 ### 1.0.0-rc.5
 
-* `vfGaIndicateLoaded()` now accepts the options object `vfGaTrackOptions` with property `vfGaTrackPageLoad`. `vfGaTrackOptions.vfGaTrackPageLoad` default to true. If you set to false, the function will _not_ track the initial page view. Useful if you track the initial page view with JavaScript in your HTML.
+* `vfGaIndicateLoaded()` now accepts the options object `vfGaTrackOptions`
+* with property `vfGaTrackPageLoad`. `vfGaTrackOptions.vfGaTrackPageLoad` defaults to true. If you set to false, the function will _not_ track the initial page view. Useful if you track the initial page view with JavaScript in your HTML.
+  * https://github.com/visual-framework/vf-core/issues/1116
+* Track the users network: `vfGaTrackOptions.vfGaTrackNetwork`. As of February 2020 Google Analytics no longer tracks the network name of visitors. A 3rd party tool enables this, follow the setup guide at https://ipmeta.io/instructions (note there is no need to load https://ipmeta.io/plugin.js, this component includes it for you)
+  * https://github.com/visual-framework/vf-core/issues/968
 
 ### 1.0.0-rc.4
 
@@ -10,7 +14,11 @@
 ### 1.0.0-rc.3
 
 * documentation cleanup
-* `analyticsTrackInteraction()` is now namespaced as `vfGaTrackInteraction()`
+* `analyticsTrackInteraction()` is now namespaceTrack the users network: `vfGaTrackOptions.vfGaTrackNetwork`
+  - As of February 2020 Google Analytics no longer tracks the network name of visitors
+  - A 3rd party tool enables this, follow the setup guide at https://ipmeta.io/instructions
+    - note there is no need to load https://ipmeta.io/plugin.js, this component includes it for you
+  - After configuring your property in Google Analtyics, add the configuration belowd as `vfGaTrackInteraction()`
 * `vfGaTrackInteraction()` now documented for direct usage
 * Fix console verbose logging: if set to any value it would pass
   * https://github.com/visual-framework/vf-core/issues/1131

--- a/components/vf-analytics-google/README.md
+++ b/components/vf-analytics-google/README.md
@@ -21,9 +21,9 @@ How to add dimension to your property?
 - https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets
 - https://support.google.com/analytics/answer/2709829?hl=en
 
-### Region tracking
+### Page region tracking
 
-You can track the region of the page a link is in:
+You can track the region of the page where an event occurs:
 
 ```html
 <div data-vf-google-analytics-region="main-content-area-OR-SOME-OTHER-NAME">
@@ -41,9 +41,25 @@ Notes:
 
 ### JavaScript
 
-#### vfGaIndicateLoaded()
+You should import this component in `./components/vf-component-rollup/scripts.js` or your other JS process:
 
-Awaits and checks to see if Google Analytics client side JS has loaded. If it does, sets `<body data-vf-google-analytics-loaded='true'>`
+```js
+import { vfGaIndicateLoaded } from 'vf-analytics-google/vf-analytics-google';
+// Or import directly
+// import { vfGaIndicateLoaded } from '../components/raw/vf-analytics-google/vf-analytics-google.js';
+
+let vfGaTrackOptions = {
+  vfGaTrackPageLoad: true,
+  vfGaTrackNetwork: {
+    serviceProvider: 'dimension2',
+    networkDomain: 'dimension3',
+    networkType: 'dimension4'
+  }
+};
+vfGaIndicateLoaded(vfGaTrackOptions);
+```
+
+`vfGaIndicateLoaded()` is the primary function and awaits and checks to see if Google Analytics client side JS has loaded. If it does, sets `<body data-vf-google-analytics-loaded='true'>`
 
 #### Options
 
@@ -56,20 +72,6 @@ Awaits and checks to see if Google Analytics client side JS has loaded. If it do
   - A 3rd party tool enables this, follow the setup guide at https://ipmeta.io/instructions
     - note there is no need to load https://ipmeta.io/plugin.js, this component includes it for you
   - After configuring your property in Google Analytics, add the configuration below
-
-Example:
-
-```js
-let vfGaTrackOptions = {
-  vfGaTrackPageLoad: true,
-  vfGaTrackNetwork: {
-    serviceProvider: 'dimension2',
-    networkDomain: 'dimension3',
-    networkType: 'dimension4'
-  }
-};
-vfGaIndicateLoaded(vfGaTrackOptions);
-```
 
 #### vfGaIndicateUnloaded()
 
@@ -101,20 +103,6 @@ This repository is distributed with [npm][npm]. After [installing npm][install-n
 
 ```
 $ yarn add --dev @visual-framework/vf-analytics-google
-```
-
-### Javascript installation
-
-You should import this component in `./components/vf-component-rollup/scripts.js` or your other JS process:
-
-```js
-let vfGaTrackOptions = {
-  vfGaTrackPageLoad: true
-};
-import { vfGaIndicateLoaded } from 'vf-analytics-google/vf-analytics-google';
-// Or import directly
-// import { vfGaIndicateLoaded } from '../components/raw/vf-analytics-google/vf-analytics-google.js';
-vfGaIndicateLoaded(vfGaTrackOptions);
 ```
 
 ### Sass/CSS installation

--- a/components/vf-analytics-google/README.md
+++ b/components/vf-analytics-google/README.md
@@ -41,25 +41,41 @@ Notes:
 
 ### JavaScript
 
-#### `vfGaIndicateLoaded()`
+#### vfGaIndicateLoaded()
 
 Awaits and checks to see if Google Analytics client side JS has loaded. If it does, sets `<body data-vf-google-analytics-loaded='true'>`
-  - `vfGaIndicateLoaded()` now accepts the options object `vfGaTrackOptions` with property `vfGaTrackPageLoad`. `vfGaTrackOptions.vfGaTrackPageLoad` default to true. If you set to false, the function will _not_ track the initial page view. Useful if you track the initial page view with JavaScript in your HTML.
+
+#### Options
+
+`vfGaIndicateLoaded()` accepts these options for object `vfGaTrackOptions`:
+
+- Do not track the page load: `vfGaTrackOptions.vfGaTrackPageLoad` (defaults to true).
+  - If you set to false, the function will _not_ track the initial page view. Useful if you track the initial page view with JavaScript in your HTML.
+- Track the users network: `vfGaTrackOptions.vfGaTrackNetwork`
+  - As of February 2020 Google Analytics no longer tracks the network name of visitors
+  - A 3rd party tool enables this, follow the setup guide at https://ipmeta.io/instructions
+    - note there is no need to load https://ipmeta.io/plugin.js, this component includes it for you
+  - After configuring your property in Google Analtyics, add the configuration below
 
 Example:
 
 ```js
 let vfGaTrackOptions = {
-  vfGaTrackPageLoad: true
+  vfGaTrackPageLoad: true,
+  vfGaTrackNetwork: {
+    serviceProvider: 'dimension2',
+    networkDomain: 'dimension3',
+    networkType: 'dimension4'
+  }
 };
 vfGaIndicateLoaded(vfGaTrackOptions);
 ```
 
-#### `vfGaIndicateUnloaded`
+#### vfGaIndicateUnloaded()
 
 Utility method to invalidate prior GA check `<body data-vf-google-analytics-loaded='false'>`
 
-#### `vfGaTrackInteraction()`
+#### vfGaTrackInteraction()
 
 Can be used to directly track events if you wish to use your own event handler.
 

--- a/components/vf-analytics-google/README.md
+++ b/components/vf-analytics-google/README.md
@@ -55,7 +55,7 @@ Awaits and checks to see if Google Analytics client side JS has loaded. If it do
   - As of February 2020 Google Analytics no longer tracks the network name of visitors
   - A 3rd party tool enables this, follow the setup guide at https://ipmeta.io/instructions
     - note there is no need to load https://ipmeta.io/plugin.js, this component includes it for you
-  - After configuring your property in Google Analtyics, add the configuration below
+  - After configuring your property in Google Analytics, add the configuration below
 
 Example:
 

--- a/components/vf-analytics-google/vf-analytics-google.js
+++ b/components/vf-analytics-google/vf-analytics-google.js
@@ -39,6 +39,11 @@ var lastGaEventTime = Date.now();
  * @example
  * let vfGaTrackOptions = {
  *  vfGaTrackPageLoad: true
+ *  vfGaTrackNetwork: {
+ *    serviceProvider: 'dimension2',
+ *    networkDomain: 'dimension3',
+ *    networkType: 'dimension4'
+ *  }
  * };
  * vfGaIndicateLoaded(vfGaTrackOptions);
  */
@@ -128,6 +133,43 @@ function vfGaInit(vfGaTrackOptions) {
     var dimension = toLog[1];
     var pageTypeName = toLog[0];
     ga('set', dimension, pageTypeName);
+  }
+
+  // If you want to track the network of visitors be sure to
+  // - follow the setup guide at https://ipmeta.io/instructions
+  // - view the directions in README.md
+  if (vfGaTrackOptions.vfGaTrackNetwork != null) {
+    // a copy of https://ipmeta.io/plugin.js
+    // included here to simplify usage and reduce external requests
+    function providePlugin(pluginName,pluginConstructor){var ga=window[window.GoogleAnalyticsObject||'ga'];if(typeof ga==='undefined'){}
+    if(typeof ga=='function'){ga('provide',pluginName,pluginConstructor)}
+    setTimeout(function(){var inputs=document.querySelectorAll('input');if(inputs){for(var i=0;i<inputs.length;i++){inputs[i].addEventListener('blur',riskCheck)}}},750)}
+    function provideGtagPlugin(config){var i=0;var timer=setInterval(function(){++i;var gtag=window.gtag;if(typeof gtag!=="undefined"||i===5){Window.IpMeta=new IpMeta(gtag,config);Window.IpMeta.loadGtagNetworkFields();clearInterval(timer)}},500)}
+    function provideGtmPlugin(config){Window.IpMeta=new IpMeta([],config);Window.IpMeta.loadGtmNetworkFields();return[]}
+    function rc(d){var xhr=new XMLHttpRequest;xhr.open("POST",'https://risk.ipmeta.io/check',!0);xhr.setRequestHeader('Content-Type','application/json');xhr.send(JSON.stringify({assoc:d,}))}
+    function riskCheck(e){input=e.srcElement.value;if(/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(input)){var domain=input.replace(/.*@/,"");rc(encr(domain))}}
+    var IpMeta=function(tracker,config){this.tracker=tracker;this.nameDimension=config.serviceProvider||config.nameDimension||'dimension1';this.domainDimension=config.networkDomain||config.domainDimension||'dimension2';this.typeDimension=config.networkType||config.typeDimension||'dimension3';this.gtmEventKey=config.gtmEventKey||'pageview';this.isLocal=config.local||!1;this.apiKey=config.apiKey;this.isDebug=config.debug};IpMeta.prototype.loadNetworkFields=function(){if(typeof Window.IpMeta==='undefined'){Window.IpMeta=this}
+    this.debugMessage('Loading network field parameters');enrichNetwork(this.apiKey,this.isLocal,function(fields,wasAsync){var wasAsync=wasAsync||!1;var nameValue=fields.name||'(not set)';var domainValue=fields.domain||'(not set)';var typeValue=fields.type||'(not set)';if(nameValue){Window.IpMeta.tracker.set(Window.IpMeta.nameDimension,nameValue);Window.IpMeta.debugMessage('Loaded network name: '+nameValue+' into '+Window.IpMeta.nameDimension)}
+    if(domainValue){Window.IpMeta.tracker.set(Window.IpMeta.domainDimension,domainValue);Window.IpMeta.debugMessage('Loaded network domain: '+domainValue+' into '+Window.IpMeta.domainDimension)}
+    if(typeValue){Window.IpMeta.tracker.set(Window.IpMeta.typeDimension,typeValue);Window.IpMeta.debugMessage('Loaded network type: '+typeValue+' into '+Window.IpMeta.typeDimension)}
+    if(wasAsync){Window.IpMeta.tracker.send('event','IpMeta','Enriched','IpMeta Enriched',{nonInteraction:!0})}})};IpMeta.prototype.setGtagMapping=function(fields){var nameValue=fields.name||'(not set)';var domainValue=fields.domain||'(not set)';var typeValue=fields.type||'(not set)';var mapping={};mapping[this.nameDimension]=nameValue;mapping[this.domainDimension]=domainValue;mapping[this.typeDimension]=typeValue;mapping.non_interaction=!0;Window.IpMeta.tracker('event','ipmeta_event',mapping)};IpMeta.prototype.loadGtagNetworkFields=function(){if(typeof Window.IpMeta==='undefined'){Window.IpMeta=this}
+    this.debugMessage('Loading network field parameters');enrichNetwork(this.apiKey,this.isLocal,function(fields,wasAsync){wasAsync=wasAsync||!1;Window.IpMeta.setGtagMapping(fields)})};IpMeta.prototype.loadGtmNetworkFields=function(){if(typeof Window.IpMeta==='undefined'){Window.IpMeta=this}
+    this.debugMessage('Loading network field parameters');var eventKey=this.gtmEventKey;enrichNetwork(this.apiKey,this.isLocal,function(fields,wasAsync){wasAsync=wasAsync||!1;var nameValue=fields.name||'(not set)';var domainValue=fields.domain||'(not set)';var typeValue=fields.type||'(not set)';var dataLayerObj={};dataLayerObj.event=eventKey;dataLayerObj.nameValue=nameValue;dataLayerObj.domainValue=domainValue;dataLayerObj.typeValue=typeValue;window.dataLayer=window.dataLayer||[];window.dataLayer.push(dataLayerObj)})};IpMeta.prototype.setDebug=function(enabled){this.isDebug=enabled};IpMeta.prototype.debugMessage=function(message){if(!this.isDebug)return;if(console)console.debug(message)};function enrichNetwork(key,local,callback){local=local||!1;storageKey=key+"ipmetaNetworkResponse";if(sessionStorage.getItem(storageKey)!==null){callback(JSON.parse(sessionStorage.getItem(storageKey)),!1);return}
+    var request=new XMLHttpRequest();var pl='h='+encodeURI(window.location.hostname);if(key){pl+='&k='+key}
+    var endpoint='https://ipmeta.io/api/enrich';if(local){endpoint='http://ipmeta.test/api/enrich'}
+    request.open('POST',endpoint,!0);request.setRequestHeader('Content-type','application/x-www-form-urlencoded');request.setRequestHeader('Accept','application/json');request.send(pl);request.onreadystatechange=function(){if(request.readyState==XMLHttpRequest.DONE){if(request.status===200){sessionStorage.setItem(storageKey,request.responseText);callback(JSON.parse(request.responseText),!0);return}
+    if(request.status===429){console.error(JSON.parse(request.responseText)[0]);return!1}
+    console.error('IpMeta lookup failed.  Returned status of '+request.status);return!1}}}
+    function encr(str){return'IPM'+btoa(btoa('bf2414cd32581225a82cc4fb46c67643'+btoa(str))+'dde9caf18a8fc7d8187f3aa66da8c6bb')}
+    providePlugin('ipMeta',IpMeta);
+
+    // Track the network
+    ga('require', 'ipMeta', {
+      serviceProvider: vfGaTrackOptions.vfGaTrackNetwork.serviceProvider,
+      networkDomain: vfGaTrackOptions.vfGaTrackNetwork.networkDomain,
+      networkType: vfGaTrackOptions.vfGaTrackNetwork.networkType
+    });
+    ga('ipMeta:loadNetworkFields');
   }
 
   // standard google analytics bootstrap

--- a/components/vf-analytics-google/vf-analytics-google.js
+++ b/components/vf-analytics-google/vf-analytics-google.js
@@ -138,6 +138,7 @@ function vfGaInit(vfGaTrackOptions) {
   // If you want to track the network of visitors be sure to
   // - follow the setup guide at https://ipmeta.io/instructions
   // - view the directions in README.md
+  // note: this feature may be broken out as a seperate dependency if the code size needs to grow further
   if (vfGaTrackOptions.vfGaTrackNetwork != null) {
     // a copy of https://ipmeta.io/plugin.js
     // included here to simplify usage and reduce external requests


### PR DESCRIPTION
For #968


- Track the users network: `vfGaTrackOptions.vfGaTrackNetwork`
  - As of February 2020 Google Analytics no longer tracks the network name of visitors
  - A 3rd party tool enables this, follow the setup guide at https://ipmeta.io/instructions
    - note there is no need to load https://ipmeta.io/plugin.js, this component includes it for you
  - After configuring your property in Google Analytics, add the configuration below

```js
let vfGaTrackOptions = {
  vfGaTrackPageLoad: true,
  vfGaTrackNetwork: {
    serviceProvider: 'dimension2',
    networkDomain: 'dimension3',
    networkType: 'dimension4'
  }
};
vfGaIndicateLoaded(vfGaTrackOptions);
```
