### PR TITLE
Chore: typo in npm install command

### DIFF
--- a/components/embl-conditional-edit/README.md
+++ b/components/embl-conditional-edit/README.md
@@ -16,7 +16,7 @@ Note: this method is not about hiding the a URL from a user being able to see th
 
 ## Install
 
-This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `primer-buttons` with this command.
+This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install with this command.
 
 ```
 $ yarn add --dev @visual-framework/embl-conditional-edit

--- a/components/embl-content-hub-loader/README.md
+++ b/components/embl-content-hub-loader/README.md
@@ -48,8 +48,7 @@ Breakdown:
 
 ## Install
 
-This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `primer-buttons` with this command.
-
+This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install with this command.
 ```
 $ yarn add --dev @visual-framework/embl-content-hub-loader
 ```

--- a/components/vf-article-meta-information/README.md
+++ b/components/vf-article-meta-information/README.md
@@ -8,7 +8,7 @@ Use this alongside articles, news items and blog posts.
 
 ## Install
 
-This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `primer-buttons` with this command.
+This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install with this command.
 
 ```
 $ yarn add --dev @visual-framework/vf-article-meta-information

--- a/components/vf-discussion/README.md
+++ b/components/vf-discussion/README.md
@@ -8,7 +8,7 @@ For comment-style discussions.
 
 ## Install
 
-This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `primer-buttons` with this command.
+This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install with this command.
 
 ```
 $ yarn add --dev @visual-framework/vf-discussion

--- a/components/vf-inlay/README.md
+++ b/components/vf-inlay/README.md
@@ -4,7 +4,7 @@
 
 ## Install
 
-This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `primer-buttons` with this command.
+This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install with this command.
 
 ```
 $ yarn add --dev @visual-framework/vf-inlay

--- a/components/vf-intro/README.md
+++ b/components/vf-intro/README.md
@@ -54,7 +54,7 @@ vf_intro_text:
 ```
 ## Install
 
-This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install `vf-profile` with this command.
+This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install with this command.
 
 ```
 $ yarn add --dev @visual-framework/vf-intro

--- a/components/vf-lede/README.md
+++ b/components/vf-lede/README.md
@@ -8,7 +8,7 @@ Use `vf-lede` for introductory text.
 
 ## Install
 
-This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `primer-buttons` with this command.
+This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install with this command.
 
 ```
 $ yarn add --dev @visual-framework/vf-lede

--- a/components/vf-pagination/README.md
+++ b/components/vf-pagination/README.md
@@ -6,7 +6,7 @@
 
 ## Install
 
-This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `primer-buttons` with this command.
+This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install with this command.
 
 ```
 $ yarn add --dev @visual-framework/vf-pagination

--- a/components/vf-search/README.md
+++ b/components/vf-search/README.md
@@ -10,7 +10,7 @@
 
 ## Install
 
-This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `primer-buttons` with this command.
+This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://www.npmjs.com/get-npm) and [yarn](https://classic.yarnpkg.com/en/docs/install), you can install with this command.
 
 ```
 $ yarn add --dev @visual-framework/vf-search


### PR DESCRIPTION
Found these while going through the docs.  Several components refer in the text to installing `primer-buttons`.

This fixes that.

We should wait to merge this one after a `lerna publish` so we don't trigger a bunch of superflous version bumps.