### PR TITLE
Bug: missing imports in component index.scss files

### DIFF
--- a/components/vf-activity-group/CHANGELOG.md
+++ b/components/vf-activity-group/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.0-alpha.9
+
+* Resolve issue of missing import in index.scss
+  * https://github.com/visual-framework/vf-core/pull/1306
+
 ### 1.0.0-alpha.8 (2019-10-23)
 
 * Version bump only for package @visual-framework/vf-activity-group

--- a/components/vf-activity-group/index.scss
+++ b/components/vf-activity-group/index.scss
@@ -1,5 +1,6 @@
 // setup files required
 
+@import 'vf-global-variables';
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';

--- a/components/vf-font-plex-mono/CHANGELOG.md
+++ b/components/vf-font-plex-mono/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.1.1
+
+* Resolve issue of missing import in index.scss
+  * https://github.com/visual-framework/vf-core/pull/1306
+
 ### 1.1.0
 
 * removes path in Sass @import as not needed

--- a/components/vf-font-plex-mono/index.scss
+++ b/components/vf-font-plex-mono/index.scss
@@ -1,6 +1,7 @@
 // setup files required
 
 // sass-lint:disable clean-import-paths
+@import 'vf-global-variables';
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';

--- a/components/vf-font-plex-sans/CHANGELOG.md
+++ b/components/vf-font-plex-sans/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.1.1
+
+* Resolve issue of missing import in index.scss
+  * https://github.com/visual-framework/vf-core/pull/1306
+
 ### 1.1.0
 
 * removes path in Sass @import as not needed

--- a/components/vf-font-plex-sans/index.scss
+++ b/components/vf-font-plex-sans/index.scss
@@ -1,6 +1,7 @@
 // setup files required
 
 // sass-lint:disable clean-import-paths
+@import 'vf-global-variables';
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';

--- a/components/vf-intro/CHANGELOG.md
+++ b/components/vf-intro/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.4.3
+
+* Resolve issue of missing import in index.scss
+  * https://github.com/visual-framework/vf-core/pull/1306
+
 ### 1.4.2
 
 * bug: don't apply styling to `a` elements that have a `.vf-*` class

--- a/components/vf-intro/index.scss
+++ b/components/vf-intro/index.scss
@@ -1,5 +1,6 @@
 // setup files required
 
+@import 'vf-global-variables';
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';

--- a/components/vf-link-list/CHANGELOG.md
+++ b/components/vf-link-list/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.3.1
+
+* Resolve issue of missing import in index.scss
+  * https://github.com/visual-framework/vf-core/pull/1306
+
 ### 1.3.0
 
 * makes the `vf-links__heading` optional.

--- a/components/vf-link-list/index.scss
+++ b/components/vf-link-list/index.scss
@@ -1,5 +1,6 @@
 // setup files required
 
+@import 'vf-global-variables';
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';

--- a/components/vf-page-header/CHANGELOG.md
+++ b/components/vf-page-header/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.1.1
+
+* Resolve issue of missing import in index.scss
+  * https://github.com/visual-framework/vf-core/pull/1306
+
 ### 1.1.0
 
 * updates spacing design tokens

--- a/components/vf-page-header/index.scss
+++ b/components/vf-page-header/index.scss
@@ -1,5 +1,6 @@
 // setup files required
 
+@import 'vf-global-variables';
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';

--- a/components/vf-section-header/CHANGELOG.md
+++ b/components/vf-section-header/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.3.1
+
+* Resolve issue of missing import in index.scss
+  * https://github.com/visual-framework/vf-core/pull/1306
+
 ### 1.3.0
 
 * updates spacing design tokens

--- a/components/vf-section-header/index.scss
+++ b/components/vf-section-header/index.scss
@@ -1,5 +1,6 @@
 // setup files required
 
+@import 'vf-global-variables';
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';


### PR DESCRIPTION
Several components were missing the vf-global-variables from their index.scss file, resulting in this on the compontent css build:

```
[18:28:47] Starting 'vf-css:generate-component-css'...
[18:28:47] Finished 'vf-css:generate-component-css' after 1.29 ms
Error: Undefined variable.
  ╷
6 │ @mixin set-type($font-size, $font-family: $global-font-family, $custom-margin-bottom: auto) {
  │                                           ^^^^^^^^^^^^^^^^^^^
  ╵
  ../../components/vf-sass-config/mixins/_typography.scss 6:43  set-type()
  ../../components/vf-heading/vf-heading.scss 17:3              @import
  ../../components/vf-section-header/index.scss 9:9             root stylesheet
Error: Undefined variable.
   ╷
22 │     @if $vf-include-normalisations == true {
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  ../../components/vf-sass-config/mixins/_typography.scss 22:9    set-type()
...
```

This resolves that.