### PR TITLE
the one that fixes a bug introduced to `vf-navigation--additional`

### DIFF
--- a/components/vf-navigation/CHANGELOG.md
+++ b/components/vf-navigation/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 2.1.0
+
+* fixes a bug with the `--additional` variant.
+* introduces `njk`/`yml` variable look up to determine classnames to use:
+  * adds `vf-cluster` only to `--main` variant.
+  * replaces `--additional` CSS for full bleed background with `vf-u-fullbleed` class.
+
 ### 2.0.0
 
 * increases font size for `--main`.

--- a/components/vf-navigation/vf-navigation--additional.scss
+++ b/components/vf-navigation/vf-navigation--additional.scss
@@ -12,21 +12,6 @@
   text-transform: uppercase;
   width: 100%;
 
-  &::before {
-    background-color: inherit;
-    border: 0px solid set-color(vf-color--grey);
-    border-width: 1px 0 1px 0;
-    box-sizing: border-box;
-    content: '';
-    height: calc(100% + 1px);
-    left: 50%;
-    margin: 0 -50vw;
-    position: absolute;
-    right: 50%;
-    top: 0;
-    width: 100vw;
-  }
-
   .vf-navigation__heading {
     color: set-ui-color(vf-ui-color--white);
     padding-top: 6px; // magic number

--- a/components/vf-navigation/vf-navigation.config.yml
+++ b/components/vf-navigation/vf-navigation.config.yml
@@ -1,6 +1,6 @@
 title: Navigation
 label: Navigation
-
+preview: '@preview--nogrid'
 status: live
 
 context:

--- a/components/vf-navigation/vf-navigation.njk
+++ b/components/vf-navigation/vf-navigation.njk
@@ -1,4 +1,8 @@
-<nav class="vf-navigation {%- if classModifier %} vf-navigation--{{ classModifier }}{% endif %} | vf-cluster">
+<nav class="vf-navigation
+  {%- if classModifier %} vf-navigation--{{ classModifier }}{% endif -%}
+  {%- if classModifier == 'main' %} | vf-cluster{%- endif -%}
+  {%- if classModifier == 'additional' %} | vf-u-fullbleed{%- endif -%}
+  ">
   {% if heading %}
   <h3 class="vf-navigation__heading">{{ heading }}</h3>
   {% endif %}


### PR DESCRIPTION
With the last release we defaulted to using `vf-cluster` to aid layout of things.

This broke `--additional` quite a bit.

This update uses some `nil`/`yaml` variables to determine when to use what

It also introduces using `vf-u-fullbleed` for `--additional` to save a few bites of CSS. 