### PR TITLE
bug: in vf-intro don't force styles on vf components

### DIFF
--- a/components/vf-intro/CHANGELOG.md
+++ b/components/vf-intro/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.2
+
+* bug: don't apply styling to `a` elements that have a `.vf-*` class
+
 ### 1.4.1
 
 * added `column-gap` as this was missed

--- a/components/vf-intro/vf-intro.scss
+++ b/components/vf-intro/vf-intro.scss
@@ -87,7 +87,7 @@
     margin-bottom: 0;
   }
 
-  & > a {
+  & > a:not([class*='vf-']) {
     @include inline-link;
   }
 }


### PR DESCRIPTION
Sometimes it useful to have a button for call-to-actions inside vf-intro, but the current CSS forces `@include inline-link;` on `a.vf-button`

And this ensures any `a.vf-*` element inside vf-intro won't get accidental styles applied.

![image](https://user-images.githubusercontent.com/928100/99074752-9e00e100-25b8-11eb-803f-f4ccafaa2353.png)
