### PR TITLE
Enhancement: echo component generation time

### DIFF
--- a/components/vf-componenet-rollup/CHANGELOG.md
+++ b/components/vf-componenet-rollup/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.2.1
+
+* adds `buildTimeStamp` from `componentInfo` to Sass template
+  * https://github.com/visual-framework/vf-core/issues/974
+
 ### 1.1.4
 
 - dependency bump

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -11,6 +11,7 @@
  * Version: #{map-get($componentInfo, 'version')}
  * Location: #{map-get($componentInfo, 'location')}
  * VF Core version in use: #{map-get($componentInfo, 'vfCoreVersion')}
+ * Build time: #{map-get($componentInfo, 'buildTimeStamp')}
  */
 
 @import 'vf-sass-config/index.scss';

--- a/tools/vf-component-generator/CHANGELOG.md
+++ b/tools/vf-component-generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.3
+
+* adds `buildTimeStamp` from `componentInfo` to Sass template
+  * https://github.com/visual-framework/vf-core/issues/974
+
 ### 1.0.2
 
 * move vf-component-generator gulp tasks into this project

--- a/tools/vf-component-generator/templates/_component.scss
+++ b/tools/vf-component-generator/templates/_component.scss
@@ -15,6 +15,7 @@
  * Component: #{map-get($componentInfo, 'name')}
  * Version: #{map-get($componentInfo, 'version')}
  * Location: #{map-get($componentInfo, 'location')}
+ * Build time: #{map-get($componentInfo, 'buildTimeStamp')}
  */
 <% } -%>
 

--- a/tools/vf-core/CHANGELOG.md
+++ b/tools/vf-core/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 2.2.7
+
+- adds `buildTimeStamp` to `componentInfo` component sass map
+  - https://github.com/visual-framework/vf-core/issues/974
+
+### 2.2.7
+
+- dependency bump
+
 ### 2.2.6
 
 - dependency bump

--- a/tools/vf-core/gulp-tasks/vf-css.js
+++ b/tools/vf-core/gulp-tasks/vf-css.js
@@ -51,7 +51,8 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
              name: "` + name + `",
              version: "` + version + `",
              location: "` + location + `",
-             vfCoreVersion: "` + global.vfVersion + `"
+             vfCoreVersion: "` + global.vfVersion + `",
+             buildTimeStamp: "` + new Date().toUTCString() + `"
           );`
 
           done(null, output);


### PR DESCRIPTION
This addresses #974 so that we get:

```css
/*! Component: @visual-framework/vf-componenet-rollup
 * Version: 1.2.0
 * Location: components/vf-componenet-rollup
 * VF Core version in use: 2.2.7
 * Build time: Mon, 19 Oct 2020 07:53:11 GMT
 */
```

It adds support in vf-core, the component generator and the vf-component-rollup. To do the reaminder of the components, this line will needto be added to each component's Sass file:

```
 * Build time: #{map-get($componentInfo, 'buildTimeStamp')}
```

Which will of course bump all the versions, perhaps best saved for a less busy time.