### PR TITLE
fixes a margin issue

### DIFF
--- a/components/vf-content/CHANGELOG.md
+++ b/components/vf-content/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.0
+
+* adds top margin override for first item inside of `vf-content`
+
 ### 1.3.2
 
 * dependency bump

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -31,8 +31,7 @@
   h2:not([class*='vf-']) {
     @include set-type(text-heading--2, $custom-margin-bottom: 39px);
 
-    margin-top: 0;
-    padding-top: 13px;
+    margin-top: 13px;
 
     b,
     strong {
@@ -82,6 +81,11 @@
     strong {
       font-weight: inherit;
     }
+  }
+
+  // remove the top margin from first items becasue some times the first item is an h3
+  & > :first-child {
+    margin-top: 0 !important;
   }
 
   p:not([class*='vf-']) {


### PR DESCRIPTION
There are several instances of `vf-content` being used where the first item is not an h1 … this leads to added spacing with margin to the 'box' that the content is in. 

This wholesale removes the top margin from the direct first child of `vf-content`.