### PR TITLE
The one that refactors, enhances, and starts to deprecate some things for the vf-card.

### DIFF
--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 2.3.0
+
+* adds new `--bordered` and `--striped` design variants.
+* added `vf-stack` to the `vf-card__content` element to determine spacing.
+* allows for the lack of `vf-stack` for older components.
+* started the deprecation of the 'Mortal Kombat' variants, initally by hiding them in vf-core.
+* introduced `newTheme` so the 'Mortal Kombat' variants can live side-by-side with news versions for now.
+  * the `newTheme` moves us back to the 'primary' being the embl green, the secondary the embl blue, etc.
+  * we now remove the `-theme` part of the css class moving forward as it's cleaner, easier to read, and states the same thing without it.
+* created theme variants of the new design variants (these are hidden, and should not be used).
+
 ### 2.2.1
 
 * fixes a hover issue if the card has a link and is the `--easy` variant.

--- a/components/vf-card/README.md
+++ b/components/vf-card/README.md
@@ -6,6 +6,8 @@
 
 There are currently two types of card component that can be used for your projects. Each card component requires the additional modifier class to be added into either your `.yml` file or directly into the HTML.
 
+__Do Not__ have more than one variant of the `vf-card` in a container.
+
 ## Install
 
 This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `vf-card` with this command.

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -4,7 +4,6 @@ title: Card
 label: Card
 status: alpha
 # preview: '@preview--nogrid'
-collated: true
 # The template used from /components/_previews
 #
 context:
@@ -13,11 +12,76 @@ context:
 # Per-variant options
 variants:
   - name: default
-    label: Default
-    hidden: true
+    label: default
+    context:
+      card_title: A Default Card Title
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+  - name: Default with Link
+    label: Default with Link
+    hidden: false
+    context:
+      card_title: A Default With Link Card Title
+      card_href: "JavaScript:Void(0);"
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+
+  - name: Bordered
+    label: Bordered
+    hidden: false
+    context:
+      card_title: A Bordered Card Title
+      variant: bordered
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+  - name: Bordered with Link
+    label: Bordered with Link
+    hidden: false
+    context:
+      card_title: A Bordered With Link Card Title
+      variant: bordered
+      card_href: "JavaScript:Void(0);"
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+
+  - name: Striped
+    label: Striped
+    hidden: false
+    context:
+      card_title: A Striped Card Title
+      variant: striped
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+  - name: striped-link
+    label: Striped with link
+    context:
+      card_title: A Striped Card Title with Link
+      variant: striped
+      card_href: "JavaScript:Void(0);"
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, <a class="vf-card__link" href="JavaScript:Void(0);">consectetur</a> adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+
+
+
+
+
+
+
+
+
+
+
+
+
   - name: very-easy
     label: Very Easy
-    hidden: false
+    hidden: true
     context:
       card_title: A Easy Card Title 1
       variant: very-easy
@@ -26,7 +90,7 @@ variants:
       card_image__alt: Image alt text
   - name: easy
     label: Easy
-    hidden: false
+    hidden: true
     context:
       card_title: A Easy Card Title 2
       variant: easy
@@ -35,6 +99,7 @@ variants:
       card_image__alt: Image alt text
   - name: easy--primary
     label: Easy (primary)
+    hidden: true
     context:
       card_title: Easy Card with primary accent
       theme: primary
@@ -44,6 +109,7 @@ variants:
       card_image__alt: Image alt text
   - name: easy--secondary
     label: Easy (secondary)
+    hidden: true
     context:
       theme: secondary
       variant: easy
@@ -53,6 +119,7 @@ variants:
       card_image__alt: Image alt text
   - name: easy--tertiary
     label: Easy (tertiary)
+    hidden: true
     context:
       theme: tertiary
       variant: easy
@@ -62,6 +129,7 @@ variants:
       card_image__alt: Image alt text
   - name: easy--quaternary
     label: Easy (quaternary)
+    hidden: true
     context:
       theme: quaternary
       variant: easy
@@ -71,6 +139,7 @@ variants:
       card_image__alt: Image alt text
   - name: normal
     label: Normal
+    hidden: true
     context:
       card_title: A Normal Card
       variant: normal
@@ -79,6 +148,7 @@ variants:
       card_image__alt: Image alt text
   - name: normal--primary
     label: Normal (primary)
+    hidden: true
     context:
       card_title: A Normal Card with primary accent
       theme: primary
@@ -88,7 +158,7 @@ variants:
       card_image__alt: Image alt text
   - name: normal--secondary
     label: Normal (secondary)
-    hidden: false
+    hidden: true
     context:
       theme: secondary
       variant: normal
@@ -98,7 +168,7 @@ variants:
       card_image__alt: Image alt text
   - name: normal--tertiary
     label: Normal (tertiary)
-    hidden: false
+    hidden: true
     context:
       theme: tertiary
       variant: normal
@@ -108,7 +178,7 @@ variants:
       card_image__alt: Image alt text
   - name: normal--quaternary
     label: Normal (quaternary)
-    hidden: false
+    hidden: true
     context:
       theme: quaternary
       variant: normal
