### PR TITLE
the one that fixes missing context items

### DIFF
--- a/components/vf-hero/vf-hero.njk
+++ b/components/vf-hero/vf-hero.njk
@@ -1,9 +1,11 @@
 {%- if context %}
 
-  {% set vf_hero_heading = context.vf_hero_heading %}
-  {% set vf_hero_summary_title = context.vf_hero_summary_title %}
-  {% set vf_hero_subheading = context.vf_hero_subheading %}
   {% set vf_hero_image = context.vf_hero_image %}
+
+  {% set vf_hero_heading = context.vf_hero_heading %}
+  {% set vf_hero_heading_additional = context.vf_hero_heading_additional %}
+  {% set vf_hero_subheading = context.vf_hero_subheading %}
+  {% set vf_hero_text = context.vf_hero_text %}
 
   {% set striped = context.striped %}
   {% set inverted = context.inverted %}


### PR DESCRIPTION
adds

```
{% set vf_hero_text = context.vf_hero_text %}
```
and
```
{% set vf_hero_heading_additional = context.vf_hero_heading_additional %}
```