### PR TITLE
📝 the one that updates the design tokens documentation pages

### DIFF
--- a/components/vf-design-tokens/CHANGELOG.md
+++ b/components/vf-design-tokens/CHANGELOG.md
@@ -1,6 +1,10 @@
+### 2.1.0
+
+- update documentation pages for all design tokens used to make use of updated CSS.
+
 ### 2.0.0
 
-- updates all spacing variables to use numbers for sizing. 
+- updates all spacing variables to use numbers for sizing.
 
 ### 1.3.1
 

--- a/components/vf-design-tokens/README.md
+++ b/components/vf-design-tokens/README.md
@@ -2,6 +2,21 @@
 
 These are the colour, typography, spacing, and other stylistic decisions as design tokens for consumption
 
+The Design Tokens used within `vf-core` are generated from several `.yml` files. These are then compiled into various Sass files as needed.
+
+
+In the future we hope to offer Sketch and Photoshop colour palettes.
+
+
+If you required a different format (LESS, iOS, Android). Please get in touch.
+
+
+> Design tokens are the visual design atoms of the design system — specifically, they are named entities that store visual design attributes. We use them in place of hard-coded values (such as hex values for color or pixel values for spacing) in order to maintain a scalable and consistent visual system for UI development.
+
+> — Salesforce, Lightning Design System.
+
+
+
 ## Building
 
 To update these run `gulp vf-tokens` from `./components/vf-design-tokens`.

--- a/components/vf-design-tokens/vf-design-tokens--breakpoints.njk
+++ b/components/vf-design-tokens/vf-design-tokens--breakpoints.njk
@@ -9,14 +9,14 @@
 
 
   <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