@@ -118,6 +188,7 @@ variants:
       card_image__alt: Image alt text
   - name: normal--primary--with-link
     label: Normal (primary) link
+    hidden: true
     context:
       card_title: A Normal Primary Card with Link
       theme: primary

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -15,7 +15,7 @@ variants:
     label: default
     context:
       card_title: A Default Card Title
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: Default with Link
@@ -24,7 +24,7 @@ variants:
     context:
       card_title: A Default With Link Card Title
       card_href: "JavaScript:Void(0);"
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
 
@@ -35,7 +35,7 @@ variants:
       card_title: A Bordered Card Title
       variant: bordered
       newTheme: primary
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: Bordered Secondary
@@ -45,7 +45,7 @@ variants:
       card_title: A Bordered Card Title
       variant: bordered
       newTheme: secondary
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: Bordered Tertiary
@@ -55,7 +55,7 @@ variants:
       card_title: A Bordered Card Title
       variant: bordered
       newTheme: tertiary
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: Bordered with Link
@@ -66,7 +66,7 @@ variants:
       variant: bordered
       newTheme: primary
       card_href: "JavaScript:Void(0);"
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
 
@@ -77,7 +77,7 @@ variants:
       card_title: A Striped Card Title
       variant: striped
       newTheme: primary
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: Striped Secondary
@@ -87,7 +87,7 @@ variants:
       card_title: A Striped Card Title
       variant: striped
       newTheme: secondary
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: Striped Tertiary
@@ -97,7 +97,7 @@ variants:
       card_title: A Striped Card Title
       variant: striped
       newTheme: tertiary
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: striped-link
@@ -108,7 +108,7 @@ variants:
       variant: striped
       newTheme: primary
       card_href: "JavaScript:Void(0);"
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, <a class="vf-card__link" href="JavaScript:Void(0);">consectetur</a> adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
 
@@ -118,7 +118,7 @@ variants:
     context:
       card_title: A Easy Card Title 1
       variant: very-easy
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: easy
@@ -127,7 +127,7 @@ variants:
     context:
       card_title: A Easy Card Title 2
       variant: easy
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: easy--primary
@@ -137,7 +137,7 @@ variants:
       card_title: Easy Card with primary accent
       theme: primary
       variant: easy
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: easy--secondary
@@ -147,7 +147,7 @@ variants:
       theme: secondary
       variant: easy
       card_title: A Easy Card with secondary accent
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: easy--tertiary
@@ -157,7 +157,7 @@ variants:
       theme: tertiary
       variant: easy
       card_title: A Easy Card with tertiary accent
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: easy--quaternary
@@ -167,7 +167,7 @@ variants:
       theme: quaternary
       variant: easy
       card_title: A Easy Card with quaternary accent
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: normal
@@ -176,7 +176,7 @@ variants:
     context:
       card_title: A Normal Card
       variant: normal
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: normal--primary
@@ -186,7 +186,7 @@ variants:
       card_title: A Normal Card with primary accent
       theme: primary
       variant: normal
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: normal--secondary
@@ -196,7 +196,7 @@ variants:
       theme: secondary
       variant: normal
       card_title: A Normal Card with secondary accent
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: normal--tertiary
@@ -206,7 +206,7 @@ variants:
       theme: tertiary
       variant: normal
       card_title: A Normal Card with tertiary accent
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: normal--quaternary
@@ -216,7 +216,7 @@ variants:
       theme: quaternary
       variant: normal
       card_title: A Normal Card with quaternary accent
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: normal--primary--with-link
@@ -226,6 +226,6 @@ variants:
       card_title: A Normal Primary Card with Link
       theme: primary
       card_href: "JavaScript:Void(0);"
-      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg
       card_text: Lorem ipsum dolor sit amet, <a class="vf-card__link" href="JavaScript:Void(0);">consectetur</a> adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -34,6 +34,27 @@ variants:
     context:
       card_title: A Bordered Card Title
       variant: bordered
+      newTheme: primary
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+  - name: Bordered Secondary
+    label: Bordered / Secondary
+    hidden: true
+    context:
+      card_title: A Bordered Card Title
+      variant: bordered
+      newTheme: secondary
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+  - name: Bordered Tertiary
+    label: Bordered / Tertiary
+    hidden: true
+    context:
+      card_title: A Bordered Card Title
+      variant: bordered
+      newTheme: tertiary
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
@@ -43,6 +64,7 @@ variants:
     context:
       card_title: A Bordered With Link Card Title
       variant: bordered
+      newTheme: primary
       card_href: "JavaScript:Void(0);"
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
@@ -54,30 +76,41 @@ variants:
     context:
       card_title: A Striped Card Title
       variant: striped
+      newTheme: primary
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+  - name: Striped Secondary
+    label: Striped / Secondary
+    hidden: true
+    context:
+      card_title: A Striped Card Title
+      variant: striped
+      newTheme: secondary
+      card_image: ../../assets/vf-card/assets/vf-card-example.png
+      card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
+      card_image__alt: Image alt text
+  - name: Striped Tertiary
+    label: Striped / Tertiary
+    hidden: true
+    context:
+      card_title: A Striped Card Title
+      variant: striped
+      newTheme: tertiary
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
   - name: striped-link
     label: Striped with link
