### PR TITLE
adds design principles to documentation site

### DIFF
--- a/tools/vf-component-library/src/site/_includes/navigation.njk
+++ b/tools/vf-component-library/src/site/_includes/navigation.njk
@@ -4,6 +4,9 @@
       <a href="/about" class="vf-navigation__link">About</a>
     </li>
     <li class="vf-navigation__item">
+      <a href="/design-principles" class="vf-navigation__link">Design Principles</a>
+    </li>
+    <li class="vf-navigation__item">
       <a href="/components" class="vf-navigation__link">Components</a>
     </li>
     <li class="vf-navigation__item">

--- a/tools/vf-component-library/src/site/design-principles/index.njk
+++ b/tools/vf-component-library/src/site/design-principles/index.njk
@@ -72,7 +72,7 @@ layout: layouts/base.njk
     <h2 class="vf-section-header__heading">Sustainable</h2>
   </div>
   <div class="vf-content | vf-stack vf-stack--400">
-    <h3 style="margin-top: 0;">Make it Sustainable</h3>
+    <h3>Make it Sustainable</h3>
     <p>We will create a long-term, sustainable system. Designed for efficiency, re-use, and scale.</p>
 
     <p>Sustainable systems are diverse and productive indefinitely. Being holistically focussed on how EMBL interacts with its audiences internal and external, means we create meaningful, sustainable experiences over the longer term.</p>
@@ -84,7 +84,7 @@ layout: layouts/base.njk
     <h2 class="vf-section-header__heading">Visible</h2>
   </div>
   <div class="vf-content">
-    <h3 style="margin-top: 0;">Show Our Work</h3>
+    <h3>Show Our Work</h3>
     <p>We will prioritise demonstration over discussion. Through prototyping we will show how these principles and values apply to the work.</p>
 
     <p>We will embrace modern design practices by starting small and iterating quickly. We will avoid big reveals and develop a process of publishing early and often. This requires a change of mindset of the team: to be comfortable with ‘not done yet’; to be satisfied to prioritise function over form; to get the things we make in the hands of our audience so we can understand their needs more quickly.</p>
@@ -96,7 +96,7 @@ layout: layouts/base.njk
     <h2 class="vf-section-header__heading">Simple</h2>
   </div>
   <div class="vf-content">
-  <h3 style="margin-top: 0;">Keep It Simple</h3>
+  <h3>Keep It Simple</h3>
     <p>We will do the difficult work to keep the things we make simple, approachable, and put the user’s needs first.</p>
 
     <p>EMBL is complex. As are the audiences, services, applications, and communications material that operate within the brand. We will do the hard work to uncover and expose the simplicity of the core.</p>
@@ -108,7 +108,7 @@ layout: layouts/base.njk
     <h2 class="vf-section-header__heading">Unified</h2>
   </div>
   <div class="vf-content">
-  <h3 style="margin-top: 0;">We are all one institute</h3>
+  <h3>We are all one institute</h3>
       <p>We will cultivate cross-pollination of services, products, ideas, and collaboration.</p>
 
       <p>We will proactively seek out opportunities to collaborate on the design of services across all channels throughout EMBL and invite feedback and new perspectives. We will share and discuss our methods.</p>
@@ -120,7 +120,7 @@ layout: layouts/base.njk
     <h2 class="vf-section-header__heading">Syncronised</h2>
   </div>
   <div class="vf-content">
-    <h3 style="margin-top: 0;">Physical, digital, and environmental are in sync</h3>
+    <h3>Physical, digital, and environmental are in sync</h3>
     <p>We will ensure a holistic approach for one system for all printed, digital and environmental touch-points.</p>
 
     <p>Design systems across media evolve at different rates. We will ensure systems across all channels are relevant to the media, but also share nomenclature, design patterns, and are built from the same principles. We will think and act as a cross-disciplinary design team.</p>
@@ -132,7 +132,7 @@ layout: layouts/base.njk
     <h2 class="vf-section-header__heading">Ingrained</h2>
   </div>
   <div class="vf-content">
-    <h3 style="margin-top: 0;">Repeat the words we use</h3>
+    <h3>Repeat the words we use</h3>
     <p>Through consistency and repetition, we will create and maintain a design nomenclature that will become part of the EMBL vernacular.</p>
 
     <p>The words we use are important. By repeating these words about EMBLs products and services, they can remind us many times every day what we believe. Changing the words we use can help change the culture of an organisation to be more design and brand aware.</p>

