### PR TITLE
Bug: fix vf-tabs display

### DIFF
--- a/components/vf-tabs/CHANGELOG.md
+++ b/components/vf-tabs/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.2.0
+
+* Restructures that link between tabs from a sequential relationship to an explicit relationship based off the tab href and panel id.
+  * https://github.com/visual-framework/vf-core/issues/1136
+* This is a non-breaking change that may be further improved with an optional data-vf-js-tab-id
+
 ### 1.1.2
 
 * JS linting

--- a/components/vf-tabs/README.md
+++ b/components/vf-tabs/README.md
@@ -4,7 +4,13 @@
 
 ## About
 
-The ever-useful tabs. This component works best with the included JS, but you can use the CSS styling on other tab sets, like Bootstrap tabs.
+The ever-useful tabs. This component works best with the included JS, but you can use the CSS styling on other tab implementations, like Bootstrap tabs.
+
+## Usage
+
+These tabs have been made with accessibility in mind, however tabs should be avoided where content structure avoids the need to use tabs.
+
+Nested tabs are also possible, as demonstrated in the example, however this provides further usability challenges and should be strongly avoided.
 
 ## Install
 

--- a/components/vf-tabs/vf-tabs.config.yml
+++ b/components/vf-tabs/vf-tabs.config.yml
@@ -39,11 +39,11 @@ context:
                 <p>Nullam at diam nec arcu suscipit auctor non a erat. Sed et magna semper, eleifend magna non, facilisis nisl. Proin et est et lorem dictum finibus ut nec turpis. Aenean nisi tortor, euismod a mauris a, mattis scelerisque tortor. Sed dolor risus, varius a nibh id, condimentum lacinia est. In lacinia cursus odio a aliquam. Curabitur tortor magna, laoreet ut rhoncus at, sodales consequat tellus.</p>
               </section>
             </div>
-    - tab_title: A Rather Long Section
+    - tab_title: A fifth section
       tab_number: 5
-      tab_heading: Section 3
+      tab_heading: Section 5
       tab_content: Phasellus ac tristique orci. Nulla maximus <a class="vf-link" href="#">justo nec dignissim consequat</a>. Sed vehicula diam sit amet mi efficitur vehicula in in nisl. Aliquam erat volutpat. Suspendisse lorem turpis, accumsan consequat consectetur gravida, <a class="vf-link" href="#">pellentesque ac ante</a>. Aliquam in commodo ligula, sit amet mollis neque. Vestibulum at facilisis massa.
-    - tab_title: A Rather Long Section
+    - tab_title: A sixth section
       tab_number: 6
-      tab_heading: Section 3
+      tab_heading: Section 6
       tab_content: Phasellus ac tristique orci. Nulla maximus <a class="vf-link" href="#">justo nec dignissim consequat</a>. Sed vehicula diam sit amet mi efficitur vehicula in in nisl. Aliquam erat volutpat. Suspendisse lorem turpis, accumsan consequat consectetur gravida, <a class="vf-link" href="#">pellentesque ac ante</a>. Aliquam in commodo ligula, sit amet mollis neque. Vestibulum at facilisis massa.

--- a/components/vf-tabs/vf-tabs.js
+++ b/components/vf-tabs/vf-tabs.js
@@ -33,8 +33,14 @@ function vfTabs(scope) {
       oldTab.removeAttribute("aria-selected");
       oldTab.setAttribute("tabindex", "-1");
       oldTab.classList.remove("is-active");
-      let oldIndex = Array.prototype.indexOf.call(tabs, oldTab);
-      panels[oldIndex].hidden = true;
+
+      for (let item = 0; item < panels.length; item++) {
+        const panel = panels[item];
+        if (panel.id === oldTab.id){
+          panel.hidden = true;
+          break;
+        }
+      }
     }
 
     newTab.focus();
@@ -45,15 +51,21 @@ function vfTabs(scope) {
     newTab.classList.add("is-active");
     // Get the indices of the new tab to find the correct
     // tab panel to show
-    let index = Array.prototype.indexOf.call(tabs, newTab);
-    panels[index].hidden = false;
+    for (let item = 0; item < panels.length; item++) {
+      const panel = panels[item];
+      if (panel.id === newTab.id){
+        panel.hidden = false;
+        break;
+      }
+    }
   };
 
   // Add semantics are remove user focusability for each tab
   Array.prototype.forEach.call(tabs, (tab, i) => {
+    const tabId = tab.href.split('#')[1]; // calculate an ID based off the tab href (todo: add support for a vf-js-tab-id, and if set use that)
     tab.setAttribute("role", "tab");
-    tab.setAttribute("id", "tab" + (i + 1));
-    tab.setAttribute("data-tabs__item", "tab" + (i + 1));
+    tab.setAttribute("id", tabId);
+    tab.setAttribute("data-tabs__item", tabId);
     tab.setAttribute("tabindex", "-1");
     tab.parentNode.setAttribute("role", "presentation");
 
@@ -89,7 +101,7 @@ function vfTabs(scope) {
     panel.setAttribute("role", "tabpanel");
     panel.setAttribute("tabindex", "-1");
     // let id = panel.getAttribute("id");
-    panel.setAttribute("aria-labelledby", tabs[i].id);
+    panel.setAttribute("aria-labelledby", panel.id);
     panel.hidden = true;
   });
 

--- a/components/vf-tabs/vf-tabs.js
+++ b/components/vf-tabs/vf-tabs.js
@@ -62,7 +62,7 @@ function vfTabs(scope) {
 
   // Add semantics are remove user focusability for each tab
   Array.prototype.forEach.call(tabs, (tab, i) => {
-    const tabId = tab.href.split('#')[1]; // calculate an ID based off the tab href (todo: add support for a vf-js-tab-id, and if set use that)
+    const tabId = tab.href.split('#')[1]; // calculate an ID based off the tab href (todo: add support for a data-vf-js-tab-id, and if set use that)
     tab.setAttribute("role", "tab");
     tab.setAttribute("id", tabId);
     tab.setAttribute("data-tabs__item", tabId);


### PR DESCRIPTION
There were a couple of display issues with the content titles that made the actual bug behaviour hard to follow.

* Restructures that link between tabs from a sequential relationship to an explicit relationship based off the tab href and panel id.
  * https://github.com/visual-framework/vf-core/issues/1136
* This is a non-breaking change that may be further improved with an optional data-vf-js-tab-id

Fixes #1136