### PR TITLE
the one that refactors vf-intro

### DIFF
--- a/components/vf-intro/CHANGELOG.md
+++ b/components/vf-intro/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.4.0
+
+- adds the option to have a nicer styled 'sub-heading'.
+- introduces the use of `vf-stack` to layout out the vertical stacking of the content.
+- use `--vf-stack-margin--custom` to align things as required.
+- removes use of `embl-grid` and lets `vf-intro` roll it's own.
+
 ### 1.3.2
 
 - resets the custom property used for `gap` in `embl-grid` so it only worries about the column gap.

--- a/components/vf-intro/vf-intro.config.yml
+++ b/components/vf-intro/vf-intro.config.yml
@@ -4,13 +4,19 @@ preview: '@preview'
 status: live
 context:
   component-type: container
-  vf_intro_heading: Cancer
-  vf_intro_lede: Cancer is a generic term for lots of different diseases in which cells divide many more times than usual. This abnormal growth can affect many cell types in almost any part of the body.
-  vf_intro_text:
-    - Cancer is a multi-stage process. Normal cells begin to divide abnormally, spreading beyond their normal boundaries, and abnormal tissue growth causes swellings called tumours to form. Tumours can be benign – with no harmful effect on the body – or malignant, invading healthy tissue and interfering with normal bodily functions.
-    - There are more than 100 types of cancer and symptoms vary depending on the type. <a class="vf-link" href="JavaScript:Void(0);">Read more about Cancer</a>.
+
+  vf_intro_heading: Transversal research themes
+
   vf_intro_badge:
     style: ["phases"]
-    text: alpha
+    text: beta
     theme: primary
     badge_href: 'JavaScript:Void(0);'
+
+  vf_intro_subheading: Understanding life in the context of its environment
+
+  vf_intro_lede: EMBL’s future directions will be driven by the goal of understanding life in the context of its environment. While the effects of the environment on living systems have been well studied at the level of individual organisms and populations, many of the underlying molecular processes remain obscure.
+
+  vf_intro_text:
+    - We now have the tools and technologies to explore these processes, allowing us to understand life in its natural context from the level of molecules to whole ecosystems. This new understanding will be critically important if we are to tackle societal challenges such as environmental degradation and loss of biodiversity, climate change, and threats to human health such as the emergence of new epidemics.
+    - EMBL’s new transversal research themes will enable us to realise this vision of understanding life in context. The transversal research themes will be highly interdisciplinary and will encourage dynamic internal and external collaborations. These themes will enable transformative discoveries by bringing together experts in fields such as ecology, epidemiology, toxicology, zoology, population genetics, engineering, and mathematical theory. There will be strong support for building collaborations within each theme, as well as with the wider scientific community, not only to enable scientific discovery but also to build these themes across the EMBL sites.

--- a/components/vf-intro/vf-intro.njk
+++ b/components/vf-intro/vf-intro.njk
@@ -13,10 +13,13 @@
   {% set intro_text = context.intro_text %}
 
 {% endif %}
+<section class="vf-intro"
+  {%- if intro_stack_spacing %} style="--vf-intro-spacing: {{intro_stack_spacing}}"{%- endif -%}
+>
 
-<section class="vf-intro | embl-grid embl-grid--has-centered-content">
   <div><!-- empty --></div>
-  <div>
+
+  <div class="vf-stack">
 
   <h1 class="vf-intro__heading {% if (vf_intro_phase) or (vf_intro_badge) %}vf-intro__heading--has-tag{% endif %}">
 
@@ -30,7 +33,7 @@
     {%- if (vf_intro_heading_href) %}
       <a href="{{- intro_heading_href -}}" class="vf-badge vf-badge--primary vf-badge--phases">{{- vf_intro_phase -}}</a>
     {%- else -%}
