### PR TITLE
fix: vf-sass-config import order

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -3,6 +3,7 @@
 * introduces a `space` Sass function to save the keystrokes.
   * instead of typeing `map-get($vf-spacing-map, vf-spacing--400)` you can write `spacing(400)` for the same result.
 * I've added this terse naming of the function for `set-color` and `set-ui-color` to be something like `color(green)` instead of `set-color(vf-color--green)`. The old way still works.
+* fixes import order of `vf-global-custom-properties.scss`
 
 ### 2.2.1
 

--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -4,6 +4,7 @@
   * instead of typeing `map-get($vf-spacing-map, vf-spacing--400)` you can write `spacing(400)` for the same result.
 * I've added this terse naming of the function for `set-color` and `set-ui-color` to be something like `color(green)` instead of `set-color(vf-color--green)`. The old way still works.
 * fixes import order of `vf-global-custom-properties.scss`
+  * https://github.com/visual-framework/vf-core/pull/1263
 
 ### 2.2.1
 

--- a/components/vf-sass-config/index.scss
+++ b/components/vf-sass-config/index.scss
@@ -1,5 +1,5 @@
 @import 'variables/vf-variables.scss';
-@import 'variables/vf-global-custom-properties.scss';
 @import 'variables/vf-global-variables.scss';
 @import 'functions/vf-functions.scss';
 @import 'mixins/vf-mixins.scss';
+@import 'variables/vf-global-custom-properties.scss';


### PR DESCRIPTION
`variables/vf-global-custom-properties.scss` should be imported after `mixins/vf-mixins.scss`

From:

```css
/* --- test */
.test {
  padding: space(400);
  --test: #{space(400)};
}
```

I now can get the expected:

```css
/* stylelint-enable */
:root {
  --vf-body-width: 81.25em;
  --page-grid-gap: map-get($vf-spacing-map, vf-spacing--400);
  --embl-grid-module--prime: 16rem;
  --embl-grid-spacing-normaliser: 0px;
  /* custom prop test */
  padding: 1rem;
  --test: 1rem;
}
```