--- a/tools/vf-component-library/src/site/design-principles/index.njk
+++ b/tools/vf-component-library/src/site/design-principles/index.njk
@@ -1,0 +1,140 @@
+---
+is_index: true
+title: Design Principles
+subtitle:
+date: 2021-02-02 13:29:50
+section: Design Principles
+order: 1
+tags:
+  - design principles
+  - sections
+layout: layouts/base.njk
+---
+
+{% include "navigation.njk" %}
+
+{% render '@vf-intro', {
+  "vf_intro_heading": title,
+  "vf_intro_subheading": "",
+  "vf_intro_lede": "",
+  "vf_intro_text": [
+    'Many organisations have design principles to guide their work. They are often described as ‘the star to sail your ship by’; a set of common beliefs and guidelines for a project, product, organisation, or initiative.'
+  ],
+  "vf_intro_badge": false
+} %}
+<section class="embl-grid">
+<div><!-- empty div --></div>
+<div class="vf-links vf-links__list--easy">
+  <h3 class="vf-links__heading">On this page</h3>
+  <ul class="vf-links__list | vf-list">
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#Sustainable">
+        Sustainable
+        <svg class="vf-icon vf-icon__arrow--down | vf-list__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.249,7.207,11.233,19.678h0a1.066,1.066,0,0,0,1.539,0L23.751,7.207a.987.987,0,0,0-.107-1.414l-1.85-1.557a1.028,1.028,0,0,0-1.438.111L12.191,13.8a.25.25,0,0,1-.379,0L3.644,4.346A1.021,1.021,0,0,0,2.948,4a1,1,0,0,0-.741.238L.356,5.793A.988.988,0,0,0,0,6.478.978.978,0,0,0,.249,7.207Z"></path></svg>
+      </a>
+    </li>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#Visible">
+        Visible
+        <svg class="vf-icon vf-icon__arrow--down | vf-list__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.249,7.207,11.233,19.678h0a1.066,1.066,0,0,0,1.539,0L23.751,7.207a.987.987,0,0,0-.107-1.414l-1.85-1.557a1.028,1.028,0,0,0-1.438.111L12.191,13.8a.25.25,0,0,1-.379,0L3.644,4.346A1.021,1.021,0,0,0,2.948,4a1,1,0,0,0-.741.238L.356,5.793A.988.988,0,0,0,0,6.478.978.978,0,0,0,.249,7.207Z"></path></svg>
+      </a>
+    </li>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#Simple">
+        Simple
+        <svg class="vf-icon vf-icon__arrow--down | vf-list__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.249,7.207,11.233,19.678h0a1.066,1.066,0,0,0,1.539,0L23.751,7.207a.987.987,0,0,0-.107-1.414l-1.85-1.557a1.028,1.028,0,0,0-1.438.111L12.191,13.8a.25.25,0,0,1-.379,0L3.644,4.346A1.021,1.021,0,0,0,2.948,4a1,1,0,0,0-.741.238L.356,5.793A.988.988,0,0,0,0,6.478.978.978,0,0,0,.249,7.207Z"></path></svg>
+      </a>
+    </li>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#Unified">
+        Unified
+        <svg class="vf-icon vf-icon__arrow--down | vf-list__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.249,7.207,11.233,19.678h0a1.066,1.066,0,0,0,1.539,0L23.751,7.207a.987.987,0,0,0-.107-1.414l-1.85-1.557a1.028,1.028,0,0,0-1.438.111L12.191,13.8a.25.25,0,0,1-.379,0L3.644,4.346A1.021,1.021,0,0,0,2.948,4a1,1,0,0,0-.741.238L.356,5.793A.988.988,0,0,0,0,6.478.978.978,0,0,0,.249,7.207Z"></path></svg>
+      </a>
+    </li>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#Syncronised">
+        Syncronised
+        <svg class="vf-icon vf-icon__arrow--down | vf-list__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.249,7.207,11.233,19.678h0a1.066,1.066,0,0,0,1.539,0L23.751,7.207a.987.987,0,0,0-.107-1.414l-1.85-1.557a1.028,1.028,0,0,0-1.438.111L12.191,13.8a.25.25,0,0,1-.379,0L3.644,4.346A1.021,1.021,0,0,0,2.948,4a1,1,0,0,0-.741.238L.356,5.793A.988.988,0,0,0,0,6.478.978.978,0,0,0,.249,7.207Z"></path></svg>
+      </a>
+    </li>
+    <li class="vf-list__item">
+      <a class="vf-list__link" href="#Ingrained">
+        Ingrained
+        <svg class="vf-icon vf-icon__arrow--down | vf-list__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.249,7.207,11.233,19.678h0a1.066,1.066,0,0,0,1.539,0L23.751,7.207a.987.987,0,0,0-.107-1.414l-1.85-1.557a1.028,1.028,0,0,0-1.438.111L12.191,13.8a.25.25,0,0,1-.379,0L3.644,4.346A1.021,1.021,0,0,0,2.948,4a1,1,0,0,0-.741.238L.356,5.793A.988.988,0,0,0,0,6.478.978.978,0,0,0,.249,7.207Z"></path></svg>
+      </a>
+    </li>
+  </ul>
+</div>
+</section>
+
+<section class="embl-grid">
+  <div class="vf-section-header" id="Sustainable">
+    <h2 class="vf-section-header__heading">Sustainable</h2>
+  </div>
+  <div class="vf-content | vf-stack vf-stack--400">
+    <h3 style="margin-top: 0;">Make it Sustainable</h3>
+    <p>We will create a long-term, sustainable system. Designed for efficiency, re-use, and scale.</p>
+
+    <p>Sustainable systems are diverse and productive indefinitely. Being holistically focussed on how EMBL interacts with its audiences internal and external, means we create meaningful, sustainable experiences over the longer term.</p>
+  </div>
+</section>
+<hr class="vf-divider">
+<section class="embl-grid">
+  <div class="vf-section-header" id="Visibke">
+    <h2 class="vf-section-header__heading">Visible</h2>
+  </div>
+  <div class="vf-content">
+    <h3 style="margin-top: 0;">Show Our Work</h3>
+    <p>We will prioritise demonstration over discussion. Through prototyping we will show how these principles and values apply to the work.</p>
+
+    <p>We will embrace modern design practices by starting small and iterating quickly. We will avoid big reveals and develop a process of publishing early and often. This requires a change of mindset of the team: to be comfortable with ‘not done yet’; to be satisfied to prioritise function over form; to get the things we make in the hands of our audience so we can understand their needs more quickly.</p>
+  </div>
+</section>
+<hr class="vf-divider">
+<section class="embl-grid">
+  <div class="vf-section-header" id="Simple">
+    <h2 class="vf-section-header__heading">Simple</h2>
+  </div>
+  <div class="vf-content">
+  <h3 style="margin-top: 0;">Keep It Simple</h3>
+    <p>We will do the difficult work to keep the things we make simple, approachable, and put the user’s needs first.</p>
+
+    <p>EMBL is complex. As are the audiences, services, applications, and communications material that operate within the brand. We will do the hard work to uncover and expose the simplicity of the core.</p>
+  </div>
+</section>
+<hr class="vf-divider">
+<section class="embl-grid">
+  <div class="vf-section-header" id="Unified">
+    <h2 class="vf-section-header__heading">Unified</h2>
+  </div>
+  <div class="vf-content">
+  <h3 style="margin-top: 0;">We are all one institute</h3>
+      <p>We will cultivate cross-pollination of services, products, ideas, and collaboration.</p>
+
+      <p>We will proactively seek out opportunities to collaborate on the design of services across all channels throughout EMBL and invite feedback and new perspectives. We will share and discuss our methods.</p>
+  </div>
+</section>
+<hr class="vf-divider">
+<section class="embl-grid">
+  <div class="vf-section-header" id="Syncronised">
+    <h2 class="vf-section-header__heading">Syncronised</h2>
+  </div>
+  <div class="vf-content">
+    <h3 style="margin-top: 0;">Physical, digital, and environmental are in sync</h3>
+    <p>We will ensure a holistic approach for one system for all printed, digital and environmental touch-points.</p>
+
+    <p>Design systems across media evolve at different rates. We will ensure systems across all channels are relevant to the media, but also share nomenclature, design patterns, and are built from the same principles. We will think and act as a cross-disciplinary design team.</p>
+  </div>
+</section>
+<hr class="vf-divider">
+<section class="embl-grid">
+  <div class="vf-section-header" id="Ingrained">
+    <h2 class="vf-section-header__heading">Ingrained</h2>
+  </div>
+  <div class="vf-content">
+    <h3 style="margin-top: 0;">Repeat the words we use</h3>
+    <p>Through consistency and repetition, we will create and maintain a design nomenclature that will become part of the EMBL vernacular.</p>
+
+    <p>The words we use are important. By repeating these words about EMBLs products and services, they can remind us many times every day what we believe. Changing the words we use can help change the culture of an organisation to be more design and brand aware.</p>
+  </div>
+</section>

--- a/tools/vf-component-library/src/site/design-principles/index.njk
+++ b/tools/vf-component-library/src/site/design-principles/index.njk
@@ -137,4 +137,8 @@ layout: layouts/base.njk
 
     <p>The words we use are important. By repeating these words about EMBLs products and services, they can remind us many times every day what we believe. Changing the words we use can help change the culture of an organisation to be more design and brand aware.</p>
   </div>
+
+  <section class="vf-grid vf-content">
+    <p>These Design Principles were originally showcased in this <a href="https://blogs.embl.org/communications/2017/07/10/our-design-principles/">blogpost</a> on the communications team blog.</p>
+  </section>
 </section>


### PR DESCRIPTION
I've taken the original design principles from here - https://blogs.embl.org/communications/2017/07/10/our-design-principles/ and added them to the documentation site, including in the main navigation. 

We might need to:

1. revisit them to see if they can be improved or need to be altered
2. add some snazzy graphics to make them 'pop'. 