### PR TITLE
nicety: vf-design-tokens-command

### DIFF
--- a/components/vf-design-tokens/CHANGELOG.md
+++ b/components/vf-design-tokens/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.4.1
+
+* Adds a gulp command vf-design-tokens alias for developers who easily forget.
+
 ### 3.4.0
 
 * introduces neutral colours stack Design Tokens.

--- a/components/vf-design-tokens/gulpfile.js
+++ b/components/vf-design-tokens/gulpfile.js
@@ -167,6 +167,16 @@ ${result
   `;
 });
 
+gulp.task("tokens:command-help", function (done) {
+  console.warn("vf-design-tokens","You're probably looking for the `gulp vf-tokens` command.");
+  done();
+});
+
 gulp.task("vf-tokens", gulp.parallel(
   "tokens:variables", "tokens:json", "tokens:typographic-scale", "tokens:maps", "tokens:props"
+));
+
+// an alias for developers who easily forget
+gulp.task("vf-design-tokens", gulp.parallel(
+  'tokens:command-help'
 ));


### PR DESCRIPTION
I nearly always forget to do `gulp vf-tokens` and not `gulp vf-design-tokens`

This will save me (and perhaps others) a bit of _ugh_ in the future.