### PR TITLE
Chore: use feature to disable banner from EBI VF 1.4

### DIFF
--- a/components/ebi-header-footer/CHANGELOG.md
+++ b/components/ebi-header-footer/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.0.1
+
+* Use VF 1.4 JS to load the HTML for the global header.
+* Add documentation and example on disabling the 1.4 data protection banner, as you should use the 2.0 data protection banner from the contentHub.
+
 ### 2.0.0
 
 * Adds distinct footer, header templates as the header currently has more legacy dependencies.

--- a/components/ebi-header-footer/README.md
+++ b/components/ebi-header-footer/README.md
@@ -12,6 +12,7 @@ This provides support for using the EMBL-EBI header and footer from the EMBL-EBI
 - This requires VF 2.0 footer CSS and other styles.
 - If you do not currently have VF 2.0 CSS and JS as part of your project, [you can use the CDN JS](https://stable.visual-framework.dev/#cdn).
 - This uses the existing `//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/script.js` to load the HTML for the header.
+- The EBI VF 1.x will also included a data protection banner, to disable this with 1.4 you can an included an element with `data-protection-message-disable="true"`
 
 ## Install
 

--- a/components/ebi-header-footer/ebi-header-footer--header.njk
+++ b/components/ebi-header-footer/ebi-header-footer--header.njk
@@ -1,5 +1,8 @@
+<!-- Tell the VF 1.4 not to display a data protection banner. -->
+<!-- You should use the 2.0 data protection banner from the contentHub. -->
+<span data-protection-message-disable="true"></span>
 <!-- embl-ebi global header -->
 <header id="masthead-black-bar" class="clearfix masthead-black-bar | ebi-header-footer vf-content vf-u-fullbleed"></header>
 <link rel="import" href="https://www.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=6682&pattern=node-body&source=contenthub" data-target="self" data-embl-js-content-hub-loader>
 <link rel="stylesheet" href="//ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
-<script defer="defer" src="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/script.js"></script>
+<script defer="defer" src="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js"></script>


### PR DESCRIPTION
Add documentation and example on disabling the 1.4 data protection banner, as you should use the 2.0 data protection banner from the contentHub