### PR TITLE
fixes issue with squishy inputs

### DIFF
--- a/components/vf-form__checkbox/vf-form__checkbox.scss
+++ b/components/vf-form__checkbox/vf-form__checkbox.scss
@@ -42,6 +42,7 @@
     content: '';
     display: inline-block;
     height: 1rem;
+    min-width: 1rem;;
     position: relative;
     top: 4px; // need to look at a better way to do this that keeps the semantics of a label
     width: 1rem;
@@ -62,12 +63,11 @@
     background-repeat: no-repeat;
     background-size: .75em;
     border-color: color(blue);
-
   }
+
   &:checked:hover + .vf-form__label::before,
   &:checked:focus + .vf-form__label::before {
-  box-shadow:
-    0 0 0 .125rem color(grey--dark)
+    box-shadow: 0 0 0 .125rem color(grey--dark)
   }
 
   // Disabled state .vf-form__label.

--- a/components/vf-form__radio/vf-form__radio.scss
+++ b/components/vf-form__radio/vf-form__radio.scss
@@ -30,6 +30,7 @@
     display: inline-block;
     height: 1rem;
     margin-right: 8px;
+    min-width: 1rem;
     position: relative;
     top: 4px; // need to look at a better way to do this that keeps the semantics of a label
     width: 1rem;


### PR DESCRIPTION
adds `min-width` to the `::before` on checkboxes and radios so the input doesn't squish


I've not updated the changelogs as they haven't been shipped yet