### PR TITLE
🐛 bug: css compilation location readout

### DIFF
--- a/tools/vf-core/CHANGELOG.md
+++ b/tools/vf-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.2.12
 
 * bug: issue where the compiled css location would be incorrectly output in some scenarios
+  * https://github.com/visual-framework/vf-core/pull/1245
 
 ### 2.2.9
 

--- a/tools/vf-core/CHANGELOG.md
+++ b/tools/vf-core/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.12
+
+* bug: issue where the compiled css location would be incorrectly output in some scenarios
+
 ### 2.2.9
 
 - fix: avoid build failure on missing .eslintrc.js config in child projects

--- a/tools/vf-core/gulp-tasks/vf-css.js
+++ b/tools/vf-core/gulp-tasks/vf-css.js
@@ -43,10 +43,9 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
       return new Transform({
         objectMode: true,
         transform: (data, _, done) => {
-          location = 'components/' + location.split('components/')[1];
+          location = 'components/' + location.split(/-components\/(.+)/)[1];
           let name = JSON.parse(data.contents.toString()).name;
           let version = JSON.parse(data.contents.toString()).version;
-
           var output = `$componentInfo: (
              name: "` + name + `",
              version: "` + version + `",
@@ -54,7 +53,6 @@ module.exports = function(gulp, path, componentPath, componentDirectories, build
              vfCoreVersion: "` + global.vfVersion + `",
              buildTimeStamp: "` + new Date().toUTCString() + `"
           );`
-
           done(null, output);
         }
       })


### PR DESCRIPTION
This fixes an issue where the compiled css location would be incorrectly output in some scenarios, resulting in:

```css
 * Location: components/vf-core-
```

We'll now see the more correct:

```css
 * Location: components/vf-core-components/embl-conditional-edit
```

This issue was intermittent and appears to have mainly occurred on Mac OS, but not Linux.