### PR TITLE
the one that fixes SVG used with within the `vf-hero` link

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.5
+
+* adds a `flex` property to the SVG so that it's always visible and doesn't get cut off.
+
 ### 2.0.4
 
 * fixes missing context rule for `hero__text` and `hero__heading--additional`.

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -106,6 +106,7 @@
 
   svg {
     fill: currentColor;
+    flex: 1 0 auto;
     margin-left: map-get($vf-spacing-map, vf-spacing--200);
   }
 


### PR DESCRIPTION
before:

![Screenshot 2020-12-03 at 15 17 52](https://user-images.githubusercontent.com/925197/101048707-c312bf00-357a-11eb-850c-ffb5dd79baba.png)


adding `flex: 1 0 auto` to the SVG:

![Screenshot 2020-12-03 at 15 18 00](https://user-images.githubusercontent.com/925197/101048760-d160db00-357a-11eb-930e-54e82f8f9672.png)


I think this is can be considered a 'hot fix' and we should discuss wether the icon should flow with the text or always be 'top right' of the link / heading when on smaller viewports