### PR TITLE
the one that makes the inline search variant better when it has less space

### DIFF
--- a/components/vf-search/CHANGELOG.md
+++ b/components/vf-search/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.0.0
+
+* adds a div around the form content.
+* makes changes to the CSS for `--inline` variant so it's responsive to the parent width.
+
 ### 1.2.0
 
 * don't allow inline search to get too large

--- a/components/vf-search/README.md
+++ b/components/vf-search/README.md
@@ -4,9 +4,13 @@
 
 ## About
 
+
+
 ## Usage
 
-- You can enable `autofocus` on the search element, but should only do so if most users intend to search on the page
+**note:** Version `2.0.0` of the `vf-search--inline` has no maximum width and will fill the space of it's parent. Because of this it is recommended to make sure the component is not too wide by wrapping it in the `embl-grid` with the `--centered-content` variant. If you wish to use ths `vf-search--inline` with `vf-grid` you will need to make use the `vf-search--inline` component also has an appropraite `.vf-u-grid__col--span` class.
+
+- You can enable `autofocus` on the search element, but should only do so if most users intend to search on the page.
 
 ## Install
 

--- a/components/vf-search/vf-search.config.yml
+++ b/components/vf-search/vf-search.config.yml
@@ -1,12 +1,10 @@
-# The title shown on the component page
 title: Search
-# Label shown on index pages
 label: Search
 status: beta
-collated: true
-# The template used from /components/_previews
-#
-# Per-variant options
+
+context:
+  component-type: block
+
 variants:
   - name: default
     label: Default
@@ -34,6 +32,3 @@ variants:
       search_description: 'Here are some tips on how your can search. Examples: <a href="JavaScript:Void(0);" class="vf-link">Cheese</a>, <a href="JavaScript:Void(0);" class="vf-link">Brie</a>. You can also use the <a href="JavaScript:Void(0);" class="vf-link">advanced search</a>.'
       search_id: inlinesearchitem
       search_value_default: ''
-context:
-  component-type: block
-  # custom-values: passed as {{custom-values}}

--- a/components/vf-search/vf-search.njk
+++ b/components/vf-search/vf-search.njk
@@ -15,14 +15,26 @@
   {% set modifiers = context.modifiers %}
   {% set override_class = context.override_class %}
 {%- endif -%}
