### PR TITLE
Docs: design kit stub

### DIFF
--- a/tools/vf-component-library/src/site/_data/siteConfig.js
+++ b/tools/vf-component-library/src/site/_data/siteConfig.js
@@ -42,6 +42,10 @@ module.exports = {
       url: "/patterns",
       title: "Patterns"
     },
+    designkit: {
+      url: "/design-kit",
+      title: "Design kit"
+    },
     styles: {
       url: "/styles",
       title: "Styles"

--- a/tools/vf-component-library/src/site/design-kit/index.njk
+++ b/tools/vf-component-library/src/site/design-kit/index.njk
@@ -1,0 +1,23 @@
+---
+is_index: true
+promoted: true
+hideSubPosts: true
+title: Design kit
+subtitle: Use Figma software to design and collaborate on ideas without using code.
+intro: Here you'll learn about how to use the Figma library, where it is and how to stay posted on updates.
+date: 2020-12-14 18:24:50
+section: designkit
+order: 5
+tags:
+  - designkit
+  - sections
+layout: layouts/section.njk
+---
+
+The Figma library is in early development, watch this space for updates.
+
+For more updates:
+
+- [Slack group](https://join.slack.com/t/visual-framework/shared_invite/enQtNDAxNzY0NDg4NTY0LWFhMjEwNGY3ZTk3NWYxNWVjOWQ1ZWE4YjViZmY1YjBkMDQxMTNlNjQ0N2ZiMTQ1ZTZiMGM4NjU5Y2E0MjM3ZGQ)
+- [Updates blog](/updates)
+- [RSS Feed](/feed.xml)

--- a/tools/vf-component-library/src/site/index.njk
+++ b/tools/vf-component-library/src/site/index.njk
@@ -123,9 +123,9 @@ layout: layouts/base.njk
   } %}
 
   <style>
-  .vf-card {
+  .vf-card__image {
     /* would be nice if this was a custom property */
-    grid-template-rows: 188px 1fr;
+    aspect-ratio: 8/4;
   }
   </style>
 


### PR DESCRIPTION
This adds a stub design kit page and navigation that will be useful for the communications around the Figma library and updated homepage; related links:

- https://docs.google.com/document/d/1bVAe3kesFrs92z1KqPLr34NwaV6BEWlg5wsJaD-dJWE/edit
- https://github.com/visual-framework/vf-roadmap/discussions/23
- https://github.com/visual-framework/vf-core/milestone/20

@sturobson @cindyebi Even though this is a stub, I think it's worth getting live now as it works us towards the overall goals and allows users to see activity. 

Please feel free to modify the PR as you like. 

![image](https://user-images.githubusercontent.com/928100/108497114-4525a080-72ab-11eb-9333-42979fc7cf42.png)
