### PR TITLE
Bug: vf-intro usage of vf_intro_subheading

### DIFF
--- a/components/vf-intro/CHANGELOG.md
+++ b/components/vf-intro/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.4.4
+
+* Fixes a missing vf_intro_subheading vf-intro.njk's context.
+* Fixes README.md invalid example syntax.
+* https://github.com/visual-framework/vf-core/pull/1326
+
 ### 1.4.3
 
 * Resolve issue of missing import in index.scss

--- a/components/vf-intro/README.md
+++ b/components/vf-intro/README.md
@@ -12,27 +12,27 @@ The `vf-intro` component is to be used as the main title of a page or section wh
 
 To use this component in a `vf-eleventy` project you will need to set the context for the content to pass through from the nunjucks file associated yaml file and include it.
 
-<code>&lcub;% set context == UniqueContextName %&rcub;
+<code>&lcub;% set context = UniqueContextName %&rcub;
 <br>
 &lcub;% include containers.vf_intro %&rcub;
 </code>
 
-**note:** due to how nunjucks handles special characters we have remove the `@` at sign and need to replace the `-` hyphen used for an `_` underscore to `&lcub;% include &rcub;` a component or container. As shown above instead of writing something like `&lcub;% include contaienrs.@vf-intro &rcub;` we need to type `&lcub;% include vf_intro &rcub;`
+**note:** due to how nunjucks handles special characters we have remove the `@` at sign and need to replace the `-` hyphen used for an `_` underscore to `{ include }` a component or container. As shown above instead of writing something like `{ include containers.@vf-intro }` we need to type `{ include containers.intro }`
 
-You may wish to make use of some of your projects side specifc data or content. To do this you will need to set the relevant items of content before you <code>&lcub;% include ... %&rcub;</code> the component. Note: If you also declare this content in the `.yml` file it will take precedence over the inlined code.
+You may wish to make use of some of your projects side specific data or content. To do this you will need to set the relevant items of content before you <code>&lcub;% include ... %&rcub;</code> the component. Note: If you also declare this content in the `.yml` file it will take precedence over the inlined code.
 
 For example. If you wanted to make use of your projects `siteConfig` information. You can write out the inclusion of the component in you pages `.njk` file like so:
 
-<code>&lcub;% set context == UniqueContextName %&rcub;
+<code>&lcub;% set context = UniqueContextName %&rcub;
 <br>
-&lcub;% set vf_intro_heading == siteConfig.siteInformation.short_description %&rcub;
+&lcub;% set vf_intro_heading = siteConfig.siteInformation.short_description %&rcub;
 <br>
 &lcub;% include containers.intro %&rcub;
 </code>
 
 ### Content
 
-The `vf-intro` allows for a variet of text.
+The `vf-intro` allows for a variety of text.
 
 | content type | variable                | description |
 | ------------ | ----------------------- | ----------- |

--- a/components/vf-intro/vf-intro.njk
+++ b/components/vf-intro/vf-intro.njk
@@ -7,6 +7,7 @@
 
   {% set vf_intro_badge = context.vf_intro_badge %}
 
+  {% set vf_intro_subheading = context.vf_intro_subheading %}
   {% set vf_intro_lede = context.vf_intro_lede %}
 
   {% set vf_intro_text = context.vf_intro_text %}


### PR DESCRIPTION
While working on #1325 I ntoiced that `vf_intro_subheading` was missing from the context in vf-intro.njk, also the README.md had some invalid syntax.