### PR TITLE
Chore: change vf-banner dismiss button default

### DIFF
--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.7.0
+
+* Banner dismiss button now defaults to `vf-button--primary` (if a specific button variant has been requested by `vfJsBannerButtonTheme`, it will still be used)
+
 ### 1.6.3
 
 * Bug: For fixed banners, avoid interpretting numbers as strings and blowing out the page padding

--- a/components/vf-banner/vf-banner.js
+++ b/components/vf-banner/vf-banner.js
@@ -1,6 +1,5 @@
 // vf-banner
 
-
 // Turn the below code snippet into a banner
 // <div class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--notice"
 // data-vf-js-banner
@@ -211,7 +210,8 @@ function vfBannerInsert(banner,bannerId,scope) {
       generatedBannerHtml += "<button class=\"vf-button vf-button--tertary\" data-vf-js-banner-close>"+banner.vfJsBannerButtonText+"</button>";
     }
     else {
-      generatedBannerHtml += "<button class=\"vf-button vf-button--secondary\" data-vf-js-banner-close>"+banner.vfJsBannerButtonText+"</button>";
+      // default
+      generatedBannerHtml += "<button class=\"vf-button vf-button--primary\" data-vf-js-banner-close>"+banner.vfJsBannerButtonText+"</button>";
     }
   }
 


### PR DESCRIPTION
* Banner dismiss button now defaults to `vf-button--primary` (if a specific button variant has been requested by `vfJsBannerButtonTheme`, it will still be used)