-<form action="{{ search_action }}"
-  {#- You're using an ID? Really?? That'll go here -#}
-  {% if id %} id="{{-id-}}"{% endif %}
-  class="vf-form | vf-search{% if variant == 'inline' %} vf-search--inline{% endif %} {%- if override_class %} | {{override_class}}{% endif -%}">
-  <div class="vf-form__item | vf-search__item">
-    <label class="vf-form__label vf-u-sr-only | vf-search__label" for="{{ search_id }}">{{ search_label }}</label>
-    <input type="search" placeholder="{{ search_placeholder }}" id="{{ search_id }}" {% if search_value_default %} value="{{ search_value_default }}"{% endif %} class="vf-form__input | vf-search__input"{%- if search_autofocus %} autofocus{%- endif %}>
-  </div>
-  <button type="submit" class="vf-search__button | vf-button vf-button--primary"> {{ search_button }}</button>
-  {% if search_description %}<p class="vf-search__description">{{ search_description}}</p>{% endif %}
-</form>
+<div class="vf-container vf-container--search | vf-u-fullbleed">
+  <form action="{{ search_action }}"
+    {#- You're using an ID? Really?? That'll go here -#}
+    {% if id %} id="{{-id-}}"{% endif %}
+    class="vf-form | vf-search{% if variant == 'inline' %} vf-search--inline{% endif %} {%- if override_class %} | {{override_class}}{% endif -%}">
+
+    <div class="vf-container__inner">
+
+      <div class="vf-form__item | vf-search__item">
+
+        <label class="vf-form__label vf-u-sr-only | vf-search__label" for="{{ search_id }}">{{ search_label }}</label>
+        <input type="search" placeholder="{{ search_placeholder }}" id="{{ search_id }}" {% if search_value_default %} value="{{ search_value_default }}"{% endif %} class="vf-form__input | vf-search__input"{%- if search_autofocus %} autofocus{%- endif %}>
+      </div>
+
+      <button type="submit" class="vf-search__button | vf-button vf-button--primary"> {{ search_button }}</button>
+
+      {% if search_description %}<p class="vf-form__helper">{{ search_description}}</p>{% endif %}
+    </div>
+
+  </form>
+
+</div>
+

--- a/components/vf-search/vf-search.njk
+++ b/components/vf-search/vf-search.njk
@@ -15,26 +15,24 @@
   {% set modifiers = context.modifiers %}
   {% set override_class = context.override_class %}
 {%- endif -%}
-<div class="vf-container vf-container--search | vf-u-fullbleed">
-  <form action="{{ search_action }}"
-    {#- You're using an ID? Really?? That'll go here -#}
-    {% if id %} id="{{-id-}}"{% endif %}
-    class="vf-form | vf-search{% if variant == 'inline' %} vf-search--inline{% endif %} {%- if override_class %} | {{override_class}}{% endif -%}">
 
-    <div class="vf-container__inner">
+<form action="{{ search_action }}"
+  {#- You're using an ID? Really?? That'll go here -#}
+  {% if id %} id="{{-id-}}"{% endif %}
+  class="vf-form | vf-search{% if variant == 'inline' %} vf-search--inline{% endif %} {%- if override_class %} | {{override_class}}{% endif -%}">
 
-      <div class="vf-form__item | vf-search__item">
+  <div class="vf-container__inner">
 
-        <label class="vf-form__label vf-u-sr-only | vf-search__label" for="{{ search_id }}">{{ search_label }}</label>
-        <input type="search" placeholder="{{ search_placeholder }}" id="{{ search_id }}" {% if search_value_default %} value="{{ search_value_default }}"{% endif %} class="vf-form__input | vf-search__input"{%- if search_autofocus %} autofocus{%- endif %}>
-      </div>
+    <div class="vf-form__item | vf-search__item">
 
-      <button type="submit" class="vf-search__button | vf-button vf-button--primary"> {{ search_button }}</button>
-
-      {% if search_description %}<p class="vf-form__helper">{{ search_description}}</p>{% endif %}
+      <label class="vf-form__label vf-u-sr-only | vf-search__label" for="{{ search_id }}">{{ search_label }}</label>
+      <input type="search" placeholder="{{ search_placeholder }}" id="{{ search_id }}" {% if search_value_default %} value="{{ search_value_default }}"{% endif %} class="vf-form__input | vf-search__input"{%- if search_autofocus %} autofocus{%- endif %}>
     </div>
 
-  </form>
+    <button type="submit" class="vf-search__button | vf-button vf-button--primary"> {{ search_button }}</button>
 
-</div>
+    {% if search_description %}<p class="vf-form__helper">{{ search_description}}</p>{% endif %}
+  </div>
+
+</form>
 

--- a/components/vf-search/vf-search.scss
+++ b/components/vf-search/vf-search.scss
@@ -24,22 +24,33 @@
 */
 
 .vf-search--inline {
-  display: flex;
-  flex-wrap: wrap;
+  --vf-sidebar-spacing: #{space(400)};
+  --vf-sidebar--width: 60%;
 
-  .vf-search__item {
-    flex-grow: 1;
-    max-width: $vf-breakpoint--sm;
-  }
-
-  .vf-search__button {
-    margin-bottom: 0;
-    margin-left: 16px;
-    top: -12px;
-  }
-
-  .vf-search__description {
-    @include set-type(text-body--3);
+  .vf-form__helper {
     flex-basis: 100%;
   }
+
 }
+
+.vf-search--inline > * {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  margin: -.5rem;
+  margin: calc(var(--vf-sidebar-spacing) / 2 * -1);
+}
+
+.vf-search--inline > * > * {
+  flex-grow: 1;
+  margin: .5rem;
+  margin: calc(var(--vf-sidebar-spacing) / 2);
+}
+
+.vf-search--inline > * > :first-child {
+  flex-basis: 0;
+  flex-grow: 999;
+  min-width: calc(60% - 1rem);
+  min-width: calc(var(--vf-sidebar--width) - var(--vf-sidebar-spacing));
+}
+


### PR DESCRIPTION
We have a problem when the `vf-search--inline` is on smaller viewports or has a small amount of the page space to fill.

The button drops underneath but it's still a bit messy.

This PR fixes that by:

- introducing the CSS that will eventually become it's own layout component using [this great resource](https://every-layout.dev/layouts/sidebar/)
- adds a wrapping `div` around the `vf-form` content.
- replaces all the existing CSS for the `vf-search--inline` variant.

This, I feel, can be considered a 'short' or 'medium' term solution as we still need to create a better 'search container' now that we have some decisions made on what it should look like etc. etc.

I think, also, that the `--inline` variant can be the default version for search on embl.org properties with the merge now too. 

On small viewports where the search input cannot take up 60% of the space because of the button:

![Screen Shot 2021-03-06 at 14 02 46](https://user-images.githubusercontent.com/925197/110125723-8e054b00-7dbb-11eb-8639-938b09563cb8.png)

On larger viewports where there is more space:

![Screen Shot 2021-03-06 at 14 02 37](https://user-images.githubusercontent.com/925197/110125762-99587680-7dbb-11eb-8a1b-44d247408aa6.png)

