### PR TITLE
updates vf-hero to demonstrate and style the heading link

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.1.0
+
+* adds link styles to the `vf-hero__heading`
+* updated the documentation to include the `vf-hero__heading_link` details.
+
 ### 3.0.1
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-hero/README.md
+++ b/components/vf-hero/README.md
@@ -17,6 +17,7 @@ IE 11 will get the background colour and the roundels image, it will not paint a
 | Content name | Usage                                                                          | `.yml` key           |
 | ------------ | ------------------------------------------------------------------------------ | -------------------- |
 | Heading      | To be used for the heading of the page.                                                                               | `vf_hero_heading`    |
+| Heading HREF | To be used as a 'return to home' link for the micro site. | `vf_hero_heading_href` |
 | Subheading   | Optional content to be used along with the Heading for a terse explainer.                                                                               | `vf_hero_subheading` |
 | Kicker       | Optional content that helps define the context of overall content of the page. | `vf_hero_kicker`     |
 | Text         | Optional content that can help explain the page content in a brief paragraph.                                                                               | `vf_hero_text`       |
@@ -29,6 +30,7 @@ IE 11 will get the background colour and the roundels image, it will not paint a
 | ------------ | -------------------- | --------------------- |
 | Kicker       | `vf_hero_kicker`     | `vf-hero__kicker`     |
 | Heading      | `vf_hero_heading`    | `vf-hero__heading`    |
+| Heading HREF | `vf_hero_heading_href`    | `vf-hero__heading_link`    |
 | Subheading   | `vf_hero_subheading` | `vf-hero__subheading` |
 | Text         | `vf_hero_text`       | `vf-hero__text`       |
 | Link Text    | `vf_hero_link_text`  | `vf-hero__link`       |

--- a/components/vf-hero/vf-hero.config.yml
+++ b/components/vf-hero/vf-hero.config.yml
@@ -20,6 +20,7 @@ variants:
     context:
       vf_hero_kicker: <a href="JavaScript:Void(0);">VF Hamburg</a> | Structural Biology
       vf_hero_heading: About the Hentze group!
+      vf_hero_heading_href: JavaScript:Void(0);
       vf_hero_subheading: an example of some ancillary text
       vf_hero_text:
         - The Hentze group combines biochemical and <a href="JavaScript:Void(0);">systems–level approaches</a> to investigate the connections between <a href="JavaScript:Void(0);">gene expression</a> and <a href="JavaScript:Void(0);">cell metabolism</a>, and their roles in human disease.

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -63,6 +63,17 @@
   word-break: break-word;
 }
 
+.vf-hero__heading_link {
+  color: currentColor;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+  }
+}
+
 .vf-hero__subheading {
   @include set-type(text-heading--4, $custom-margin-bottom: 0);
 


### PR DESCRIPTION
Although `3.0.0` included the option to make the`vf-hero__heading` also a link. It was not documented, there was no example of it, and there was no CSS for the interaction. 

This PR fixes that.