### PR TITLE
the one that adds a max-content width so shorter titles

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.2
+
+* adds a width of `max-content` to the `__content` part of the component so short titles don't look silly.
+
 ### 2.0.1
 
 * adds the option to add an url to `vf-hero__heading` with nunjucks/yaml.

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -43,6 +43,7 @@
   padding: map-get($vf-spacing-map, vf-spacing--400);
   padding: calc( var(--vf-hero--spacing) / 2);
   position: relative;
+  width: max-content;
   z-index: set-layer(vf-z-index--hero);
 
   @supports (filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, .1))) {


### PR DESCRIPTION
one thing I noticed while pre-emptively looking at `vf-hero` being used on embl.org was that our current (`v2.0.1`) has a `max-width` of `60ch`. 

This makes some things look wrong and gives them too much of the dreaded white space.

before:
![Screenshot 2020-11-27 at 14 45 24](https://user-images.githubusercontent.com/925197/100460520-3b7f0900-30bf-11eb-9d1c-e2c23c0bc840.png)

after:
![Screenshot 2020-11-27 at 14 46 01](https://user-images.githubusercontent.com/925197/100460560-4b96e880-30bf-11eb-8946-7317c32242df.png)