+    hidden: false
     context:
       card_title: A Striped Card Title with Link
       variant: striped
+      newTheme: primary
       card_href: "JavaScript:Void(0);"
       card_image: ../../assets/vf-card/assets/vf-card-example.png
       card_text: Lorem ipsum dolor sit amet, <a class="vf-card__link" href="JavaScript:Void(0);">consectetur</a> adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       card_image__alt: Image alt text
-
-
-
-
-
-
-
-
-
-
-
-
 
   - name: very-easy
     label: Very Easy

--- a/components/vf-card/vf-card.njk
+++ b/components/vf-card/vf-card.njk
@@ -8,6 +8,7 @@
   {% set card_image__alt = context.card_image__alt %}
 
   {% set theme = context.theme %}
+  {% set newTheme = context.newTheme %}
   {% set variant = context.variant %}
 
   {% set id = context.id %}
@@ -22,6 +23,7 @@
   class="vf-card
 
   {%- if theme %} vf-card-theme--{{theme}}{% endif -%}
+  {%- if newTheme %} vf-card--{{newTheme}}{% endif -%}
   {%- if variant %} vf-card--{{variant}}{% endif %}
 
   {%- if modifier %} | {{modifier}}{% endif -%}
@@ -48,5 +50,4 @@
     <p class="vf-card__text">{{- card_text -}}</p>
     {%- endif %}
   </div>
-
 </article>

--- a/components/vf-card/vf-card.njk
+++ b/components/vf-card/vf-card.njk
@@ -32,7 +32,7 @@
   <img src="{{ card_image }}" alt="{{ card_image__alt }}" class="vf-card__image" loading="lazy">
   {%- endif %}
 
-  <div class="vf-card__content">
+  <div class="vf-card__content | vf-stack vf-stack--400">
 
     <{%- if card_title %}h3{% else %}span{%- endif %} class="vf-card__title">
     {%- if card_href %}<a class="vf-card__link" href="{{ card_href if card_href else '#' }}">{% endif -%}

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -21,7 +21,6 @@
   display: grid;
   grid-template-rows: 288px 1fr;
   position: relative;
