### PR TITLE
the one that fixes a little max-width space issue on the `vf-body`

### DIFF
--- a/components/vf-body/CHANGELOG.md
+++ b/components/vf-body/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.2.0
 
 * removes `box-sizing: border-box;`
+* adds a little more to the documentation.
 
 ### 1.1.0
 

--- a/components/vf-body/CHANGELOG.md
+++ b/components/vf-body/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.2.0
+
+* removes `box-sizing: border-box;`
+
 ### 1.1.0
 
 * Makes the max-width a factor of 16px.

--- a/components/vf-body/README.md
+++ b/components/vf-body/README.md
@@ -12,6 +12,11 @@ The `vf-body` layout should be added to the `body` element in your mark up and t
 
 This layout component sets a maximum width to the 'page' and centers it. The maximum width of the page is set as a default to `80em` or `1280px` but can be changed using the CSS custom property `--vf-body-width` if needed. As the web is, by default, a fluid medium the `vf-body` needs to give some inline spacing when the browswer viewport is smaller than `1280px` like on a tablet or mobile device. This is made possible using `padding: 0 1em` which is the same as `padding-left: 1em; padding-right: 1em`.
 
+✅ `<body class="vf-body | vf-stack vf-stack--400">...</body>`
+
+❌ `<body> <div class="my-app | vf-body"> ... </div> </body>`
+
+
 ### CSS
 
 ```css

--- a/components/vf-body/README.md
+++ b/components/vf-body/README.md
@@ -8,11 +8,14 @@ The Body component can be used to create a centered layout to add your content. 
 
 ## Usage
 
+The `vf-body` layout should be added to the `body` element in your mark up and therefore should only be added once.
+
+This layout component sets a maximum width to the 'page' and centers it. The maximum width of the page is set as a default to `80em` or `1280px` but can be changed using the CSS custom property `--vf-body-width` if needed. As the web is, by default, a fluid medium the `vf-body` needs to give some inline spacing when the browswer viewport is smaller than `1280px` like on a tablet or mobile device. This is made possible using `padding: 0 1em` which is the same as `padding-left: 1em; padding-right: 1em`.
+
 ### CSS
 
 ```css
 .vf-body {
-  --vf-body-width: 80em;
   display: block;
   margin: 0 auto;
   max-width: 80em;

--- a/components/vf-body/vf-body.scss
+++ b/components/vf-body/vf-body.scss
@@ -23,7 +23,6 @@ html {
 }
 
 .vf-body {
-  box-sizing: border-box;
   display: block;
   margin: 0 auto;
   max-width: 80em;


### PR DESCRIPTION
A while ago we changed things up a little on `vf-body` so that it uses CSS with the 'rule of least power'. Which meant removing CSS `grid` and rely on `max-width` which means there's more browser interoprability.

Before this I think we decided that the 'page' or maximum size should be 1280px. 

Unfortunately we included `box-sizing: border-box;` for this layout component -- which mean the left and right `1rem` padding was eating into the maximum of 1280px giving the page a maximum of 1248px.

This issue quickly resolves that.

I've also add some more information to the documentation too. 