### PR TITLE
Docs: content guide

### DIFF
--- a/tools/vf-component-library/src/site/_data/siteConfig.js
+++ b/tools/vf-component-library/src/site/_data/siteConfig.js
@@ -42,6 +42,10 @@ module.exports = {
       url: "/patterns",
       title: "Patterns"
     },
+    designkit: {
+      url: "/design-kit",
+      title: "Design kit"
+    },
     styles: {
       url: "/styles",
       title: "Styles"

--- a/tools/vf-component-library/src/site/_includes/layouts/section.njk
+++ b/tools/vf-component-library/src/site/_includes/layouts/section.njk
@@ -36,6 +36,7 @@ templateEngineOverride: njk, md
 {%- endfor %}
 
 {% if sectionHasSubposts and hideSubPosts != true %}
+<hr class="vf-divider" />
 <section class="embl-grid embl-grid--has-centered-content">
   <div></div>
   <div class="vf-content">

--- a/tools/vf-component-library/src/site/design-kit/index.njk
+++ b/tools/vf-component-library/src/site/design-kit/index.njk
@@ -1,0 +1,23 @@
+---
+is_index: true
+promoted: true
+hideSubPosts: true
+title: Design kit
+subtitle: Use Figma software to design and collaborate on ideas without using code.
+intro: Here you'll learn about how to use the Figma library, where it is and how to stay posted on updates.
+date: 2020-12-14 18:24:50
+section: designkit
+order: 5
+tags:
+  - designkit
+  - sections
+layout: layouts/section.njk
+---
+
+The Figma library is in early development, watch this space for updates.
+
+For more updates:
+
+- [Slack group](https://join.slack.com/t/visual-framework/shared_invite/enQtNDAxNzY0NDg4NTY0LWFhMjEwNGY3ZTk3NWYxNWVjOWQ1ZWE4YjViZmY1YjBkMDQxMTNlNjQ0N2ZiMTQ1ZTZiMGM4NjU5Y2E0MjM3ZGQ)
+- [Updates blog](/updates)
+- [RSS Feed](/feed.xml)

--- a/tools/vf-component-library/src/site/guidance/content-guidelines.md
+++ b/tools/vf-component-library/src/site/guidance/content-guidelines.md
@@ -1,0 +1,51 @@
+---
+title: Content guidelines
+subtitle: Unique to the web are certain types of content that support user interaction.
+intro: On this page we've compiled a list of many of the top do-s and don't-s.
+date: 2021-02-24 19:33:50
+section: building
+tags:
+  - posts
+  - guidance
+layout: layouts/section.njk
+---
+
+## Read more and click here <a id="read-more"></a>
+
+It's common to see phrases like "read more" and "click here" at the end of a section or container. These typically provide sub-optimal user experiences and lower conversion rates. It's better to add links within the content itself.
+
+[GOV.UK advises](https://www.gov.uk/guidance/content-design/links):
+
+> When writing a link, make it descriptive and front-load it with relevant terms instead of using something generic like ‘click here’ or ‘more’. Generic links do not make sense out of context or tell users where a link will take them. They also do not work for people using screen readers, who often scan through lists of links to navigate a page. It’s important the links are descriptive so they make sense in isolation.
+
+<br/>Nielsen Norman Group [has further guidance on how linking to content](https://www.nngroup.com/articles/learn-more-links/).
+
+The issue of "read more" links [has come up several times within VF discussions](https://github.com/visual-framework/vf-core/issues/1287) and we've found that reducing redundant links is both better for user experience and saves on page size.
+
+## Decorative icons vs illustrations <a id="icons"></a>
+
+Icons are very popular within the Visual Framework v1 as they provided a convenient and easy way to decorate content. However they come at a cost in performance and, more importantly, clarity.
+
+When an icon is not paired with text it must be able to convey meaning, and "universal" icons are rare. So icons are not a replacement for text links and often result in the use of more space.
+
+Icons should be viewed as illustrations and not shorthand for text and labels, so we typically recommend going without icons when possible.
+
+Nielsen Norman Group has [further guidance on the usability and best practices when using icons](https://www.nngroup.com/articles/icon-usability/).
+
+The Visual Framework is planning [a more robust approach for decorative iconography later in 2021](https://github.com/visual-framework/vf-core/discussions/1388).
+
+## Opening content in new tabs <a id="tabs"></a>
+
+The web allows for links to target a new tab or window when opening. The [recommended default (and what most users want)](https://www.nngroup.com/articles/new-browser-windows-and-tabs/) is to _not_ open in a new browser tab.
+
+Before setting links to open in new tabs, you should consider (and, if possible, observe) if a user's task benefits by opening in a new window.
+
+Example: you might open a link in a new windows if a user is filling in a long form and clicks on a "help" link. The user probably does not want to be taken away from their partly completed form.
+
+If you do open links in new tabs, you should try to label it as such: [I'm an example (opens in a new tab)](#)
+
+## White space <a id="white-space"></a>
+
+The Visual Framework is not just about providing "generic" good defaults, we consider what would be good defaults for users navigating the usually complex topics on life science websites. A major priority is to make site as easy-to-use as possible and that often means reducing their [cognitive load](https://www.invisionapp.com/design-defined/cognitive-load/).
+
+White space is critical to helping users navigate complex information. The extra spacing [provides room for orientation and eases the ability to read](https://www.caktusgroup.com/blog/2017/10/30/white-space-explained).

--- a/tools/vf-component-library/src/site/index.njk
+++ b/tools/vf-component-library/src/site/index.njk
@@ -123,9 +123,9 @@ layout: layouts/base.njk
   } %}
 
   <style>
-  .vf-card {
+  .vf-card__image {
     /* would be nice if this was a custom property */
-    grid-template-rows: 188px 1fr;
+    aspect-ratio: 8/4;
   }
   </style>
 


### PR DESCRIPTION
As has come up a few times (including #1287) there is a need for some high level guidelines on web content.

For now I've stuck them in the guidance section, but I suspect we have a reorganisation coming sometime soon, and I didn't want to get distracted with that here — instead I've focused on making the content.

Topics added in this PR:

- read more
- icons
- links in new tabs
- white space

This builds atop #1377, which should be merged first.

