### PR TITLE
fixes bug on hover of link and easy variant

### DIFF
--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.1
+
+* fixes a hover issue if the card has a link and is the `--easy` variant.
+
 ### 2.2.0
 
 * adds a slight box shadow to all card variants to denote that it's something on the page, not 'of the page'

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -121,7 +121,6 @@ variants:
     context:
       card_title: A Normal Primary Card with Link
       theme: primary
-      variant: normal
       card_href: "JavaScript:Void(0);"
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, <a class="vf-card__link" href="JavaScript:Void(0);">consectetur</a> adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -112,6 +112,7 @@
     --card-text-color: #{set-ui-color(vf-ui-color--black)};
   }
 
+  // fixes bug on hover of link and easy variant #1215
   .vf-card__link {
     &::after {
       height: calc(100% + 8px);

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -111,6 +111,12 @@
   .vf-card__text {
     --card-text-color: #{set-ui-color(vf-ui-color--black)};
   }
+
+  .vf-card__link {
+    &::after {
+      height: calc(100% + 8px);
+    }
+  }
 }
 
 .vf-card--normal {


### PR DESCRIPTION
@kasprzyk-sz found an issue if the `vf-card` was the `--easy` variant and the heading has a `__link` where the `:hover` shadow wasn't full height. 