### PR TITLE
Enhancement: Add vf-news-container--featured

### DIFF
--- a/components/vf-news-container/CHANGELOG.md
+++ b/components/vf-news-container/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.0-rc.1
+
+* Adds vf-news-container--featured
+  * https://github.com/visual-framework/vf-core/issues/1036
+
 ### 1.0.0-alpha.8
 
 * Version bump only for package @visual-framework/vf-news-container

--- a/components/vf-news-container/README.md
+++ b/components/vf-news-container/README.md
@@ -4,6 +4,8 @@
 
 ## About
 
+Use this component to show a section of news content. It also offers a `vf-news-container--featured` variant with support for `vf-summary` for when news is a higher level and, well, featured content on layout.
+
 ## Install
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-news-container` with this command.

--- a/components/vf-news-container/vf-news-container--featured.njk
+++ b/components/vf-news-container/vf-news-container--featured.njk
@@ -1,7 +1,7 @@
-<section class="vf-news-container | embl-grid">
+<section class="vf-news-container vf-news-container--featured | embl-grid">
   {% render '@vf-section-header'%}
 
-  <div class="vf-news-container__content">
+  <div class="vf-news-container__content vf-grid">
     {% render '@vf-summary--news-has-image' %}
     {% render '@vf-summary--news-has-image' %}
     {% render '@vf-summary--news-has-image' %}
@@ -13,3 +13,4 @@
   </div>
   -->
 </section>
+

--- a/components/vf-news-container/vf-news-container.scss
+++ b/components/vf-news-container/vf-news-container.scss
@@ -9,3 +9,24 @@
  * Location: #{map-get($componentInfo, 'location')}
  */
 
+
+.vf-news-container--featured {
+  .vf-summary {
+    grid-template-columns: none;
+  }
+
+  .vf-summary > .vf-summary__date {
+    grid-row: 7;
+  }
+
+  .vf-summary > .vf-summary__image {
+    max-width: 100%;
+    margin-bottom: 16px;
+  }
+
+  @media (max-width: 600px) {
+     .vf-summary {
+      grid-row-gap: 0;
+    }
+  }
+}

--- a/components/vf-summary/CHANGELOG.md
+++ b/components/vf-summary/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.1
+
+* Fix image URL in vf-summary--news-has-image.
+
 ### 1.4.0
 
 * makes the title of summary a little larger

--- a/components/vf-summary/vf-summary--news-has-image.njk
+++ b/components/vf-summary/vf-summary--news-has-image.njk
@@ -1,6 +1,6 @@
 <article class="vf-summary vf-summary--news">
   <span class="vf-summary__date">22 June 2018</span>
-  <img class="vf-summary__image" src="{{ '../../assets/vf-summary/assets/vf-summary--news-has-image.jpg' | path }}" alt="" loading="lazy">
+  <img class="vf-summary__image" src="../../assets/vf-summary/assets/vf-summary--news-has-image.jpg" alt="News image alt" loading="lazy">
   <h3 class="vf-summary__title">
     <a href="{{ summary__href }}" class="vf-summary__link">
       {{ summary__title }}


### PR DESCRIPTION
This addresses the long-lingering #1036, where we've been sprinkling local CSS to achieve a "Featured news" container.

Even though the vf-summary and vf-news-container have uncertain futures, this would stop the propagation of "local CSS" across sites to enable a smoother transition to "the new thing", once we figure out what it is.