### PR TITLE
Bug: vf-form fix name from "@visual-framework/form "

### DIFF
--- a/components/vf-form/package.json
+++ b/components/vf-form/package.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1.2",
-  "name": "@visual-framework/form ",
+  "name": "@visual-framework/vf-form",
   "description": "form  component",
   "homepage": "https://stable.visual-framework.dev/",
   "author": "VF",
@@ -11,7 +11,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/form ",
+  "repo": "https://github.com/visual-framework/vf-core/tree/master/components/elements/vf-form",
   "bugs": {
     "url": "https://github.com/visual-framework/vf-core/issues/new"
   },


### PR DESCRIPTION
Fixes two things:

- trailing space
- should be @visual-framework/vf-form

No changelog as we've not released the latest vf-form version to npm

Marked as critical as the trailing space is causing lerna to fail and would result in the wrong package name on mpm (`form` vs `vf-form`)