-    <h3>{{ item.meta.friendlyName }}</h3>
+    <h3 class="vf-card__title">{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
-    <p>Sass:</p>
-      <p>{{ item.meta.sassVariable }}</p>
+    <p class="vf-card__text">Sass:</p>
+      <p class="vf-card__text"><code>{{ item.meta.sassVariable }}</code></p>
     {% if item.meta.comment %}
     <hr class="vf-divider">
       <h4>notes:</h4>
-      <p>
+      <p class="vf-card__text">
         {{ item.meta.comment }}
       </p>
     {% endif %}

--- a/components/vf-design-tokens/vf-design-tokens--breakpoints.njk
+++ b/components/vf-design-tokens/vf-design-tokens--breakpoints.njk
@@ -1,108 +1,22 @@
-<style>
-/* vf-swatches might one day be a component, but for now it's CSS we'll just use for the design token demonstration */
-.vf-swatches {
-  grid-row-gap: 32px;
-  margin: 48px 0;
-}
-.vf-swatch {
-  border: 1px solid #d0d0ce;
-  display: grid;
-  grid-template-rows: 160px 1fr;
-}
-
-.vf-swatch__details {
-  padding: 16px;
-  border-top: 1px solid #d0d0ce;
-}
-.vf-swatch:nth-of-type(6),
-.vf-swatch:nth-of-type(11) {
-  grid-column-start: 1;
-}
-.vf-swatch__colour {
-  /* margin: 16px;
-  height: calc(100% - 32px);
-  width: calc(100% - 32px); */
-  height: 100%;
-  width: 100%;
-}
-.vf-swatch__colour-name {
-  margin: 0 0 12px 0;
-}
-
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__comment,
-.vf-swatch__css-property {
-  margin: 0 0 12px 0;
-}
-.vf-swatch__colour-hex {
-  text-transform: uppercase;
-}
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__css-property {
-  font-family: monospace;
-  font-size: 1em;
-  align-items: start;
-}
-
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__css-property {
-  font-family: 'IBM Plex Mono', Monaco, Consolas, 'Lucida Console', monospace;
-  font-size: 14px;
-}
-
-.vf-swatch__notes {
-  margin: 12px 0 0px 0;
-}
-
-.vf-swatch__notes,
-.vf-swatch__colour-name,
-.vf-swatch__meta {
-  font-family: 'IBM Plex Sans', Helvetica, Arial, sans-serif;
-}
-.vf-swatch__colour-name {
-  padding: 16px;
-}
-
-.vf-swatch__meta {
-  font-size: 16px;
-}
-
-.vf-swatch__details p {
-  margin-bottom: 16px;
-}
-.vf-swatch__details p:last-of-type {
-  margin-bottom: 0;
-}
-.breakpoint-example {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-}
-</style>
-
-
-<main class="vf-swatches | vf-grid vf-grid__col-3">
+<main class="vf-grid vf-grid__col-3">
 {% for item in breakpoints.properties %}
 
 
-<article class="vf-swatch">
-  <div class="breakpoint-example">
+<article class="vf-card">
+  <div style="display: flex; justify-content: center; align-items: center;">
     <p class="">{{ item.value }}</p>
   </div>
 
-  <section class="vf-swatch__details">
-    <h3 class="vf-swatch__colour-name">{{ item.meta.friendlyName }}</h3>
-    {% if item.meta.sassVariable %}
+
+  <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
+    <h3>{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
     <p>Sass:</p>
-      <p class="vf-swatch__sass-variable">${{ item.meta.sassVariable }}</p>
-    {% endif %}
+      <p>{{ item.meta.sassVariable }}</p>
     {% if item.meta.comment %}
-      <h4 class="vf-swatch__notes">notes:</h4>
-      <p class="vf-swatch__comment">
+    <hr class="vf-divider">
+      <h4>notes:</h4>
+      <p>
         {{ item.meta.comment }}
       </p>
     {% endif %}

--- a/components/vf-design-tokens/vf-design-tokens--colours.njk
+++ b/components/vf-design-tokens/vf-design-tokens--colours.njk
@@ -1,112 +1,30 @@
-<style>
-/* vf-swatches might one day be a component, but for now it's CSS we'll just use for the design token demonstration */
-.vf-swatches {
-  grid-row-gap: 32px;
-  margin: 48px 0;
-}
-.vf-swatch {
-  border: 1px solid #d0d0ce;
-  display: grid;
-  grid-template-rows: 160px 1fr;
-}
-
-.vf-swatch__details {
-  padding: 16px;
-  border-top: 1px solid #d0d0ce;
-}
-.vf-swatch:nth-of-type(6),
-.vf-swatch:nth-of-type(11) {
-  grid-column-start: 1;
-}
-.vf-swatch__colour {
-  /* margin: 16px;
-  height: calc(100% - 32px);
-  width: calc(100% - 32px); */
-  height: 100%;
-  width: 100%;
-}
-.vf-swatch__colour-name {
-  margin: 0 0 12px 0;
-}
-
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__comment,
-.vf-swatch__css-property {
-  margin: 0 0 12px 0;
-}
-.vf-swatch__colour-hex {
-  text-transform: uppercase;
-}
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__css-property {
-  font-family: monospace;
-  font-size: 1em;
-  align-items: start;
-}
-
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__css-property {
-  font-family: 'IBM Plex Mono', Monaco, Consolas, 'Lucida Console', monospace;
-  font-size: 14px;
-}
-
-.vf-swatch__notes {
-  margin: 12px 0 0px 0;
-}
-
-.vf-swatch__notes,
-.vf-swatch__colour-name,
-.vf-swatch__meta {
-  font-family: 'IBM Plex Sans', Helvetica, Arial, sans-serif;
-}
-.vf-swatch__colour-name {
-  padding: 16px;
-}
-
-.vf-swatch__meta {
-  font-size: 16px;
-}
-
-.vf-swatch__details p {
-  margin-bottom: 16px;
-}
-.vf-swatch__details p:last-of-type {
-  margin-bottom: 0;
-}
-</style>
-
-
-<main class="vf-swatches | vf-grid vf-grid__col-3">
+<main class="vf-grid vf-grid__col-3">
 {% for item in colors.properties %}
 
 
-<article class="vf-swatch">
-  <div class="vf-swatch__colour" style="background-color: {{ item.value}};">
-  </div>
+<article class="vf-card">
+  <div style="background-color: {{ item.value}};"></div>
 
-  <section class="vf-swatch__details">
-    <h3 class="vf-swatch__colour-name">{{ item.meta.friendlyName }}</h3>
+  <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
+    <h3>{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
-    <p>Colour code:</p>
-    <p class="vf-swatch__colour-hex">{{ item.value }}</p>
-    <p class="vf-swatch__colour-hex">{{ item.value | hextorgb }}</p>
+    <p class="vf-card__text">Colour code:</p>
+    <p class="vf-card__text"><code>{{ item.value }}</code></p>
+    <p class="vf-card__text"><code>{{ item.value | hextorgb }}</code></p>
     {% if item.meta.sassVariable %}
     <hr class="vf-divider">
-    <p>Sass:</p>
-      <p class="vf-swatch__sass-variable">${{ item.meta.sassVariable }}</p>
-      <p class="vf-swatch__sass-variable">map-get($vf-colors-map, {{ item.meta.sassVariable }})</p>
+    <p class="vf-card__text">Sass:</p>
+      <p class="vf-card__text"><code>{{ item.meta.sassVariable }}</code></p>
+      <p class="vf-card__text"><code>map-get($vf-colors-map, {{ item.meta.sassVariable }})</code></p>
     {% endif %}
     {% if item.meta.CSSCustomProperty %}
     <hr class="vf-divider">
-    <p>CSS custom property:</p>
-      <p class="vf-swatch__css-property">{{ item.meta.CSSCustomProperty }}</p>
+    <p class="vf-card__text">CSS custom property:</p>
+      <p class="vf-card__text"><code>{{ item.meta.CSSCustomProperty }}</code></p>
     {% endif %}
     {% if item.meta.comment %}
-      <h4 class="vf-swatch__notes">notes:</h4>
-      <p class="vf-swatch__comment">
+      <h4>notes:</h4>
+      <p class="vf-card__text">
         {{ item.meta.comment }}
       </p>
     {% endif %}

--- a/components/vf-design-tokens/vf-design-tokens--colours.njk
+++ b/components/vf-design-tokens/vf-design-tokens--colours.njk
@@ -8,7 +8,7 @@
   <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
     <h3>{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
-    <p class="vf-card__text">Colour code:</p>
+    <p class="vf-card__text">Value:</p>
     <p class="vf-card__text"><code>{{ item.value }}</code></p>
     <p class="vf-card__text"><code>{{ item.value | hextorgb }}</code></p>
     {% if item.meta.sassVariable %}

--- a/components/vf-design-tokens/vf-design-tokens--spacing.njk
+++ b/components/vf-design-tokens/vf-design-tokens--spacing.njk
@@ -5,23 +5,23 @@
     <div style="height: {{ item.value }}; width: {{ item.value }}; background: #009f4d;"></div>
   </div>
   <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
-    <h3>{{ item.meta.friendlyName }}</h3>
+    <h3 class="vf-card__title">{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
-    <p>Value:</p>
-    <p>{{ item.value }}</p>
+    <p class="vf-card__text">Value:</p>
+    <p class="vf-card__text"><code>{{ item.value }}</code></p>
     {% if item.meta.sassVariable %}
     <hr class="vf-divider">
-    <p>Sass:</p>
-      <p>{{ item.meta.sassVariable }}</p>
+    <p class="vf-card__text">Sass:</p>
+      <p class="vf-card__text"><code>{{ item.meta.sassVariable }}</code></p>
     {% endif %}
     {% if item.meta.CSSCustomProperty %}
     <hr class="vf-divider">
-    <p>CSS custom property:</p>
-      <p>{{ item.meta.CSSCustomProperty }}</p>
+    <p class="vf-card__text">CSS custom property:</p>
+      <p class="vf-card__text"><code>{{ item.meta.CSSCustomProperty }}</code></p>
     {% endif %}
     {% if item.meta.comment %}
       <h4>notes:</h4>
-      <p>
+      <p class="vf-card__text">
         {{ item.meta.comment }}
       </p>
     {% endif %}

--- a/components/vf-design-tokens/vf-design-tokens--spacing.njk
+++ b/components/vf-design-tokens/vf-design-tokens--spacing.njk
@@ -1,44 +1,30 @@
-
-<style>
-.swatches {
-    grid-row-gap: 32px;
-}
-.swatch {
-  border: 2px solid #333;
-}
-.swatch__details {
-  padding: 16px;
-}
-.spacing__example {
-  border-bottom: 2px solid #333;
-  background-color: #f3f3f3;
-  display: flex;
-  width: 100%;
-  height: 200px;
-  justify-content: center;
-  align-items: center;
-}
-</style>
-<main class="swatches | vf-grid vf-grid__col-4">
+<main class="vf-grid vf-grid__col-3">
 {% for item in spacing.properties %}
-
-<article class="swatch">
-  <div class="spacing__example">
-    <item class="spacing" style="height: {{ item.value }}; width: {{ item.value }}; background: #009f4d;"></item>
+<article class="vf-card">
+  <div style="display: flex; justify-content: center; align-items: center;">
+    <div style="height: {{ item.value }}; width: {{ item.value }}; background: #009f4d;"></div>
   </div>
-  <section class="swatch__details">
-  <h3 class="swatch__colour-name">{{ item.meta.friendlyName }}</h3>
-  <p class="swatch__colour-hex"><span class="swatch__meta">Value: </span>{{ item.value }}</p>
-  {% if item.meta.sassVariable %}
-  <p class="swatch__sass-variable"><span class="swatch__meta">Sass Variable: </span>`{{ item.meta.sassVariable }}`</p>
-  {% endif %}
-  {% if item.meta.CSSCustomProperty %}
-  <p class="swatch__css-property"><span class="swatch__meta">CSS: </span>`{{ item.meta.CSSCustomProperty }}`</p>
-  {% endif %}
-  {% if item.meta.comment %}
-  <h4 class="swatch__notes">notes:</h4>
-  <p class="swatch__comment">{{ item.meta.comment }}</p>
-  {% endif %}
+  <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
+    <h3>{{ item.meta.friendlyName }}</h3>
+    <hr class="vf-divider">
+    <p>Value:</p>
+    <p>{{ item.value }}</p>
+    {% if item.meta.sassVariable %}
+    <hr class="vf-divider">
+    <p>Sass:</p>
+      <p>{{ item.meta.sassVariable }}</p>
+    {% endif %}
+    {% if item.meta.CSSCustomProperty %}
+    <hr class="vf-divider">
+    <p>CSS custom property:</p>
+      <p>{{ item.meta.CSSCustomProperty }}</p>
+    {% endif %}
+    {% if item.meta.comment %}
+      <h4>notes:</h4>
+      <p>
+        {{ item.meta.comment }}
+      </p>
+    {% endif %}
   </section>
 </article>
 

--- a/components/vf-design-tokens/vf-design-tokens--themes.njk
+++ b/components/vf-design-tokens/vf-design-tokens--themes.njk
@@ -1,112 +1,30 @@
-<style>
-/* vf-swatches might one day be a component, but for now it's CSS we'll just use for the design token demonstration */
-.vf-swatches {
-  grid-row-gap: 32px;
-  margin: 48px 0;
-}
-.vf-swatch {
-  border: 1px solid #d0d0ce;
-  display: grid;
-  grid-template-rows: 160px 1fr;
-}
-
-.vf-swatch__details {
-  padding: 16px;
-  border-top: 1px solid #d0d0ce;
-}
-.vf-swatch:nth-of-type(3),
-.vf-swatch:nth-of-type(5) {
-  grid-column-start: 1;
-}
-.vf-swatch__colour {
-  /* margin: 16px;
-  height: calc(100% - 32px);
-  width: calc(100% - 32px); */
-  height: 100%;
-  width: 100%;
-}
-.vf-swatch__colour-name {
-  margin: 0 0 12px 0;
-}
-
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__comment,
-.vf-swatch__css-property {
-  margin: 0 0 12px 0;
-}
-.vf-swatch__colour-hex {
-  text-transform: uppercase;
-}
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__css-property {
-  font-family: monospace;
-  font-size: 1em;
-  align-items: start;
-}
-
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__css-property {
-  font-family: 'IBM Plex Mono', Monaco, Consolas, 'Lucida Console', monospace;
-  font-size: 14px;
-}
-
-.vf-swatch__notes {
-  margin: 12px 0 0px 0;
-}
-
-.vf-swatch__notes,
-.vf-swatch__colour-name,
-.vf-swatch__meta {
-  font-family: 'IBM Plex Sans', Helvetica, Arial, sans-serif;
-}
-.vf-swatch__colour-name {
-  padding: 16px;
-}
-
-.vf-swatch__meta {
-  font-size: 16px;
-}
-
-.vf-swatch__details p {
-  margin-bottom: 16px;
-}
-.vf-swatch__details p:last-of-type {
-  margin-bottom: 0;
-}
-</style>
-
-
-<main class="vf-swatches | vf-grid vf-grid__col-3">
+<main class="vf-grid vf-grid__col-3">
 {% for item in themes.properties %}
 
 
-<article class="vf-swatch">
-  <div class="vf-swatch__colour" style="background-color: {{ item.value}};">
-  </div>
+<article class="vf-card">
+  <div style="background-color: {{ item.value}};"></div>
 
-  <section class="vf-swatch__details">
-    <h3 class="vf-swatch__colour-name">{{ item.meta.friendlyName }}</h3>
+  <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
+    <h3>{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
     <p>Colour code:</p>
-    <p class="vf-swatch__colour-hex">{{ item.value }}</p>
-    <p class="vf-swatch__colour-hex">{{ item.value | hextorgb }}</p>
+    <p>{{ item.value }}</p>
+    <p>{{ item.value | hextorgb }}</p>
     {% if item.meta.sassVariable %}
     <hr class="vf-divider">
     <p>Sass:</p>
-      <p class="vf-swatch__sass-variable">${{ item.meta.sassVariable }}</p>
-      <p class="vf-swatch__sass-variable">map-get($vf-themes-map, {{ item.meta.sassVariable }})</p>
+      <p>${{ item.meta.sassVariable }}</p>
+      <p>map-get($vf-colors-map, {{ item.meta.sassVariable }})</p>
     {% endif %}
     {% if item.meta.CSSCustomProperty %}
     <hr class="vf-divider">
     <p>CSS custom property:</p>
-      <p class="vf-swatch__css-property">{{ item.meta.CSSCustomProperty }}</p>
+      <p>{{ item.meta.CSSCustomProperty }}</p>
     {% endif %}
     {% if item.meta.comment %}
-      <h4 class="vf-swatch__notes">notes:</h4>
-      <p class="vf-swatch__comment">
+      <h4>notes:</h4>
+      <p>
         {{ item.meta.comment }}
       </p>
     {% endif %}

--- a/components/vf-design-tokens/vf-design-tokens--themes.njk
+++ b/components/vf-design-tokens/vf-design-tokens--themes.njk
@@ -8,23 +8,23 @@
   <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
     <h3>{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
-    <p>Colour code:</p>
-    <p>{{ item.value }}</p>
-    <p>{{ item.value | hextorgb }}</p>
+    <p class="vf-card__text">Value:</p>
+    <p class="vf-card__text"><code>{{ item.value }}</code></p>
+    <p class="vf-card__text"><code>{{ item.value | hextorgb }}</code></p>
     {% if item.meta.sassVariable %}
     <hr class="vf-divider">
-    <p>Sass:</p>
-      <p>${{ item.meta.sassVariable }}</p>
-      <p>map-get($vf-colors-map, {{ item.meta.sassVariable }})</p>
+    <p class="vf-card__text">Sass:</p>
+      <p class="vf-card__text"><code>{{ item.meta.sassVariable }}</code></p>
+      <p class="vf-card__text"><code>map-get($vf-colors-map, {{ item.meta.sassVariable }})</code></p>
     {% endif %}
     {% if item.meta.CSSCustomProperty %}
     <hr class="vf-divider">
-    <p>CSS custom property:</p>
-      <p>{{ item.meta.CSSCustomProperty }}</p>
+    <p class="vf-card__text">CSS custom property:</p>
+      <p class="vf-card__text"><code>{{ item.meta.CSSCustomProperty }}</code></p>
     {% endif %}
     {% if item.meta.comment %}
       <h4>notes:</h4>
-      <p>
+      <p class="vf-card__text">
         {{ item.meta.comment }}
       </p>
     {% endif %}

--- a/components/vf-design-tokens/vf-design-tokens--typography.njk
+++ b/components/vf-design-tokens/vf-design-tokens--typography.njk
@@ -1,28 +1,23 @@
-<main class="vf-swatches | vf-grid vf-grid__col-2">
-
+<main class="vf-grid vf-grid__col-3">
 {% for item in typography.properties %}
 
-<article class="vf-swatch">
-  <div class="vf-swatch__colour">
-    <h3 class="vf-swatch__colour-name">
-      {{ item.meta.friendlyName }}
-    </h3>
+<article class="vf-card">
+  <div style="padding: 16px;">
+    <p style="font-size: {{ item.value.fontSize }}; font-weight: {{ item.value.fontWeight }}; line-height: {{ item.value.lineHeight }}">{{ item.meta.pangram }}</p>
   </div>
 
-  <section class="vf-swatch__details">
-    <p style="font-size: {{ item.value.fontSize }}; font-weight: {{ item.value.fontWeight }}; line-height: {{ item.value.lineHeight }}">{{ item.meta.pangram }}</p>
+  <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
+    <h3>{{ item.meta.friendlyName }}</h3>
+    <hr class="vf-divider">
+    <p><span>Font Size: </span><code>{{ item.value.fontSize }}</code></p>
+    <p><span>Font Weight: </span><code>{{ item.value.fontWeight }}</code></p>
+    <p><span>Ling Height: </span><code>{{ item.value.lineHeight}}</code></p>
+    <hr class="vf-divider">
+    <p>Sass:</p>
+    <code>@mixin set-type(`{{ item.meta.sassMap }}`)</code>
   </section>
-  <ul class="">
-    <li><span>Font Size: </span>{{ item.value.fontSize }}</li>
-    <li><span>Font Weight: </span>{{ item.value.fontWeight }}</li>
-    <li><span>Ling Height: </span>{{ item.value.lineHeight}}</li>
-  </ul>
-  {% markdown %}
-  {% endmarkdown %}
-  <ul>
-    <li><span>Sass: </span><code>@mixin set-type(`{{ item.meta.sassMap }}`)</code></li>
-  </ul>
 </article>
+
 {% else %}
 
 <p>Something went wrong.</p>

--- a/components/vf-design-tokens/vf-design-tokens--typography.njk
+++ b/components/vf-design-tokens/vf-design-tokens--typography.njk
@@ -7,13 +7,13 @@
   </div>
 
   <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
-    <h3>{{ item.meta.friendlyName }}</h3>
+    <h3 class="vf-card__title">{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
-    <p><span>Font Size: </span><code>{{ item.value.fontSize }}</code></p>
-    <p><span>Font Weight: </span><code>{{ item.value.fontWeight }}</code></p>
-    <p><span>Ling Height: </span><code>{{ item.value.lineHeight}}</code></p>
+    <p class="vf-card__text"><span>Font Size: </span><code>{{ item.value.fontSize }}</code></p>
+    <p class="vf-card__text"><span>Font Weight: </span><code>{{ item.value.fontWeight }}</code></p>
+    <p class="vf-card__text"><span>Ling Height: </span><code>{{ item.value.lineHeight}}</code></p>
     <hr class="vf-divider">
-    <p>Sass:</p>
+    <p class="vf-card__text">Sass:</p>
     <code>@mixin set-type(`{{ item.meta.sassMap }}`)</code>
   </section>
 </article>

--- a/components/vf-design-tokens/vf-design-tokens--ui-colours.njk
+++ b/components/vf-design-tokens/vf-design-tokens--ui-colours.njk
@@ -1,109 +1,30 @@
-<style>
-/* vf-swatches might one day be a component, but for now it's CSS we'll just use for the design token demonstration */
-.vf-swatches {
-  grid-row-gap: 32px;
-  margin: 48px 0;
-}
-.vf-swatch {
-  border: 1px solid #d0d0ce;
-  display: grid;
-  grid-template-rows: 160px 1fr;
-}
-
-.vf-swatch__details {
-  padding: 16px;
-  border-top: 1px solid #d0d0ce;
-}
-
-.vf-swatch__colour {
-  /* margin: 16px;
-  height: calc(100% - 32px);
-  width: calc(100% - 32px); */
-  height: 100%;
-  width: 100%;
-}
-.vf-swatch__colour-name {
-  margin: 0 0 12px 0;
-}
-
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__comment,
-.vf-swatch__css-property {
-  margin: 0 0 12px 0;
-}
-.vf-swatch__colour-hex {
-  text-transform: uppercase;
-}
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__css-property {
-  font-family: monospace;
-  font-size: 1em;
-  align-items: start;
-}
-
-.vf-swatch__colour-hex,
-.vf-swatch__sass-variable,
-.vf-swatch__css-property {
-  font-family: 'IBM Plex Mono', Monaco, Consolas, 'Lucida Console', monospace;
-  font-size: 14px;
-}
-
-.vf-swatch__notes {
-  margin: 12px 0 0px 0;
-}
-
-.vf-swatch__notes,
-.vf-swatch__colour-name,
-.vf-swatch__meta {
-  font-family: 'IBM Plex Sans', Helvetica, Arial, sans-serif;
-}
-.vf-swatch__colour-name {
-  padding: 16px;
-}
-
-.vf-swatch__meta {
-  font-size: 16px;
-}
-
-.vf-swatch__details p {
-  margin-bottom: 16px;
-}
-.vf-swatch__details p:last-of-type {
-  margin-bottom: 0;
-}
-</style>
-
-
-<main class="vf-swatches | vf-grid vf-grid__col-3">
+<main class="vf-grid vf-grid__col-3">
 {% for item in uiColors.properties %}
 
 
-<article class="vf-swatch">
-  <div class="vf-swatch__colour" style="background-color: {{ item.value}};">
-  </div>
+<article class="vf-card">
+  <div style="background-color: {{ item.value}};"></div>
 
-  <section class="vf-swatch__details">
-    <h3 class="vf-swatch__colour-name">{{ item.meta.friendlyName }}</h3>
+  <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
+    <h3>{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
     <p>Colour code:</p>
-    <p class="vf-swatch__colour-hex">{{ item.value }}</p>
-    <p class="vf-swatch__colour-hex">{{ item.value | hextorgb }}</p>
+    <p>{{ item.value }}</p>
+    <p>{{ item.value | hextorgb }}</p>
     {% if item.meta.sassVariable %}
     <hr class="vf-divider">
     <p>Sass:</p>
-      <p class="vf-swatch__sass-variable">${{ item.meta.sassVariable }}</p>
-      <p class="vf-swatch__sass-variable">map-get($vf-colors-map, {{ item.meta.sassVariable }})</p>
+      <p>${{ item.meta.sassVariable }}</p>
+      <p>map-get($vf-colors-map, {{ item.meta.sassVariable }})</p>
     {% endif %}
     {% if item.meta.CSSCustomProperty %}
     <hr class="vf-divider">
     <p>CSS custom property:</p>
-      <p class="vf-swatch__css-property">{{ item.meta.CSSCustomProperty }}</p>
+      <p>{{ item.meta.CSSCustomProperty }}</p>
     {% endif %}
     {% if item.meta.comment %}
-      <h4 class="vf-swatch__notes">notes:</h4>
-      <p class="vf-swatch__comment">
+      <h4>notes:</h4>
+      <p>
         {{ item.meta.comment }}
       </p>
     {% endif %}

--- a/components/vf-design-tokens/vf-design-tokens--ui-colours.njk
+++ b/components/vf-design-tokens/vf-design-tokens--ui-colours.njk
@@ -8,23 +8,23 @@
   <section class="vf-stack | vf-card__content" style="--vf-stack-margin: .5rem;">
     <h3>{{ item.meta.friendlyName }}</h3>
     <hr class="vf-divider">
-    <p>Colour code:</p>
-    <p>{{ item.value }}</p>
-    <p>{{ item.value | hextorgb }}</p>
+    <p class="vf-card__text">Value:</p>
+    <p class="vf-card__text"><code>{{ item.value }}</code></p>
+    <p class="vf-card__text"><code>{{ item.value | hextorgb }}</code></p>
     {% if item.meta.sassVariable %}
     <hr class="vf-divider">
-    <p>Sass:</p>
-      <p>${{ item.meta.sassVariable }}</p>
-      <p>map-get($vf-colors-map, {{ item.meta.sassVariable }})</p>
+    <p class="vf-card__text">Sass:</p>
+      <p class="vf-card__text"><code>{{ item.meta.sassVariable }}</code></p>
+      <p class="vf-card__text"><code>map-get($vf-colors-map, {{ item.meta.sassVariable }})</code></p>
     {% endif %}
     {% if item.meta.CSSCustomProperty %}
     <hr class="vf-divider">
-    <p>CSS custom property:</p>
-      <p>{{ item.meta.CSSCustomProperty }}</p>
+    <p class="vf-card__text">CSS custom property:</p>
+      <p class="vf-card__text"><code>{{ item.meta.CSSCustomProperty }}</code></p>
     {% endif %}
     {% if item.meta.comment %}
       <h4>notes:</h4>
-      <p>
+      <p class="vf-card__text">
         {{ item.meta.comment }}
       </p>
     {% endif %}

--- a/components/vf-design-tokens/vf-design-tokens.config.js
+++ b/components/vf-design-tokens/vf-design-tokens.config.js
@@ -13,6 +13,7 @@ let fractalConfig = {
     {
       name: 'default',
       label: 'Welcome',
+      hidden: 'true',
     },
   ]
 };


### PR DESCRIPTION
they're still hardcoded, but the examples now make use of `vf-card` and `vf-stack` to make the layouts of design tokens similar across types.

Looks great inside the fractal instances, but the 'sections' page I'm working on for the component library page needs some work - which will be a separate PR anyhoo. 