### PR TITLE
the one that fixes bug where the Sass was being printed for custom property

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.3.1
+
+* fixes bug in --page-grid-gap printing Sass function in CSS
+
 ### 2.3.0
 
 * introduces a `space` Sass function to save the keystrokes.

--- a/components/vf-sass-config/variables/vf-global-custom-properties.scss
+++ b/components/vf-sass-config/variables/vf-global-custom-properties.scss
@@ -2,12 +2,12 @@
 :root {
   --vf-body-width: #{$vf-layout--comfortable};
 
-  --page-grid-gap: map-get($vf-spacing-map, vf-spacing--400);
+  --page-grid-gap: #{space(400)};
 
   --embl-grid-module--prime: 16rem;
   --embl-grid-spacing-normaliser: 0px;
 
   @media (min-width: 75em) {
-    --page-grid-gap: #{map-get($vf-spacing-map, vf-spacing--800)};
+    --page-grid-gap: #{space(800)};
   }
 }


### PR DESCRIPTION
this will fix the issue where the grid doesn't work on smaller viewports. because everything bunches together.

The Sass function wasn't interpolated -- updated to do this and make use of `space()` too. 

Will need releasing to NPM 