### PR TITLE
bug: embl-content-hub-loader results in errors in some conditions

### DIFF
--- a/components/embl-content-hub-loader/CHANGELOG.md
+++ b/components/embl-content-hub-loader/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.8
+
+* Fix a bug when vfBanner or vfTabs are not present
+  * https://github.com/visual-framework/vf-core/issues/809
+
 ### 1.0.7
 
 * JS linting

--- a/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
@@ -178,7 +178,7 @@ function emblContentHubFetch() {
     // we would use `typeof(vfBanner)` but if the function is not present it becomes aliased as `vfBanner.vfBanner`,
     // so this `try` method is more reliable
     try {
-      targetLocation(targetLocation);
+      vfBanner(targetLocation);
     } catch (error) {
       console.warn("emblContentHubLoader", "vfBanner not found, any contentHub banner-based content will not correctly render.");
     }

--- a/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
@@ -174,11 +174,18 @@ function emblContentHubFetch() {
     emblContentHubUpdateDatesFormat(position);
 
     // run JS for some components on content, if they exist
-    if (typeof(vfBanner) === "function") {
-      vfBanner(targetLocation);
+    // note: why do we use "try" here?
+    // we would use `typeof(vfBanner)` but if the function is not present it becomes aliased as `vfBanner.vfBanner`,
+    // so this `try` method is more reliable
+    try {
+      targetLocation(targetLocation);
+    } catch (error) {
+      console.warn("emblContentHubLoader", "vfBanner not found, any contentHub banner-based content will not correctly render.");
     }
-    if (typeof(vfTabs) === "function") {
+    try {
       vfTabs(targetLocation);
+    } catch (error) {
+      console.warn("emblContentHubLoader", "vfTabs not found, any contentHub tabs-based content will not correctly render.");
     }
     // don't run breadcrumbs as part of contenthub, use case is different
     // if (typeof(emblBreadcrumbs) === 'function') {


### PR DESCRIPTION
This resolves the issue by wrapping in a `try` statement. It also warns if vfTabs or vfBanner functions aren't found, as they should be used by official EMBL sites using the contentHub loader.

vfTabs is more optional, but vfBanner is a "must" for the data protection banner.

Closes #809