### PR TITLE
fix: linting defaults

### DIFF
--- a/tools/vf-core/CHANGELOG.md
+++ b/tools/vf-core/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.9
+
+- fix: avoid build failure on missing .eslintrc.js config in child projects
+
 ### 2.2.8
 
 - adds ESLint task and config

--- a/tools/vf-core/CHANGELOG.md
+++ b/tools/vf-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.2.9
 
 - fix: avoid build failure on missing .eslintrc.js config in child projects
+  - https://github.com/visual-framework/vf-core/pull/1178
 
 ### 2.2.8
 

--- a/tools/vf-core/gulp-tasks/vf-scripts.js
+++ b/tools/vf-core/gulp-tasks/vf-scripts.js
@@ -101,9 +101,12 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
   const vfJsLintPaths = [componentPath+'/**/embl-*.js', componentPath+'/**/vf-*.js', '!assets/**/*.js',  '!'+componentPath+'/**/*.precompiled.js'];
   gulp.task('vf-lint:js-soft-fail', function() {
     return gulp.src(vfJsLintPaths)
-      // eslint() attaches the lint output to the "eslint" property
-      // of the file object so it can be used by other modules.
-      .pipe(eslint())
+      // a minimal rule set if .eslintrc.js is missing (avoid build break)
+      .pipe(eslint({
+        "rules":{
+          indent: ["error", 2]
+        }
+      }))
       // eslint.format() outputs the lint results to the console.
       // Alternatively use eslint.formatEach() (see Docs).
       .pipe(eslint.format());
@@ -111,7 +114,12 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
 
   gulp.task('vf-lint:js-hard-fail', function() {
     return gulp.src(vfJsLintPaths)
-      .pipe(eslint())
+      // a minimal rule set if .eslintrc.js is missing (avoid build break)
+      .pipe(eslint({
+        "rules":{
+          indent: ["error", 2]
+        }
+      }))
       .pipe(eslint.format())
       .pipe(eslint.failAfterError());
   });


### PR DESCRIPTION
Avoid build failure on missing .eslintrc.js config in child projects