### PR TITLE
The one that makes the `vf-figure` responsive.

### DIFF
--- a/components/vf-figure/CHANGELOG.md
+++ b/components/vf-figure/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.4.0
+
+* Removed `width: 100%` from the `.vf-figure__image` class.
+* Added `display: block` to the `.vf-figure__image` class.
+* Removed CSS for the width when the `vf-figure` is using floats.
+
 ### 1.3.0
 
 * adds loading="lazy" to the img element for better performance

--- a/components/vf-figure/CHANGELOG.md
+++ b/components/vf-figure/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.4.0
+### 2.0.0
 
 * Removed `width: 100%` from the `.vf-figure__image` class.
 * Added `display: block` to the `.vf-figure__image` class.

--- a/components/vf-figure/README.md
+++ b/components/vf-figure/README.md
@@ -4,17 +4,15 @@
 
 ## About
 
-The `vf-figure` componet defaults to give the image a maximum width of 100% so that it can be placed inside of a grid (like `vf-grid`) and fill the space of the grid item(s) that have been allocated by its parent.
+The `vf-figure` component can be used to display and caption diagrams, illustrations, photos, etc. This is to be used as a 'single' item of content that if it was removed from the page or have its position moved in the DOM it would not affect the pages other content.
 
 ## Usage
 
-If you need to specify the width of the component you can use the CSS custom property `--vf-figure__width` which will override the width in the CSS.
-
-The `vf-figure` component also has some alignment class selectors available.
+The `vf-figure` component can be used within any existing Visual Framework layout component. The size of the `vf-figure` is dictated by the size of the image rather and responds to the browser viewport if the viewport is smaller. The `vf-figure` component also has some alignment class selectors available which can float or centre the component in and around the other content on the page.
 
 ### Class Selectors
 
-- `vf-figure--align`: required to align the component depending on where it is needed. This class also changes the width of the image to `auto` but can still be overriden with `--vf-figure__width`. The class also changes the `display` to `display: table` so that we can confine the `figcaption` inside of the `figure` HTML element without any overflow.
+- `vf-figure--align`: required to align the component depending on where it is needed. The class also changes the `display` to `display: table` so that we can confine the `figcaption` inside of the `figure` HTML element without any overflow.
 - `vf-figure--align-inline-start`: This class adds `float: left;`.
 - `vf-figure--align-inline-end`: This class adds `float: right;`.
 - `vf-figure--align-inline-centered`: This class adds `margin: 0 auto;`.

--- a/components/vf-figure/vf-figure.scss
+++ b/components/vf-figure/vf-figure.scss
@@ -14,18 +14,13 @@
 }
 
 .vf-figure__image {
+  display: block;
   height: auto;
   max-width: 100%;
-  width: var(--vf-figure__width, 100%);
 }
 
 .vf-figure--align {
   display: table;
-
-  .vf-figure__image {
-    max-width: unset;
-    width: var(--vf-figure__width, auto);
-  }
 
   .vf-figure__caption {
     caption-side: bottom;


### PR DESCRIPTION
The `vf-figure` was pretty strict in the amount of space it took up, and the use of a CSS custom property to change the width isn't really viable in places like blog pots. 

Highlighted by @kasprzyk-sz - this PR makes the `vf-figure__image` act like a 'responsive image' by defaulting to the image size as the width. Rather than 'brute forcing' it with `width: 100%`.

This should make things a lot easier for usage, moving forward. 