### PR TITLE
Bug: vf-sass-config neutral lookup function

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.5.2
+
+* Fix key name in `vf-color--neutral` lookup.
+
 ### 2.5.1
 
 * adds neutral colours in the custom variables import file

--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.5.2
 
 * Fix key name in `vf-color--neutral` lookup.
+  * https://github.com/visual-framework/vf-core/pull/1460
 
 ### 2.5.1
 

--- a/components/vf-sass-config/functions/_set-color.scss
+++ b/components/vf-sass-config/functions/_set-color.scss
@@ -8,7 +8,6 @@
   @return map-get($vf-ui-colors-map, $color-name);
 }
 
-
 @function color($color-name) {
   $value: "vf-color--" + $color-name;
   @return map-get($vf-colors-map, $value);
@@ -19,8 +18,7 @@
   @return map-get($vf-ui-colors-map, $value);
 }
 
-
 @function neutral($color-name) {
-  $value: "vf-color--" + $color-name;
+  $value: "vf-color--neutral--" + $color-name;
   @return map-get($vf-color__neutral-map, $value);
 }


### PR DESCRIPTION
Fix key name in `vf-color--neutral` lookup.

This was causing sass like `background-color: neutral(0);` to return a null value.