### PR TITLE
🐛 the one that corrects where CSS custom property is defined for variants

### DIFF
--- a/components/vf-cluster/CHANGELOG.md
+++ b/components/vf-cluster/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.1
+
+* fixes a bug where we overspecified the spacing custom property which affected left alignment of `--600` and `--800` variants.
+
 ### 1.0.0
 
 * replaces all spacing / sizing values with numbers

--- a/components/vf-cluster/vf-cluster.scss
+++ b/components/vf-cluster/vf-cluster.scss
@@ -30,14 +30,14 @@
   margin: calc( var(--vf-cluster-margin) / 2) !important;
 }
 
-.vf-cluster--400 > * > * {
+.vf-cluster--400 > * {
   --vf-cluster-margin: #{map-get($vf-spacing-map, vf-spacing--400)};
 }
 
-.vf-cluster--600 > * > * {
+.vf-cluster--600 > * {
   --vf-cluster-margin: #{map-get($vf-spacing-map, vf-spacing--600)};
 }
 
-.vf-cluster--800 > * > * {
+.vf-cluster--800 > * {
   --vf-cluster-margin: #{map-get($vf-spacing-map, vf-spacing--800)};
 }


### PR DESCRIPTION
This will close #1212 

![Screenshot 2020-11-04 at 14 57 09](https://user-images.githubusercontent.com/925197/98128169-7bcbdc80-1eaf-11eb-892c-d371c41f7da5.png)
