### PR TITLE
Fix: fractal bootstrap

### DIFF
--- a/tools/vf-component-initialization/CHANGELOG.md
+++ b/tools/vf-component-initialization/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.1
+
+* Pin dependencies
+
 ### 1.0.0
 
-- Initial release to be used with vf-core 2.2.0
+* Initial release to be used with vf-core 2.2.0

--- a/tools/vf-component-initialization/CHANGELOG.md
+++ b/tools/vf-component-initialization/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.1
 
-* Pin dependencies
+* Pin dependencies to avoid issue with Fractal bootstrap
+  * https://github.com/visual-framework/vf-core/pull/1170
 
 ### 1.0.0
 

--- a/tools/vf-component-initialization/package.json
+++ b/tools/vf-component-initialization/package.json
@@ -17,8 +17,8 @@
   ],
   "private": false,
   "dependencies": {
-    "@frctl/fractal": "^1.2.1",
-    "@frctl/nunjucks": "^2.0.1"
+    "@frctl/fractal": "1.3.0",
+    "@frctl/nunjucks": "2.0.4"
   },
   "author": "Ken Hawkins <ken.hawkins@embl.de>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fractal published `1.4.0` 5 days ago which resulted in an issue with the way the fractal themes are loaded, this pins the dependencies to avoid the failure. Root cause would need further investigation. Not sure if a bug on our end or theirs.

- https://www.npmjs.com/package/@frctl/fractal
- https://github.com/frctl/fractal/releases/tag/%40frctl%2Ffractal%401.4.0

```bash
(node:70363) UnhandledPromiseRejectionWarning: Error: Fractal themes must inherit from the base Theme class.
    at Web._loadTheme (/Users/khawkins/Documents/GitHub/vf-core/tools/vf-core/node_modules/@frctl/web/src/web.js:76:19)
    at Web.builder (/Users/khawkins/Documents/GitHub/vf-core/tools/vf-core/node_modules/@frctl/web/src/web.js:37:28)
    at Object.initialize (/Users/khawkins/Documents/GitHub/vf-core/tools/vf-core/fractal.js:155:35)
    at /Users/khawkins/Documents/GitHub/vf-core/tools/vf-core/gulp-tasks/vf-fractal.js:16:30
    at new Promise (<anonymous>)
    at startFractal (/Users/khawkins/Documents/GitHub/vf-core/tools/vf-core/gulp-tasks/vf-fractal.js:14:12)
    at /Users/khawkins/Documents/GitHub/vf-core/tools/vf-core/gulp-tasks/vf-fractal.js:31:5
    at vf-fractal:build (/Users/khawkins/Documents/GitHub/vf-core/tools/vf-core/node_modules/undertaker/lib/set-task.js:13:15)
    at bound (domain.js:426:14)
    at runBound (domain.js:439:12)
    at asyncRunner (/Users/khawkins/Documents/GitHub/vf-core/tools/vf-core/node_modules/async-done/index.js:55:18)
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
(node:70363) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:70363) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```