-      <span class="vf-badge vf-badge--primary vf-badge--phases">{{- vf_intro_phase -}}</span>
+      <span class="vf-badge vf-badge--primary vf-badge--phases">{{- vf_intro_phase -}};</span>
     {%- endif -%}
   {%- endif -%}
   {%- if vf_intro_badge -%}
@@ -44,6 +47,11 @@
   {%- if (vf_intro_lede) and (vf_lede_text) -%}
   <h2 style="color: var(--vf-ui-color--red)">Please use the relevant <code>vf_intro_lede</code> yaml only</h2>
   {%- endif -%}
+
+  {% if vf_intro_subheading %}
+  <h2 class="vf-intro__subheading">{{vf_intro_subheading}}</h2>
+  {% endif %}
+
   {% if vf_intro_lede %}
     {%- render '@vf-lede', {"vf_lede_text": vf_intro_lede} -%}
   {% endif %}

--- a/components/vf-intro/vf-intro.scss
+++ b/components/vf-intro/vf-intro.scss
@@ -10,7 +10,8 @@
  */
 
 .vf-intro {
-  @include margin--block(bottom, 110px);
+  margin-bottom: 1rem;
+  margin-bottom: var(--vf-intro-spacing, 1rem);
 
   & > * {
     grid-column: 2 / span 1;
@@ -20,36 +21,14 @@
   }
 }
 
-/*
- * We are moving to the idea of not relying on .vf-body for centering.
- * Until then we need to have this litte 'reset'
- */
-.vf-body .vf-intro {
-  box-sizing: initial;
-  margin-left: unset;
-  margin-right: unset;
-  max-width: unset;
-  padding-left: unset;
-  padding-right: unset;
-}
-
 .vf-intro {
-  --vf-intro-spacing: 200px;
-  --page-grid-gap: 0 1em;
-  box-sizing: border-box;
-  display: grid;
-  grid-column: main;
-  grid-template-rows: 1fr repeat(10, min-content);
-  margin-left: auto;
-  margin-right: auto;
-  max-width: $vf-layout--comfortable;
-  padding-left: 1em;
-  padding-right: 1em;
+  --vf-intro-spacing: 3rem;
 }
 
 @media (min-width: $vf-breakpoint--lg) {
   .vf-intro {
-    --page-grid-gap: 0 1.5em;
+    display: grid;
+    grid-column: 1 / -1 !important;
     grid-template-areas: '... header header' '... ...    links';
     grid-template-columns: var(--embl-grid-module--prime) auto var(--embl-grid-module--prime);
   }
@@ -59,8 +38,24 @@
 }
 
 .vf-intro__heading {
-  @include set-type(text-heading--1);
-  @include margin--block(bottom, 56px);
+  @include set-type(text-heading--1, $custom-margin-bottom: 0);
+
+  line-height: 1.25;
+
+  + .vf-lede {
+    --vf-stack-margin--custom: 2rem;
+  }
+  + .vf-intro__subheading {
+    --vf-stack-margin--custom: 0;
+  }
+}
+
+.vf-intro__subheading {
+  @include set-type(text-heading--3, $custom-margin-bottom: 0);
+
+  + * {
+    --vf-stack-margin--custom: 2rem;
+  }
 }
 
 .vf-intro__heading--has-tag {

--- a/components/vf-intro/vf-intro.scss
+++ b/components/vf-intro/vf-intro.scss
@@ -31,6 +31,7 @@
     grid-column: 1 / -1 !important;
     grid-template-areas: '... header header' '... ...    links';
     grid-template-columns: var(--embl-grid-module--prime) auto var(--embl-grid-module--prime);
+    // grid-template-columns: subgrid;
   }
 
   .vf-intro__heading { grid-area: header; }


### PR DESCRIPTION
- adds the option to have a nicer styled 'sub-heading'.
- introduces the use of `vf-stack` to layout out the vertical stacking of the content.
- use `--vf-stack-margin--custom` to align things as required.
- removes use of `embl-grid` and lets `vf-intro` roll it's own.