### PR TITLE
the one that fixes tiny transitional bug with card titles

### DIFF
--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.3.1
+
+* issue with margin-bottom still in place when using `vf-stack` with `vf-card__content`.
+
 ### 2.3.0
 
 * adds new `--bordered` and `--striped` design variants.

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -175,6 +175,7 @@
 // note: as we are adding `vf-stack` to the `vf-card__content` we need to override
 // the existing `margin-bottom` to the `__title` and __text` components.
 .vf-card__content.vf-stack {
+  .vf-card__title,
   .vf-card__text {
     margin-bottom: 0;
   }


### PR DESCRIPTION
because we're not trying to wholesale deprecate existing `vf-card` components that are in use we add some more specific css to remove margins from the `__title` and `__text` when it's a new component.

I missed the margin bottom reset for `__title` in the last PR for the `vf-card`.

This will need to go into the component / vf-core release _and_ get pulled into the embl.org repo -- else cards will have some big spaces. 