### PR TITLE
the one that adds autocomplete variant of search input.

### DIFF
--- a/components/vf-form/vf-form__input/CHANGELOG.md
+++ b/components/vf-form/vf-form__input/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.1.0
+
+* adds an search input for when the search field is interactive showing 'live results'.g
 ### 2.0.1
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-form/vf-form__input/vf-form__input.njk
+++ b/components/vf-form/vf-form__input/vf-form__input.njk
@@ -15,7 +15,7 @@
   </div>
    <div class="vf-form__item vf-stack">
     <label class="vf-form__label | vf-u-sr-only" for="search">Search</label>
-    <input type="search" id="search" class="vf-form__input vf-form__input--autocomplete" placeholder="Search this part of the website">
+    <input type="search" id="search" class="vf-form__input vf-form__input--filter" placeholder="Search this part of the website">
   </div>
 
   <div class="vf-form__item vf-stack">

--- a/components/vf-form/vf-form__input/vf-form__input.njk
+++ b/components/vf-form/vf-form__input/vf-form__input.njk
@@ -13,6 +13,10 @@
     <label class="vf-form__label" for="search">Search</label>
     <input type="search" id="search" class="vf-form__input">
   </div>
+   <div class="vf-form__item vf-stack">
+    <label class="vf-form__label | vf-u-sr-only" for="search">Search</label>
+    <input type="search" id="search" class="vf-form__input vf-form__input--autocomplete">
+  </div>
 
   <div class="vf-form__item vf-stack">
     <label class="vf-form__label" for="email">Disabled email</label>

--- a/components/vf-form/vf-form__input/vf-form__input.njk
+++ b/components/vf-form/vf-form__input/vf-form__input.njk
@@ -11,11 +11,11 @@
 
   <div class="vf-form__item vf-stack">
     <label class="vf-form__label" for="search">Search</label>
-    <input type="search" id="search" class="vf-form__input">
+    <input type="search" id="search" class="vf-form__input" placeholder="Search the whole website">
   </div>
    <div class="vf-form__item vf-stack">
     <label class="vf-form__label | vf-u-sr-only" for="search">Search</label>
-    <input type="search" id="search" class="vf-form__input vf-form__input--autocomplete">
+    <input type="search" id="search" class="vf-form__input vf-form__input--autocomplete" placeholder="Search this part of the website">
   </div>
 
   <div class="vf-form__item vf-stack">

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -185,3 +185,18 @@ input[type="search"]::-webkit-search-cancel-button {
   position: relative;
   width: 1em;
 }
+
+
+.vf-form__input--autocomplete {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cpath d='M136.92 136.92a10.486 10.486 0 000-14.84l-26.6-26.6a3.514 3.514 0 01-.476-4.34 59.556 59.556 0 10-18.69 18.718 3.5 3.5 0 014.34.49l26.6 26.6a10.472 10.472 0 0014.84 0zM21 59.5A38.5 38.5 0 1159.5 98 38.528 38.528 0 0121 59.5z' fill='%23707372'/%3E%3C/svg%3E");
+  background-position: .5em center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  padding-left: 2em !important;
+
+  &:focus,
+  &:hover {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cpath d='M136.92 136.92a10.486 10.486 0 000-14.84l-26.6-26.6a3.514 3.514 0 01-.476-4.34 59.556 59.556 0 10-18.69 18.718 3.5 3.5 0 014.34.49l26.6 26.6a10.472 10.472 0 0014.84 0zM21 59.5A38.5 38.5 0 1159.5 98 38.528 38.528 0 0121 59.5z' fill='%2354585a'/%3E%3C/svg%3E");
+  }
+}
+

--- a/components/vf-form/vf-form__input/vf-form__input.scss
+++ b/components/vf-form/vf-form__input/vf-form__input.scss
@@ -187,7 +187,7 @@ input[type="search"]::-webkit-search-cancel-button {
 }
 
 
-.vf-form__input--autocomplete {
+.vf-form__input--filter {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cpath d='M136.92 136.92a10.486 10.486 0 000-14.84l-26.6-26.6a3.514 3.514 0 01-.476-4.34 59.556 59.556 0 10-18.69 18.718 3.5 3.5 0 014.34.49l26.6 26.6a10.472 10.472 0 0014.84 0zM21 59.5A38.5 38.5 0 1159.5 98 38.528 38.528 0 0121 59.5z' fill='%23707372'/%3E%3C/svg%3E");
   background-position: .5em center;
   background-repeat: no-repeat;


### PR DESCRIPTION
notes: 

This is using the 'current' styling of forms but will be updated when #1390 closes (as I'll add this there too).

This variant is **only** to be used when there is some sort of autocomplete / typeahead filtering needed when searching.

This is **not** to be used in place of the normal `input` and `button` because it's more 'visually appealing'. 