### PR TITLE
The one that fixes a couple of issues for the vf-hero

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.0.3
+
+* adds the context options so the component can be used in 11ty with content seperation.
+* changes `max-content` to `fit-content` so the `__content` element adapts to smaller viewports.
+* removes left padding from `--block` variant as it 'looked weird'.
+
 ### 2.0.2
 
 * adds a width of `max-content` to the `__content` part of the component so short titles don't look silly.

--- a/components/vf-hero/vf-hero.njk
+++ b/components/vf-hero/vf-hero.njk
@@ -5,6 +5,16 @@
   {% set vf_hero_subheading = context.vf_hero_subheading %}
   {% set vf_hero_image = context.vf_hero_image %}
 
+  {% set striped = context.striped %}
+  {% set inverted = context.inverted %}
+  {% set theme = context.theme %}
+  {% set newTheme = context.newTheme %}
+  {% set flush = context.flush %}
+  {% set offset = context.offset %}
+  {% set block = context.block %}
+  {% set centered = context.centered %}
+  {% set spacing = context.spacing %}
+
   {% set id = context.id %}
   {% set modifier_class = context.modifier_class %}
   {% set override_class = context.override_class %}

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -43,7 +43,8 @@
   padding: map-get($vf-spacing-map, vf-spacing--400);
   padding: calc( var(--vf-hero--spacing) / 2);
   position: relative;
-  width: max-content;
+  width: fit-content;
+  width: -moz-fit-content;
   z-index: set-layer(vf-z-index--hero);
 
   @supports (filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, .1))) {
@@ -282,7 +283,7 @@
   .vf-hero__content {
 
     // padding: 1.5rem;
-    // padding-left: 0;
+    padding-left: 0;
 
     &::before {
       background-color: inherit;


### PR DESCRIPTION
- adds the `context` for all the new options available so it works when using `{% include …%}
- changes `max-content` to `fit-content` (and `-moz-fit-content` for Firefox) so that the `vf-hero__content` responds to the browser viewport width.
- removes left padding from `vf-hero--block` as it 'looks weird' 