### PR TITLE
The one that makes the hero component a baller, a little less taller.

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 3.2.0
 
-* adds thinner 'vf-hero--400' variant.
+* adds thinner `vf-hero--400` variant.
 * fixes `vf-hero__content vf-box` sizing padding calculaton for `vf-hero--800` variant.
 * makes the maximum width of the `vf-hero__content` wider, but make smaller widths `max-content`.
 

--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 3.2.0
+
+* adds thinner 'vf-hero--400' variant.
+* fixes `vf-hero__content vf-box` sizing padding calculaton for `vf-hero--800` variant.
+* makes the maximum width of the `vf-hero__content` wider, but make smaller widths `max-content`.
+
 ### 3.1.0
 
 * adds link styles to the `vf-hero__heading`

--- a/components/vf-hero/vf-hero.config.yml
+++ b/components/vf-hero/vf-hero.config.yml
@@ -39,7 +39,13 @@ variants:
       vf_hero_link_href: JavaScript:Void(0);
       vf_hero_image: url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/vf-hero-intense.png');
 
-
+  - name: spacing (400)
+    context:
+      spacing: 400
+      vf_hero_heading: A journey through bioinformatics
+      vf_hero_text:
+        - Explore resources from EMBL-EBI
+      vf_hero_image_size: auto 28.5rem
   - name: spacing (800)
     context:
       spacing: 800

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -36,8 +36,9 @@
     2px 0 3px rgba(0, 0, 0, .1),
     -2px 0 3px rgba(0, 0, 0, .1),
     0 2px 3px rgba(0, 0, 0, .1);
-  max-width: 60ch;
+  max-width: 75ch;
   position: relative;
+  width: max-content;
   z-index: set-layer(vf-z-index--hero);
 }
 
@@ -131,10 +132,17 @@
 
 // sizes
 // ----------------------------------------------------------------------
+.vf-hero--400 {
+  --vf-hero--spacing: #{space(400)};
+  & > .vf-box {
+    --vf-box-padding: var(--vf-hero--spacing);
+  }
+}
+
 .vf-hero--800 {
   --vf-hero--spacing: #{space(800)};
   & > .vf-box {
-    --vf-box-padding: calc(var(--vf-hero--spacing / 2));
+    --vf-box-padding: calc(var(--vf-hero--spacing) / 2);
   }
 }
 

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -36,10 +36,9 @@
     2px 0 3px rgba(0, 0, 0, .1),
     -2px 0 3px rgba(0, 0, 0, .1),
     0 2px 3px rgba(0, 0, 0, .1);
-  max-width: 75ch;
   position: relative;
-  width: max-content;
   z-index: set-layer(vf-z-index--hero);
+  width: max-content;
 }
 
 .vf-hero__kicker {
@@ -62,6 +61,7 @@
 
   line-height: 1.25;
   word-break: break-word;
+  max-width: 30ch;
 }
 
 .vf-hero__heading_link {
@@ -79,10 +79,14 @@
   @include set-type(text-heading--4, $custom-margin-bottom: 0);
 
   --vf-stack-margin--custom: 0;
+
+  max-width: 50ch;
 }
 
 .vf-hero__text {
   @include set-type(text-body--2, $custom-margin-bottom: 0);
+
+  max-width: 60ch;
 
   a {
     border-bottom: none;
@@ -132,6 +136,7 @@
 
 // sizes
 // ----------------------------------------------------------------------
+
 .vf-hero--400 {
   --vf-hero--spacing: #{space(400)};
   & > .vf-box {


### PR DESCRIPTION
Part of Training/Academy's want for using the (soon to be deprecated) `vf-masthead` was because of the amount of vertical space it takes up … adding the `vf-hero--400` reduces the block padding of the hero.

I've also done some things that mean the `vf-hero__content` should work better for longer titles by defining the max width on the text elements rather than the `vf-hero__content` itself. 