### PR TITLE
adds word-break: break-word

### DIFF
--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.5.4
+
+* adds `word-break: break-word;` to text so the text won't exceed the box model.
+
 ### 2.5.3
 
 * Corrects fix in 2.5.2 by using `align-content: start;`.

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -86,6 +86,7 @@
   color: var( --card-text-color, #{ui-color(black)} );
   line-height: 1.333;
   text-decoration: none;
+  word-break: break-word;
 
   .vf-card__link {
     color: color(blue);
@@ -136,6 +137,8 @@
   --vf-stack-margin--custom: #{space(100)};
 
   @include set-type(text-heading--5, $custom-margin-bottom: 0);
+
+  word-break: break-word;
 }
 
 .vf-card__text {
@@ -143,6 +146,7 @@
 
   color: ui-color(white);
   color: var( --card-text-color, #{ui-color(white)} );
+  word-break: break-word;
 
   .vf-card__link,
   a {


### PR DESCRIPTION
@kasprzyk-sz showed me an issue when there are really long words in vf-cards that the text exceeds the bounding box model 

This adds `word-break: break-word" to all text elements that could be inside of a `vf-card` to fix it.