-  max-width: 360px;
 }
 
 .vf-card__image {

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -21,6 +21,7 @@
   display: grid;
   grid-template-rows: 288px 1fr;
   position: relative;
+  max-width: 360px;
 }
 
 .vf-card__image {
@@ -35,7 +36,7 @@
 
 .vf-card__content {
   grid-column: 1 / -1;
-  padding: 1rem;
+  padding: map-get($vf-spacing-map, vf-spacing--400);
 }
 
 .vf-card__title {
@@ -66,7 +67,6 @@
     }
 
     &:hover {
-      color: currentColor;
       text-decoration: none;
       &::after {
         box-shadow: 0 0 .125rem .125rem rgba(set-color(vf-color--grey), .75);
@@ -84,165 +84,22 @@
 .vf-card__text {
   @include set-type(text-body--2, $custom-margin-bottom: 0);
 
-  color: set-ui-color(vf-ui-color--black);
-  color: var( --card-text-color, #{set-ui-color(vf-ui-color--black)} );
+  color: set-ui-color(vf-ui-color--white);
+  color: var( --card-text-color, #{set-ui-color(vf-ui-color--white)} );
   a,
   .vf-card__link {
     position: relative;
     z-index: 1984;
   }
 }
-.vf-card__link {
-  @include inline-link;
-}
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-html:not(.vf-disable-deprecated) {
-  // vf-card levels of design
-  .vf-card--very-easy {
-    border-bottom: 8px solid rgba(0, 0, 0, 0); // fixes a grid layout glitch when used with variant volume's that have a bottom border
-  }
-
-  .vf-card--easy {
-    border-bottom: 8px solid set-ui-color(vf-ui-color--black);
-    border-bottom-color: var(--vf-card-theme-color--border, #{set-ui-color(vf-ui-color--black)});
-
-    .vf-card__title {
-      --card-text-color: #{set-color(vf-color--blue)};
-    }
-    .vf-card__text {
-      --card-text-color: #{set-ui-color(vf-ui-color--black)};
-    }
-
-    // fixes bug on hover of link and easy variant #1215
-    .vf-card__link {
-      &::after {
-        height: calc(100% + 8px);
-      }
-    }
-  }
-
-  .vf-card--normal {
-    --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
-    --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
-  }
-
-  .vf-card--hard {
-    --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
-    --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
-
-    .vf-card__content {
-      grid-row: 2 / -1;
-    }
-
-    .vf-card__title {
-      @include set-type(text-body--5);
-
-      display: inline-block;
-      margin-bottom: 0;
-      margin-left: -24px;
-      margin-top: 2px;
-      padding: 16px 24px;
-      text-transform: uppercase;
-    }
-
-    .vf-card__text {
-      padding-top: 16px;
-
-      .vf-card__link {
-        position: relative;
-        z-index: 1984;
-      }
-    }
-  }
-
-  // vf-card themes
-
-  [class*='ary'].vf-card--easy {
-    --vf-card-theme-color--background: #{set-ui-color(vf-ui-color--white)};
-  }
-  [class*='ary'] {
-    .vf-card__text .vf-card__link {
-      color: inherit;
-      text-decoration: underline;
-    }
-  }
-
-  .vf-card-theme--primary {
-    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
-    --vf-card-theme-color--border: #{set-color(vf-color--blue)};
-    --vf-card-theme-color--background: #{set-color(vf-color--blue)};
-  }
-
-  .vf-card-theme--secondary {
-    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
-    --vf-card-theme-color--border: #{set-color(vf-color--green)};
-    --vf-card-theme-color--background: #{set-color(vf-color--green)};
-  }
-
-  .vf-card-theme--tertiary {
-    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
-    --vf-card-theme-color--border: #{set-color(vf-color--grey--dark)};
-    --vf-card-theme-color--background: #{set-color(vf-color--grey--dark)};
-  }
-
-  .vf-card-theme--quaternary {
-    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
-    --vf-card-theme-color--border: #{set-color(vf-color--yellow)};
-    --vf-card-theme-color--background: #{set-color(vf-color--yellow)};
-  }
-
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-// Temporary Fix
-// as we are adding `vf-stack` to the `vf-card__content` we need to override
-// the existing `margin-bottom` to the `__title` and __text` components.
-
-.vf-card__content.vf-stack {
-  .vf-card__text {
-    margin-bottom: 0;
-  }
-}
-
-
-
-
-
+// --------------------------------------------------------------------------------
 // Variants
+// --------------------------------------------------------------------------------
 
 // Bordered
+// --------------------------------------------------------------------------------
+
 .vf-card--bordered {
   border-bottom: 8px solid set-color(vf-color--green);
   border-bottom-color: var(--vf-card-border-color, #{set-color(vf-color--green)});
@@ -256,6 +113,8 @@ html:not(.vf-disable-deprecated) {
 }
 
 // Striped
+// --------------------------------------------------------------------------------
+
 .vf-card--striped {
   background-color: set-color(vf-color--green--dark);
   background-color: var(--vf-card--striped-bg-color, #{set-color(vf-color--green--dark)});
@@ -264,15 +123,10 @@ html:not(.vf-disable-deprecated) {
     background-color: set-color(vf-color--green);
     background-color: var(--vf-card-bg-color, #{set-color(vf-color--green)});
     color: set-ui-color(vf-ui-color--white);
-    margin: -1rem;
-    margin-bottom: -.5rem;
-    padding: 1rem;
-    padding-bottom: .5rem;
-
-    .vf-card__link,
-    a {
-      text-decoration: none;
-    }
+    margin: map-get($vf-spacing-map, vf-spacing--400) * -1;
+    margin-bottom: map-get($vf-spacing-map, vf-spacing--200) * -1;
+    padding: map-get($vf-spacing-map, vf-spacing--400);
+    padding-bottom: map-get($vf-spacing-map, vf-spacing--200);
   }
 
   .vf-card__text {
@@ -280,23 +134,19 @@ html:not(.vf-disable-deprecated) {
 
     &:first-of-type {
       --vf-stack-margin--custom: 0;
-      padding-top: 1rem;
-    }
-
-    .vf-card__link,
-    a {
-      color: inherit;
-      text-decoration: underline;
+      padding-top: map-get($vf-spacing-map, vf-spacing--400);
     }
   }
 }
 
-
-
+// --------------------------------------------------------------------------------
 // Theming
+// --------------------------------------------------------------------------------
+
 // note:
 // - we are removing the `-theme-` part of the classname now.
 // - we are also moving towards more holistic theming with design.
+
 .vf-card--primary {
   --vf-card-bg-color: #{set-color(vf-color--green)};
   --vf-card-text-color: #{set-ui-color(vf-ui-color--white)};
@@ -317,4 +167,123 @@ html:not(.vf-disable-deprecated) {
   --vf-card-border-color: #{set-color(vf-color--grey)};
   --vf-card--striped-bg-color: #{set-color(vf-color--grey--dark)};
   --vf-card--striped-text-color: #{set-ui-color(vf-ui-color--white)};
+}
+
+// --------------------------------------------------------------------------------
+// Temporary Fix
+// --------------------------------------------------------------------------------
+
+// note: as we are adding `vf-stack` to the `vf-card__content` we need to override
+// the existing `margin-bottom` to the `__title` and __text` components.
+.vf-card__content.vf-stack {
+  .vf-card__text {
+    margin-bottom: 0;
+  }
+}
+
+
+
+
+
+
+
+// --------------------------------------------------------------------------------
+// Old Code Below -- To be deleted and removed in v3.0.0
+// --------------------------------------------------------------------------------
+
+// note: some of this CSS 'overides' CSS in the newer cards -- but only by replacing
+// like for like.
+
+// vf-card levels of design
+.vf-card--very-easy {
+  border-bottom: 8px solid rgba(0, 0, 0, 0); // fixes a grid layout glitch when used with variant volume's that have a bottom border
+}
+
+.vf-card--easy {
+  border-bottom: 8px solid set-ui-color(vf-ui-color--black);
+  border-bottom-color: var(--vf-card-theme-color--border, #{set-ui-color(vf-ui-color--black)});
+
+  .vf-card__title {
+    --card-text-color: #{set-color(vf-color--blue)};
+  }
+  .vf-card__text {
+    --card-text-color: #{set-ui-color(vf-ui-color--black)};
+  }
+
+  // fixes bug on hover of link and easy variant #1215
+  .vf-card__link {
+    &::after {
+      height: calc(100% + 8px);
+    }
+  }
+}
+
+.vf-card--normal {
+  --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
+  --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
+}
+
+.vf-card--hard {
+  --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
+  --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
+
+  .vf-card__content {
+    grid-row: 2 / -1;
+  }
+
+  .vf-card__title {
+    @include set-type(text-body--5);
+
+    display: inline-block;
+    margin-bottom: 0;
+    margin-left: -24px;
+    margin-top: 2px;
+    padding: 16px 24px;
+    text-transform: uppercase;
+  }
+
+  .vf-card__text {
+    padding-top: 16px;
+
+    .vf-card__link {
+      position: relative;
+      z-index: 1984;
+    }
+  }
+}
+
+// vf-card themes
+
+[class*='ary'].vf-card--easy {
+  --vf-card-theme-color--background: #{set-ui-color(vf-ui-color--white)};
+}
+[class*='ary'] {
+  .vf-card__text .vf-card__link {
+    color: inherit;
+    text-decoration: underline;
+  }
+}
+
+.vf-card-theme--primary {
+  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
+  --vf-card-theme-color--border: #{set-color(vf-color--blue)};
+  --vf-card-theme-color--background: #{set-color(vf-color--blue)};
+}
+
+.vf-card-theme--secondary {
+  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
+  --vf-card-theme-color--border: #{set-color(vf-color--green)};
+  --vf-card-theme-color--background: #{set-color(vf-color--green)};
+}
+
+.vf-card-theme--tertiary {
+  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
+  --vf-card-theme-color--border: #{set-color(vf-color--grey--dark)};
+  --vf-card-theme-color--background: #{set-color(vf-color--grey--dark)};
+}
+
+.vf-card-theme--quaternary {
+  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
+  --vf-card-theme-color--border: #{set-color(vf-color--yellow)};
+  --vf-card-theme-color--background: #{set-color(vf-color--yellow)};
 }

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -195,95 +195,97 @@
 // like for like.
 
 // vf-card levels of design
-.vf-card--very-easy {
-  border-bottom: 8px solid rgba(0, 0, 0, 0); // fixes a grid layout glitch when used with variant volume's that have a bottom border
-}
-
-.vf-card--easy {
-  border-bottom: 8px solid set-ui-color(vf-ui-color--black);
-  border-bottom-color: var(--vf-card-theme-color--border, #{set-ui-color(vf-ui-color--black)});
-
-  .vf-card__title {
-    --card-text-color: #{set-color(vf-color--blue)};
-  }
-  .vf-card__text {
-    --card-text-color: #{set-ui-color(vf-ui-color--black)};
+html:not(.vf-disable-deprecated) {
+  .vf-card--very-easy {
+    border-bottom: 8px solid rgba(0, 0, 0, 0); // fixes a grid layout glitch when used with variant volume's that have a bottom border
   }
 
-  // fixes bug on hover of link and easy variant #1215
-  .vf-card__link {
-    &::after {
-      height: calc(100% + 8px);
+  .vf-card--easy {
+    border-bottom: 8px solid set-ui-color(vf-ui-color--black);
+    border-bottom-color: var(--vf-card-theme-color--border, #{set-ui-color(vf-ui-color--black)});
+
+    .vf-card__title {
+      --card-text-color: #{set-color(vf-color--blue)};
     }
-  }
-}
+    .vf-card__text {
+      --card-text-color: #{set-ui-color(vf-ui-color--black)};
+    }
 
-.vf-card--normal {
-  --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
-  --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
-}
-
-.vf-card--hard {
-  --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
-  --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
-
-  .vf-card__content {
-    grid-row: 2 / -1;
-  }
-
-  .vf-card__title {
-    @include set-type(text-body--5);
-
-    display: inline-block;
-    margin-bottom: 0;
-    margin-left: -24px;
-    margin-top: 2px;
-    padding: 16px 24px;
-    text-transform: uppercase;
-  }
-
-  .vf-card__text {
-    padding-top: 16px;
-
+    // fixes bug on hover of link and easy variant #1215
     .vf-card__link {
-      position: relative;
-      z-index: 1984;
+      &::after {
+        height: calc(100% + 8px);
+      }
     }
   }
-}
 
-// vf-card themes
-
-[class*='ary'].vf-card--easy {
-  --vf-card-theme-color--background: #{set-ui-color(vf-ui-color--white)};
-}
-[class*='ary'] {
-  .vf-card__text .vf-card__link {
-    color: inherit;
-    text-decoration: underline;
+  .vf-card--normal {
+    --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
+    --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
   }
-}
 
-.vf-card-theme--primary {
-  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
-  --vf-card-theme-color--border: #{set-color(vf-color--blue)};
-  --vf-card-theme-color--background: #{set-color(vf-color--blue)};
-}
+  .vf-card--hard {
+    --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
+    --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
 
-.vf-card-theme--secondary {
-  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
-  --vf-card-theme-color--border: #{set-color(vf-color--green)};
-  --vf-card-theme-color--background: #{set-color(vf-color--green)};
-}
+    .vf-card__content {
+      grid-row: 2 / -1;
+    }
 
-.vf-card-theme--tertiary {
-  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
-  --vf-card-theme-color--border: #{set-color(vf-color--grey--dark)};
-  --vf-card-theme-color--background: #{set-color(vf-color--grey--dark)};
-}
+    .vf-card__title {
+      @include set-type(text-body--5);
 
-.vf-card-theme--quaternary {
-  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
-  --vf-card-theme-color--border: #{set-color(vf-color--yellow)};
-  --vf-card-theme-color--background: #{set-color(vf-color--yellow)};
+      display: inline-block;
+      margin-bottom: 0;
+      margin-left: -24px;
+      margin-top: 2px;
+      padding: 16px 24px;
+      text-transform: uppercase;
+    }
+
+    .vf-card__text {
+      padding-top: 16px;
+
+      .vf-card__link {
+        position: relative;
+        z-index: 1984;
+      }
+    }
+  }
+
+  // vf-card themes
+
+  [class*='ary'].vf-card--easy {
+    --vf-card-theme-color--background: #{set-ui-color(vf-ui-color--white)};
+  }
+  [class*='ary'] {
+    .vf-card__text .vf-card__link {
+      color: inherit;
+      text-decoration: underline;
+    }
+  }
+
+  .vf-card-theme--primary {
+    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
+    --vf-card-theme-color--border: #{set-color(vf-color--blue)};
+    --vf-card-theme-color--background: #{set-color(vf-color--blue)};
+  }
+
+  .vf-card-theme--secondary {
+    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
+    --vf-card-theme-color--border: #{set-color(vf-color--green)};
+    --vf-card-theme-color--background: #{set-color(vf-color--green)};
+  }
+
+  .vf-card-theme--tertiary {
+    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
+    --vf-card-theme-color--border: #{set-color(vf-color--grey--dark)};
+    --vf-card-theme-color--background: #{set-color(vf-color--grey--dark)};
+  }
+
+  .vf-card-theme--quaternary {
+    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
+    --vf-card-theme-color--border: #{set-color(vf-color--yellow)};
+    --vf-card-theme-color--background: #{set-color(vf-color--yellow)};
+  }
 }

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -21,6 +21,7 @@
   display: grid;
   grid-template-rows: 288px 1fr;
   position: relative;
+  max-width: 360px;
 }
 
 .vf-card__image {
@@ -39,7 +40,7 @@
 }
 
 .vf-card__title {
-  @include set-type(text-heading--3 , $custom-margin-bottom: 0);
+  @include set-type(text-heading--3);
 
   // font-weight: 700;
 
@@ -86,14 +87,12 @@
 
   color: set-ui-color(vf-ui-color--black);
   color: var( --card-text-color, #{set-ui-color(vf-ui-color--black)} );
-
   a,
   .vf-card__link {
     position: relative;
     z-index: 1984;
   }
 }
-
 .vf-card__link {
   @include inline-link;
 }
@@ -109,18 +108,145 @@
 
 
 
+
+
+
+
+
+
+
+
+
+html:not(.vf-disable-deprecated) {
+  // vf-card levels of design
+  .vf-card--very-easy {
+    border-bottom: 8px solid rgba(0, 0, 0, 0); // fixes a grid layout glitch when used with variant volume's that have a bottom border
+  }
+
+  .vf-card--easy {
+    border-bottom: 8px solid set-ui-color(vf-ui-color--black);
+    border-bottom-color: var(--vf-card-theme-color--border, #{set-ui-color(vf-ui-color--black)});
+
+    .vf-card__title {
+      --card-text-color: #{set-color(vf-color--blue)};
+    }
+    .vf-card__text {
+      --card-text-color: #{set-ui-color(vf-ui-color--black)};
+    }
+
+    // fixes bug on hover of link and easy variant #1215
+    .vf-card__link {
+      &::after {
+        height: calc(100% + 8px);
+      }
+    }
+  }
+
+  .vf-card--normal {
+    --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
+    --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
+  }
+
+  .vf-card--hard {
+    --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
+    --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
+
+    .vf-card__content {
+      grid-row: 2 / -1;
+    }
+
+    .vf-card__title {
+      @include set-type(text-body--5);
+
+      display: inline-block;
+      margin-bottom: 0;
+      margin-left: -24px;
+      margin-top: 2px;
+      padding: 16px 24px;
+      text-transform: uppercase;
+    }
+
+    .vf-card__text {
+      padding-top: 16px;
+
+      .vf-card__link {
+        position: relative;
+        z-index: 1984;
+      }
+    }
+  }
+
+  // vf-card themes
+
+  [class*='ary'].vf-card--easy {
+    --vf-card-theme-color--background: #{set-ui-color(vf-ui-color--white)};
+  }
+  [class*='ary'] {
+    .vf-card__text .vf-card__link {
+      color: inherit;
+      text-decoration: underline;
+    }
+  }
+
+  .vf-card-theme--primary {
+    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
+    --vf-card-theme-color--border: #{set-color(vf-color--blue)};
+    --vf-card-theme-color--background: #{set-color(vf-color--blue)};
+  }
+
+  .vf-card-theme--secondary {
+    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
+    --vf-card-theme-color--border: #{set-color(vf-color--green)};
+    --vf-card-theme-color--background: #{set-color(vf-color--green)};
+  }
+
+  .vf-card-theme--tertiary {
+    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
+    --vf-card-theme-color--border: #{set-color(vf-color--grey--dark)};
+    --vf-card-theme-color--background: #{set-color(vf-color--grey--dark)};
+  }
+
+  .vf-card-theme--quaternary {
+    --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
+    --vf-card-theme-color--border: #{set-color(vf-color--yellow)};
+    --vf-card-theme-color--background: #{set-color(vf-color--yellow)};
+  }
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// Temporary Fix
+// as we are adding `vf-stack` to the `vf-card__content` we need to override
+// the existing `margin-bottom` to the `__title` and __text` components.
+
+.vf-card__content.vf-stack {
+  .vf-card__text {
+    margin-bottom: 0;
+  }
+}
+
+
+
+
+
 // Variants
 
 // Bordered
-
 .vf-card--bordered {
   border-bottom: 8px solid set-color(vf-color--green);
-  border-bottom-color: var(--vf-card-theme-color--border, #{set-color(vf-color--green)});
-
-  .vf-card__title {
-  }
-  .vf-card__text {
-  }
+  border-bottom-color: var(--vf-card-border-color, #{set-color(vf-color--green)});
 
   // fixes bug on hover of link and easy variant #1215
   .vf-card__link {
@@ -130,15 +256,20 @@
   }
 }
 
-
+// Striped
 .vf-card--striped {
-  background: set-color(vf-color--green--dark);
+  background-color: set-color(vf-color--green--dark);
+  background-color: var(--vf-card--striped-bg-color, #{set-color(vf-color--green--dark)});
 
   .vf-card__title {
     background-color: set-color(vf-color--green);
-    color: white;
-    margin: -1rem -1rem -1rem -1rem;
-    padding: 1rem 1rem 1rem 1rem;
+    background-color: var(--vf-card-bg-color, #{set-color(vf-color--green)});
+    color: set-ui-color(vf-ui-color--white);
+    margin: -1rem;
+    margin-bottom: -.5rem;
+    padding: 1rem;
+    padding-bottom: .5rem;
+
     .vf-card__link,
     a {
       text-decoration: none;
@@ -146,111 +277,45 @@
   }
 
   .vf-card__text {
-    color: white;
-    padding-top: 1rem;
-  }
-  .vf-card__link,
-  a {
-    color: inherit;
-    text-decoration: underline;
-  }
-}
+    color: set-ui-color(vf-ui-color--white);
 
+    &:first-of-type {
+      --vf-stack-margin--custom: 0;
+      padding-top: 1rem;
+    }
 
-
-
-
-
-// vf-card levels of design
-.vf-card--very-easy {
-  border-bottom: 8px solid rgba(0, 0, 0, 0); // fixes a grid layout glitch when used with variant volume's that have a bottom border
-}
-
-.vf-card--easy {
-  border-bottom: 8px solid set-ui-color(vf-ui-color--black);
-  border-bottom-color: var(--vf-card-theme-color--border, #{set-ui-color(vf-ui-color--black)});
-
-  .vf-card__title {
-    --card-text-color: #{set-color(vf-color--blue)};
-  }
-  .vf-card__text {
-    --card-text-color: #{set-ui-color(vf-ui-color--black)};
-  }
-
-  // fixes bug on hover of link and easy variant #1215
-  .vf-card__link {
-    &::after {
-      height: calc(100% + 8px);
+    .vf-card__link,
+    a {
+      color: inherit;
+      text-decoration: underline;
     }
   }
 }
 
-.vf-card--normal {
-  --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
-  --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
+
+
+// Theming
+// note:
+// - we are removing the `-theme-` part of the classname now.
+// - we are also moving towards more holistic theming with design.
+.vf-card--primary {
+  --vf-card-bg-color: #{set-color(vf-color--green)};
+  --vf-card-text-color: #{set-ui-color(vf-ui-color--white)};
+  --vf-card-border-color: #{set-color(vf-color--green)};
+  --vf-card--striped-bg-color: #{set-color(vf-color--green--dark)};
+  --vf-card--striped-text-color: #{set-ui-color(vf-ui-color--white)};
 }
-
-.vf-card--hard {
-  --card-text-color: var(--vf-card-theme-color--foreground, #{set-ui-color(vf-ui-color--white)});
-  --card-background-color: var(--vf-card-theme-color--background, #{set-ui-color(vf-ui-color--black)});
-
-  .vf-card__content {
-    grid-row: 2 / -1;
-  }
-
-  .vf-card__title {
-    @include set-type(text-body--5);
-
-    display: inline-block;
-    margin-bottom: 0;
-    margin-left: -24px;
-    margin-top: 2px;
-    padding: 16px 24px;
-    text-transform: uppercase;
-  }
-
-  .vf-card__text {
-    padding-top: 16px;
-
-    .vf-card__link {
-      position: relative;
-      z-index: 1984;
-    }
-  }
+.vf-card--secondary {
+  --vf-card-bg-color: #{set-color(vf-color--blue)};
+  --vf-card-text-color: #{set-ui-color(vf-ui-color--white)};
+  --vf-card-border-color: #{set-color(vf-color--blue)};
+  --vf-card--striped-bg-color: #{set-color(vf-color--blue--dark)};
+  --vf-card--striped-text-color: #{set-ui-color(vf-ui-color--white)};
 }
-
-// vf-card themes
-
-[class*='ary'].vf-card--easy {
-  --vf-card-theme-color--background: #{set-ui-color(vf-ui-color--white)};
-}
-[class*='ary'] {
-  .vf-card__text .vf-card__link {
-    color: inherit;
-    text-decoration: underline;
-  }
-}
-
-.vf-card-theme--primary {
-  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
-  --vf-card-theme-color--border: #{set-color(vf-color--blue)};
-  --vf-card-theme-color--background: #{set-color(vf-color--blue)};
-}
-
-.vf-card-theme--secondary {
-  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
-  --vf-card-theme-color--border: #{set-color(vf-color--green)};
-  --vf-card-theme-color--background: #{set-color(vf-color--green)};
-}
-
-.vf-card-theme--tertiary {
-  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--white)};
-  --vf-card-theme-color--border: #{set-color(vf-color--grey--dark)};
-  --vf-card-theme-color--background: #{set-color(vf-color--grey--dark)};
-}
-
-.vf-card-theme--quaternary {
-  --vf-card-theme-color--foreground: #{set-ui-color(vf-ui-color--black)};
-  --vf-card-theme-color--border: #{set-color(vf-color--yellow)};
-  --vf-card-theme-color--background: #{set-color(vf-color--yellow)};
+.vf-card--tertiary {
+  --vf-card-bg-color: #{set-color(vf-color--grey)};
+  --vf-card-text-color: #{set-ui-color(vf-ui-color--white)};
+  --vf-card-border-color: #{set-color(vf-color--grey)};
+  --vf-card--striped-bg-color: #{set-color(vf-color--grey--dark)};
+  --vf-card--striped-text-color: #{set-ui-color(vf-ui-color--white)};
 }

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -35,11 +35,13 @@
 
 .vf-card__content {
   grid-column: 1 / -1;
-  padding: 16px 24px;
+  padding: 1rem;
 }
 
 .vf-card__title {
-  @include set-type(text-heading--3);
+  @include set-type(text-heading--3 , $custom-margin-bottom: 0);
+
+  // font-weight: 700;
 
   background-color: var(--card-background-color);
   color: set-ui-color(vf-ui-color--black);
@@ -80,7 +82,7 @@
 }
 
 .vf-card__text {
-  @include set-type(text-body--2);
+  @include set-type(text-body--2, $custom-margin-bottom: 0);
 
   color: set-ui-color(vf-ui-color--black);
   color: var( --card-text-color, #{set-ui-color(vf-ui-color--black)} );
@@ -95,6 +97,69 @@
 .vf-card__link {
   @include inline-link;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+// Variants
+
+// Bordered
+
+.vf-card--bordered {
+  border-bottom: 8px solid set-color(vf-color--green);
+  border-bottom-color: var(--vf-card-theme-color--border, #{set-color(vf-color--green)});
+
+  .vf-card__title {
+  }
+  .vf-card__text {
+  }
+
+  // fixes bug on hover of link and easy variant #1215
+  .vf-card__link {
+    &::after {
+      height: calc(100% + 8px);
+    }
+  }
+}
+
+
+.vf-card--striped {
+  background: set-color(vf-color--green--dark);
+
+  .vf-card__title {
+    background-color: set-color(vf-color--green);
+    color: white;
+    margin: -1rem -1rem -1rem -1rem;
+    padding: 1rem 1rem 1rem 1rem;
+    .vf-card__link,
+    a {
+      text-decoration: none;
+    }
+  }
+
+  .vf-card__text {
+    color: white;
+    padding-top: 1rem;
+  }
+  .vf-card__link,
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+}
+
+
+
+
+
 
 // vf-card levels of design
 .vf-card--very-easy {


### PR DESCRIPTION
From the changelog:

* adds new `--bordered` and `--striped` design variants.
* added `vf-stack` to the `vf-card__content` element to determine spacing.
* allows for the lack of `vf-stack` for older components.
* started the deprecation of the 'Mortal Kombat' variants, initally by hiding them in vf-core.
* introduced `newTheme` so the 'Mortal Kombat' variants can live side-by-side with news versions for now.
  * the `newTheme` moves us back to the 'primary' being the embl green, the secondary the embl blue, etc.
  * we now remove the `-theme` part of the css class moving forward as it's cleaner, easier to read, and states the same thing without it.
* created theme variants of the new design variants (these are hidden, and should not be used).