### PR TITLE
bug: section-header-closing-tag

### DIFF
--- a/components/vf-section-header/CHANGELOG.md
+++ b/components/vf-section-header/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.3.2
+
+* Removes an extra `}` in the Nunjucks template that was corrupting the html.
+* Better handle whitespace.
+
 ### 1.3.1
 
 * Resolve issue of missing import in index.scss

--- a/components/vf-section-header/CHANGELOG.md
+++ b/components/vf-section-header/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Removes an extra `}` in the Nunjucks template that was corrupting the html.
 * Better handle whitespace.
+* https://github.com/visual-framework/vf-core/pull/1317
 
 ### 1.3.1
 

--- a/components/vf-section-header/vf-section-header.njk
+++ b/components/vf-section-header/vf-section-header.njk
@@ -18,13 +18,13 @@
 <div class="vf-section-header">
   <{{tags}}
     class="vf-section-header__heading{% if href %} vf-section-header__heading--is-link{% endif %}" {% if href %}href="{{href}}"{% endif -%}
-    {%- if id %} id="{{id}}"{% endif -%}}
+    {%- if id %} id="{{id}}"{% endif -%}
   >
-    {{ section_title }}
+    {{- section_title -}}
 
-    {% if href %}
+    {%- if href %}
       <svg aria-hidden="true" class="vf-section-header__icon | vf-icon vf-icon-arrow--inline-end" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="" fill-rule="nonzero"></path></svg>
-    {% endif %}
+    {%- endif -%}
 
   </{{tags}}>
   {% if section__subheading %}
@@ -37,8 +37,6 @@
       <p class="vf-section-header__text">{{section__content}}</p>
     {%- endeach -%}
   {%- endif -%}
-
 </div>
-
 
 {% endspaceless %}


### PR DESCRIPTION
There was an extra `}` in the Nunjucks template that was corrupting the html.