### PR TITLE
The one that makes components stack (a little)

### DIFF
--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 3.1.0
+
+* updates to expect `vf-stack` on the body.
+* removes the backwords compatability as we're at v3.x.
+* tidies up and removes some unrequired CSS.
+
 ### 3.0.1
 
 * removes padding

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -18,12 +18,8 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
   box-sizing: border-box;
   display: flex;
   flex-wrap: wrap;
-  gap: .5rem;
-  grid-column: 1 / -1;
-  height: auto;
-  margin: .5rem auto 0 auto;
-  max-width: $vf-layout--comfortable;
-  width: 100%;
+  gap: space(200);
+  margin-top: space(200);
 
   & > [class*='logo'] {
     flex: 1; // necessary for when a logo is inside flex-based containers like vf-global-header
@@ -42,16 +38,12 @@ $vf-global-header__link-text--color: set-ui-color(vf-ui-color--black);
   }
 }
 
-// backwards compatibility with .vf-global-header 1.x vf-global-header__inner
-// will be removed in vf-global-header 3.0
-html:not(.vf-disable-deprecated) {
-  .vf-global-header__inner {
-    align-items: center;
-    box-sizing: border-box;
-    display: flex;
-    flex-wrap: wrap;
-    grid-column: 1 / -1;
-    padding: .5rem 0;
-    width: 100%;
-  }
+// Currently the GDPR banner stays in the DOM rather than getting destroyed.
+// Because of this it becomes the first item in the `vf-stack` so the next item,
+// the vf-global-header, has a top margin of 1rem.
+// This fixes that:
+// Note: we duplicate the top margin that's already on line 22.
+
+.vf-banner + div {
+  --vf-stack-margin--custom: space(200);
 }

--- a/components/vf-navigation/CHANGELOG.md
+++ b/components/vf-navigation/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.2.0
+
+* removes bottom margin for `--main`.
+* replaces padding with margin for `--main`.
+* duplicates the top margin for `--main` because sometimes it's out of the `vf-stack` flow.
+
 ### 2.1.0
 
 * fixes a bug with the `--additional` variant.

--- a/components/vf-navigation/vf-navigation--main.scss
+++ b/components/vf-navigation/vf-navigation--main.scss
@@ -2,7 +2,7 @@
 @import 'vf-navigation.variables.scss';
 
 .vf-navigation--main {
-  padding: 16px 0;
+  margin-top: space(400);
 
   .vf-navigation__item {
 


### PR DESCRIPTION
Now that we are adding `vf-stack vf-stack--400` to the <body> element (blogpost on this is in the works) there are some components that we need to remove the margin from. 

To start with I've only changed two components:

- `vf-global-header`
- `vf-navigation--main`

As _everything else_ has a mix-match of top or bottom margins and we are looking to create a more 'generic' `vf-region` component I think we can leave it for now.


We are aiming to:

-  'push' down by only using margin-top.
- make components 'free' from their margins and get it dictated by the parent. So a blocks margin will get it from the container and a container will get it from the page.


One thing to note is that the `vf-footer` on the homepage might need some additional CSS in the `static-html-pages` projects CSS to remove the margin.


We also need to update the global header used via the content hub -- the markup is woefully out of date.