### PR TITLE
chore: reclassify component types

### DIFF
--- a/components/ebi-header-footer/ebi-header-footer.config.yml
+++ b/components/ebi-header-footer/ebi-header-footer.config.yml
@@ -11,7 +11,7 @@ status: beta
   #   hidden: true
 # preview: '@preview--nogrid'
 context:
-  component-type: container
+  component-type: utility
   # custom-values: passed as {{custom-values}}
   # title: Title text
   # text: String of text

--- a/components/embl-conditional-edit/embl-conditional-edit.config.yml
+++ b/components/embl-conditional-edit/embl-conditional-edit.config.yml
@@ -10,7 +10,7 @@ status: beta
   # - name: default
   #   hidden: true
 context:
-  component-type: embl-element
+  component-type: utility
   # custom-values: passed as {{custom-values}}
   # title: Title text
   # text: String of text

--- a/components/embl-content-hub-loader/embl-content-hub-loader.config.yml
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.config.yml
@@ -2,4 +2,4 @@ title: EMBL ContentHub Loader component
 label: EMBL ContentHub Loader
 status: beta
 context:
-  component-type: embl-container
+  component-type: utility

--- a/components/embl-content-meta-properties/embl-content-meta-properties.config.yml
+++ b/components/embl-content-meta-properties/embl-content-meta-properties.config.yml
@@ -3,7 +3,7 @@ label: EMBL Content meta properties
 
 status: live
 context:
-  component-type: embl-block
+  component-type: utility
   meta_who: all
   meta_what: services, websites
   meta_where: EMBL

--- a/components/vf-details/vf-details.config.yml
+++ b/components/vf-details/vf-details.config.yml
@@ -16,7 +16,7 @@ variants:
       details_content: Something small enough to escape casual notice.
 # Global component context
 context:
-  component-type: container
+  component-type: block
   # custom-values: passed as {{custom-values}}
   # - note: you in your custom-values you should use dashes `-`
   #         and not underscores `_` as underscores prevent inherited template use

--- a/components/vf-search-client-side/vf-search-client-side.config.yml
+++ b/components/vf-search-client-side/vf-search-client-side.config.yml
@@ -11,7 +11,7 @@ status: alpha
   #   hidden: true
 context:
   # custom-values: passed as {{custom-values}}
-  component-type: block
+  component-type: utility
   search_client_prompt: Enter a search query
   search_client_button: true
   search_client_button_text: Search

--- a/components/vf-show-more/vf-show-more.config.yml
+++ b/components/vf-show-more/vf-show-more.config.yml
@@ -12,4 +12,4 @@ variants:
     context:
       showmore_content: Something small enough to escape casual notice.
 context:
-  component-type: container
+  component-type: utility


### PR DESCRIPTION
A few components were in the incorrect places.

Also fixes a few  title/labels

For #1190