### PR TITLE
BUG: vf-card issue with image height in Safari

### DIFF
--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.4.1
+
+* fixes issue with `vf-card__image` height in Safari
+* updates documentation to replace 'title' with 'heading' so it matches CSS classname.
+
 ### 2.4.0
 
 * creates option to for a subheading

--- a/components/vf-card/vf-card.config.yml
+++ b/components/vf-card/vf-card.config.yml
@@ -19,27 +19,27 @@ variants:
   # -----------------
   - name: Bordered Headings
     context:
-      card_heading: A Bordered Card Title
+      card_heading: A Bordered Card Heading
       card_subheading: With sub–heading
       variant: bordered
       newTheme: primary
   - name: Bordered Headings with Link
     context:
-      card_heading: A Bordered Card Title
+      card_heading: A Bordered Card Heading
       card_href: "JavaScript:Void(0);"
       card_text: Lorem ipsum dolor sit amet, consectetur <a href="JavaScript:Void(0);" class="vf-card__link">adipisicing elit</a>. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
       variant: bordered
       newTheme: primary
   - name: Bordered
     context:
-      card_heading: A Bordered Card Title
+      card_heading: A Bordered Card Heading
       card_subheading: With sub–heading
       variant: bordered
       newTheme: primary
       card_text: Lorem ipsum dolor sit amet, consectetur <a href="JavaScript:Void(0);" class="vf-card__link">adipisicing elit</a>. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: Bordered with Link
     context:
-      card_heading: A Bordered Card Title
+      card_heading: A Bordered Card Heading
       card_subheading: With sub–heading
       variant: bordered
       newTheme: primary
@@ -47,7 +47,7 @@ variants:
       card_text: Lorem ipsum dolor sit amet, consectetur <a href="JavaScript:Void(0);" class="vf-card__link">adipisicing elit</a>. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: Bordered with Image
     context:
-      card_heading: A Bordered Card Title
+      card_heading: A Bordered Card Heading
       card_subheading: With sub–heading
       variant: bordered
       newTheme: primary
@@ -56,7 +56,7 @@ variants:
       card_image__alt: Image alt text
   - name: Bordered with Image and Link
     context:
-      card_heading: A Bordered Card Title
+      card_heading: A Bordered Card Heading
       card_subheading: With sub–heading
       variant: bordered
       newTheme: primary
@@ -76,27 +76,27 @@ variants:
   # ----------------
   - name: Striped only Headings
     context:
-      card_heading: A Striped Card Title
+      card_heading: A Striped Card Heading
       card_subheading: With sub–heading
       variant: striped
       newTheme: primary
   - name: Striped only linked Headings
     context:
-      card_heading: A Striped Card Title
+      card_heading: A Striped Card Heading
       card_href: "JavaScript:Void(0);"
       card_subheading: With sub–heading
       variant: striped
       newTheme: primary
   - name: Striped
     context:
-      card_heading: A Striped Card Title
+      card_heading: A Striped Card Heading
       card_subheading: With sub–heading
       variant: striped
       newTheme: primary
       card_text: Lorem ipsum dolor sit amet, consectetur <a href="JavaScript:Void(0);" class="vf-card__link">adipisicing elit</a>. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?
   - name: Striped with Link
     context:
-      card_heading: A Striped Card Title
+      card_heading: A Striped Card Heading
       variant: striped
       newTheme: primary
       card_href: "JavaScript:Void(0);"
@@ -104,7 +104,7 @@ variants:
 
   - name: Striped with Image
     context:
-      card_heading: A Striped Card Title
+      card_heading: A Striped Card Heading
       card_subheading: With sub–heading
       variant: striped
       newTheme: primary
@@ -113,7 +113,7 @@ variants:
       card_image__alt: Image alt text
   - name: Striped with Image and Link
     context:
-      card_heading: A Striped Card Title
+      card_heading: A Striped Card Heading
       card_subheading: With sub–heading
       variant: striped
       newTheme: primary

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -24,10 +24,9 @@
 }
 
 .vf-card__image {
+  aspect-ratio: 6 / 4;
   grid-column: 1 / -1;
   grid-row: 1;
-  height: 100%;
-  max-width: 100%;
   object-fit: cover;
   object-position: center;
   width: 100%;
@@ -66,29 +65,27 @@
 }
 
 .vf-card__heading__icon {
-    fill: currentColor;
-    transform: translateX(map-get($vf-spacing-map, vf-spacing--100));
-    // @todo: some sort of centralised and reusable docs, tokens, guidance on animations
-    transition-duration: 125ms;
-    transition-property: transform;
-    transition-timing-function: cubic-bezier(.45, .05, .55, .95);
+  fill: currentColor;
+  transform: translateX(map-get($vf-spacing-map, vf-spacing--100));
+  // @todo: some sort of centralised and reusable docs, tokens, guidance on animations
+  transition-duration: 125ms;
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(.45, .05, .55, .95);
 }
 
 .vf-card__title,
 .vf-card__heading {
   @include set-type(text-heading--3, $custom-margin-bottom: 0);
-  line-height: 1.333;
-
-  // font-weight: 700;
 
   background-color: var(--card-background-color);
   color: set-ui-color(vf-ui-color--black);
   color: var( --card-text-color, #{set-ui-color(vf-ui-color--black)} );
+  line-height: 1.333;
   text-decoration: none;
 
   .vf-card__link {
-    display: grid;
     color: color(blue);
+    display: grid;
     grid-column-gap: space(100);
     grid-template-columns: auto 1fr;
     text-decoration: none;
@@ -132,8 +129,9 @@
 }
 
 .vf-card__subheading {
-  @include set-type(text-heading--5, $custom-margin-bottom: 0);
   --vf-stack-margin--custom: #{space(100)};
+
+  @include set-type(text-heading--5, $custom-margin-bottom: 0);
 }
 
 .vf-card__text {


### PR DESCRIPTION
This fixes an issue where we had used `height: 100%` on the image height. Safari does not respect any form of aspect ratio and simply stretches the image so it's the full height of it's container.