### PR TITLE
the one that tidies up some of the space

### DIFF
--- a/components/embl-logo/CHANGELOG.md
+++ b/components/embl-logo/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.5
+
+- makes a reduction in size for the logos `--extreme` version from 96px to 48px.
+
 ### 1.0.3
 
 - this removes the 'resize' for homepages as on devices sub 1024px the logo was a different size to every other page

--- a/components/embl-logo/embl-logo.scss
+++ b/components/embl-logo/embl-logo.scss
@@ -26,6 +26,6 @@
 
   @media (min-width: $vf-breakpoint--lg + 1) {
     background-image: url('../assets/embl-logo/assets/logo.svg');
-    height: 96px;
+    height: 48px;
   }
 }

--- a/components/vf-breadcrumbs/CHANGELOG.md
+++ b/components/vf-breadcrumbs/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.5
+
+- removes the bottom margin
+- increases the top margin
+
 ### 1.0.4
 
 - fix: links in the with-related variant weren't coming through as the parent object wasn't mapped

--- a/components/vf-breadcrumbs/vf-breadcrumbs.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.scss
@@ -13,7 +13,6 @@
 
 .vf-breadcrumbs {
   grid-column: main;
-  margin-bottom: $vf-breadcrumbs__margin--bottom;
   margin-left: auto;
   margin-right: auto;
   margin-top: $vf-breadcrumbs__margin--top;

--- a/components/vf-breadcrumbs/vf-breadcrumbs.variables.scss
+++ b/components/vf-breadcrumbs/vf-breadcrumbs.variables.scss
@@ -6,5 +6,4 @@ $vf-breadcrumbs__item-related-text--color: set-color(vf-color--grey);
 $vf-breadcrumbs__item-related-link--color: set-color(vf-color--blue);
 $vf-breadcrumbs__item-related-link--color--hover: set-color(vf-color--grey);
 
-$vf-breadcrumbs__margin--bottom: 8px;
-$vf-breadcrumbs__margin--top: 8px;
+$vf-breadcrumbs__margin--top: 1rem;

--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.0.1
+
+- removes padding.
+- adds top margin for layout.
+
 ### 3.0.0
 
 - updates max-width of component

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -21,9 +21,8 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
   gap: .5rem;
   grid-column: 1 / -1;
   height: auto;
-  margin: 0 auto;
+  margin: .5rem auto 0 auto;
   max-width: $vf-layout--comfortable;
-  padding: .5rem 0;
   width: 100%;
 
   & > [class*='logo'] {

--- a/components/vf-header/CHANGELOG.md
+++ b/components/vf-header/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.3
+
+- removes negative margin bottom when `vf-global-header` is a child of `vf-header`.
+
 ### 1.0.0-rc.2
 
 - Simplify grid

--- a/components/vf-header/vf-header.scss
+++ b/components/vf-header/vf-header.scss
@@ -40,10 +40,6 @@
   grid-row: 2;
 }
 
-.vf-header > .vf-global-header {
-  margin-bottom: -1px;
-}
-
 .vf-header--inlay {
   grid-column: 2 / -2;
 


### PR DESCRIPTION
I thought I'd already made this a PR.

It tidies up the spacing. For now. Ideally `body` should also have `vf-stack` as an HTML class.

That way we can standardise the spacing between things - and then adjust as needed with the css custom properties.

I've probably got changelogs to write.