### PR TITLE
the one that improves spacing and usability of video teaser

### DIFF
--- a/components/vf-video-teaser/CHANGELOG.md
+++ b/components/vf-video-teaser/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 2.0.0
+
+* Uses `vf-stack` to space component.
+* Adds `if` statement for the heading.
+* Makes it possible to have more than one teaser.
+* Makes the link the whole 'item' like `vf-card`.
+
 ### 1.0.0
 
 * adds loading="lazy" to the img element for better performance

--- a/components/vf-video-teaser/vf-video-teaser.config.yml
+++ b/components/vf-video-teaser/vf-video-teaser.config.yml
@@ -4,6 +4,15 @@ status: beta
 
 context:
   component-type: block
-  vf_video_teaser__title: More on our YouTube channel
-  vf_video_teaser__link: New theory deepens understanding of Turing patterns
-  video_href: 'JavaScript:Void(0);'
+
+variants:
+  - name: default
+    context:
+      vf_video_teaser__title: More on our YouTube channel
+      teasers:
+        - vf_video_teaser__link: A presentation on something to do with Life Sciences.
+          vf_video_teaser__poster: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SEMINARS_1102_lecture_vision2020_hd_retouched_500px.jpg
+          video_href: "JavaScript:Void(0);"
+        - vf_video_teaser__link: Take a look at the fancy Helix building
+          vf_video_teaser__poster: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/CONFERENCES_NonCodingSymp_7804_Retouched_500px.jpg
+          video_href: "JavaScript:Void(0);"

--- a/components/vf-video-teaser/vf-video-teaser.njk
+++ b/components/vf-video-teaser/vf-video-teaser.njk
@@ -1,5 +1,14 @@
-<div class="vf-video-teaser">
-  <h3 class="vf-video-teaser__title">{{ vf_video_teaser__title }}</h3>
-  <a href="{{ video_href }}"><img class="vf-video-teaser__image" src="{{ '../../assets/vf-video-teaser/assets/video-teaser.png' | path }}" alt="" loading="lazy"></a>
-  <a href="{{ video_href }}" class="vf-video-teaser__link vf-link">{{ vf_video_teaser__link }}</a>
+<div class="vf-video-teaser | vf-stack vf-stack--400">
+
+  {% if vf_video_teaser__title -%}
+    <h3 class="vf-video-teaser__title">{{ vf_video_teaser__title }}</h3>
+  {%- endif %}
+
+  {% for item in teasers %}
+  <article class="vf-video-teaser__item | vf-stack vf-stack--400">
+    <img class="vf-video-teaser__image" src="{{ item.vf_video_teaser__poster }}" alt="{{ item.vf_video_teaser_alt_text }}" loading="lazy">
+    <a href="{{ item.video_href }}" class="vf-video-teaser__link vf-link">{{ item.vf_video_teaser__link }}</a>
+  </article>
+  {% endfor %}
+
 </div>

--- a/components/vf-video-teaser/vf-video-teaser.scss
+++ b/components/vf-video-teaser/vf-video-teaser.scss
@@ -32,9 +32,6 @@
     position: absolute;
     right: 0;
     top: 0;
-    transition-duration: 300ms;
-    transition-property: box-shadow;
-    transition-timing-function: ease-in-out;
     z-index: 512;
   }
 

--- a/components/vf-video-teaser/vf-video-teaser.scss
+++ b/components/vf-video-teaser/vf-video-teaser.scss
@@ -12,12 +12,42 @@
 .vf-video-teaser__image {
   display: block;
   height: auto;
-  margin-bottom: 16px;
   max-width: 100%;
   width: 100%;
 }
 
 .vf-video-teaser__title {
-  @include set-type(text-heading--3);
-  margin: 0 0 16px 0;
+  @include set-type(text-heading--3, $custom-margin-bottom: 0);
+}
+
+.vf-video-teaser__link {
+  @include set-type(text-body--2, $custom-margin-bottom: 0);
+
+  display: inline-block;
+
+  &::after {
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition-duration: 300ms;
+    transition-property: box-shadow;
+    transition-timing-function: ease-in-out;
+    z-index: 512;
+  }
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+
+.vf-video-teaser__item {
+  position: relative;
+}
+
+.vf-video-teaser__item:not(:first-of-type) {
+  --vf-stack-margin--custom: 2rem;
 }


### PR DESCRIPTION
I made a start on removing the `margin-bottom` of components so we can use `vf-stack` to help space things properly but…

vf-video-teaser seemed to be missing some things and needed an update all by itself, although I don't think this has been used anywhere yet (there's no sign of it static-html-pages).

Update includes:

* Uses `vf-stack` to space component.
* Adds `if` statement for the heading.
* Makes it possible to have more than one teaser.
* Makes the link the whole 'item' like `vf-card`.
* Move the default to a variant, as this should help for when people use `{% render … %}`