### PR TITLE
🐛 The one that fixes Sass map interpolation error

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.1
+
+* fixes bug where `--page-grid-gap` wasn't getting it's correct spacing unit because the Sass `map-get` was not interpolated.
+
 ### 2.2.0
 
 * updates `--page-grid-gap` for larger viewports to `2rem` instead of `1.5rem`.

--- a/components/vf-sass-config/variables/vf-global-custom-properties.scss
+++ b/components/vf-sass-config/variables/vf-global-custom-properties.scss
@@ -8,6 +8,6 @@
   --embl-grid-spacing-normaliser: 0px;
 
   @media (min-width: 75em) {
-    --page-grid-gap: map-get($vf-spacing-map, vf-spacing--800);
+    --page-grid-gap: #{map-get($vf-spacing-map, vf-spacing--800)};
   }
 }


### PR DESCRIPTION
This will close #1211

There was a missed Sass interpolation for `--page-grid-gap` in the `vf-sass-config` CSS custom property variables.

This fixes that. 