### PR TITLE
Bug: vf-hero loop

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 3.2.1
+
+* Resolves a Nunjucks bug on `vf_hero_text` from a yaml file under certain contexts.
+* Allows vf_hero_heading_href to be passed in yaml.
+* Gobbles much of the whitespace.
+
 ### 3.2.0
 
 * adds thinner `vf-hero--400` variant.

--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 3.2.1
 
 * Resolves a Nunjucks bug on `vf_hero_text` from a yaml file under certain contexts.
+  * https://github.com/visual-framework/vf-core/pull/1462
 * Allows vf_hero_heading_href to be passed in yaml.
 * Gobbles much of the whitespace.
 

--- a/components/vf-hero/vf-hero.njk
+++ b/components/vf-hero/vf-hero.njk
@@ -46,9 +46,9 @@
     {% if vf_hero_subheading %}<p class="vf-hero__subheading">{{vf_hero_subheading}}</p>{% endif %}
 
     {%- if vf_hero_text %}
-      {% for text in vf_hero_text %}
+      {% for hero_text in vf_hero_text %}
         <p class="vf-hero__text">
-          {{- text | safe -}}
+          {{- hero_text | safe -}}
         </p>
       {%- endfor %}
     {%- endif %}

--- a/components/vf-hero/vf-hero.njk
+++ b/components/vf-hero/vf-hero.njk
@@ -1,9 +1,10 @@
+{% spaceless %}
 {%- if context %}
-
   {% set vf_hero_image = context.vf_hero_image %}
 
   {% set vf_hero_kicker = context.vf_hero_kicker %}
   {% set vf_hero_heading = context.vf_hero_heading %}
+  {% set vf_hero_heading_href = context.vf_hero_heading_href %}
   {% set vf_hero_subheading = context.vf_hero_subheading %}
 
   {% set vf_hero_text = context.vf_hero_text %}
@@ -21,45 +22,41 @@
   {% set vf_hero_heading_additional = context.vf_hero_heading_additional %}
   {% if context.vf_hero_heading_additional %}
     {% set vf_hero_kicker = context.vf_hero_heading_additional %}
-  {% endif %}
-
-{% endif -%}
-
-
+  {%- endif -%}
+{%- endif -%}
+{% endspaceless %}
 <section
   class="vf-hero{% if spacing %} vf-hero--{{spacing}}{% endif %} | vf-u-fullbleed {%- if modifier_class %} {{ modifier_class }}{% endif %}"
-
-  style="{% if vf_hero_image %}--vf-hero--bg-image: {{vf_hero_image}}{% endif %}
-  {% if vf_hero_image_size %}--vf-hero--bg-image-size: {{vf_hero_image_size}}{% endif %}
+  style="{%- if vf_hero_image -%}--vf-hero--bg-image: {{vf_hero_image}}{%- endif -%}
+  {%- if vf_hero_image_size %} --vf-hero--bg-image-size: {{vf_hero_image_size}}{%- endif -%}
   ">
-
-  <div class="vf-hero__content | vf-box | vf-stack vf-stack--400 ">
+  <div class="vf-hero__content | vf-box | vf-stack vf-stack--400">
     {%- if vf_hero_kicker -%}
-      <p class="vf-hero__kicker">{{ vf_hero_kicker }}</p>
+      <p class="vf-hero__kicker">{{- vf_hero_kicker -}}</p>
     {%- endif -%}
 
-    {% if vf_hero_heading %}
+    {%- if vf_hero_heading %}
     <h2 class="vf-hero__heading">
-      {% if vf_hero_heading_href %}<a class="vf-hero__heading_link" href="{{vf_hero_heading_href}}">{% endif %}
-      {{ vf_hero_heading }}
-      {% if vf_hero_heading_href %}</a>{% endif %}
+      {%- if vf_hero_heading_href %}<a class="vf-hero__heading_link" href="{{vf_hero_heading_href}}">{%- endif -%}
+      {{- vf_hero_heading -}}
+      {%- if vf_hero_heading_href -%}</a>{%- endif -%}
     </h2>
     {% endif %}
 
     {% if vf_hero_subheading %}<p class="vf-hero__subheading">{{vf_hero_subheading}}</p>{% endif %}
 
     {%- if vf_hero_text %}
-    <p class="vf-hero__text">
-      {% asyncEach hero_text in vf_hero_text -%}
-        {{ hero_text | safe }}
-      {% endeach %}
-    </p>
-    {% endif %}
+      {% for text in vf_hero_text %}
+        <p class="vf-hero__text">
+          {{- text | safe -}}
+        </p>
+      {%- endfor %}
+    {%- endif %}
     {%- if (vf_hero_link_href) and (vf_hero_link_text) %}
       <a class="vf-hero__link" href="{{ vf_hero_link_href }}">
       {{- vf_hero_link_text -}}
       <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="" fill-rule="nonzero"></path></svg>
       </a>
-    {% endif %}
+    {%- endif -%}
   </div>
 </section>


### PR DESCRIPTION
Found while helping update the static-html-pages: the current vf-hero.njk will error if receive a `vf_hero_text` from a yaml file under certain contexts.

This:
- fixes the above
- Allows vf_hero_heading_href to be passed in yaml
- Gobbles much of the whitespace

FYI @kasprzyk-sz 