### PR TITLE
the one that deprecates the phase variant of the banner

### DIFF
--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.7.2
+
+* adds deprecation notices around the `--phase` variant.
+
 ### 1.7.1
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-banner/vf-banner--inline.njk
+++ b/components/vf-banner/vf-banner--inline.njk
@@ -1,3 +1,5 @@
+<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="./vf-banner--info/"new</a> component.</h2> in the README.md file.
+
 <div class="vf-banner vf-banner--phase">
   <div class="vf-banner__content">
     <p class="vf-banner__text">This is a new web page. <a href="{{ vf-banner--inline_href }}" class="vf-link">Complete our quick survey</a> to help us make it better.</p>

--- a/components/vf-banner/vf-banner--inline.njk
+++ b/components/vf-banner/vf-banner--inline.njk
@@ -1,4 +1,4 @@
-<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="./vf-banner--info/"new</a> component.</h2> in the README.md file.
+<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="./vf-banner--info/"new</a> component.</h2>
 
 <div class="vf-banner vf-banner--phase">
   <div class="vf-banner__content">

--- a/components/vf-banner/vf-banner--inline.njk
+++ b/components/vf-banner/vf-banner--inline.njk
@@ -1,4 +1,4 @@
-<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="./vf-banner--info/">vf-banner--info</a> component.</h2>
+<!-- <h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="./vf-banner--info/"new</a> component.</h2> in the README.md file. -->
 
 <div class="vf-banner vf-banner--phase">
   <div class="vf-banner__content">

--- a/components/vf-banner/vf-banner--inline.njk
+++ b/components/vf-banner/vf-banner--inline.njk
@@ -1,4 +1,4 @@
-<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="./vf-banner--info/"new</a> component.</h2> in the README.md file.
+<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="./vf-banner--info/">vf-banner--info</a> component.</h2> in the README.md file.
 
 <div class="vf-banner vf-banner--phase">
   <div class="vf-banner__content">

--- a/components/vf-banner/vf-banner--phase.scss
+++ b/components/vf-banner/vf-banner--phase.scss
@@ -1,28 +1,30 @@
-.vf-banner--phase {
-  background-color: $vf-phase-banner-color--background;
+html:not(.vf-disable-deprecated) {
+  @warn 'This variant has been deprecated, please use the --notice variant of `vf-banner';
 
-  margin: 16px 0;
+  .vf-banner--phase {
+    background-color: $vf-phase-banner-color--background;
 
-  .vf-banner__text,
-  [class*='vf-text'] { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal
-    color: $vf-phase-banner-color--text;
-    margin: 0; // makes the text have no margin so the parent component defines the spacing
+    margin: 16px 0;
 
-    & .vf-banner__link,
-    & .vf-link {
-      color: $vf-banner-color--link;
+    .vf-banner__text,
+    [class*='vf-text'] { // as of 1.0.4 use of vf-text is not recommended and is subject to future removal
+      color: $vf-phase-banner-color--text;
+      margin: 0; // makes the text have no margin so the parent component defines the spacing
+
+      & .vf-banner__link,
+      & .vf-link {
+        color: $vf-banner-color--link;
+      }
+    }
+
+    .vf-banner__content {
+      display: flex;
+    }
+
+    .vf-button {
+      @media (min-width: $vf-breakpoint--lg) {
+        margin-left: auto;
+      }
     }
   }
-
-  .vf-banner__content {
-    display: flex;
-  }
-
-  .vf-button {
-    @media (min-width: $vf-breakpoint--lg) {
-      margin-left: auto;
-    }
-  }
-
-
 }

--- a/components/vf-banner/vf-banner.config.yml
+++ b/components/vf-banner/vf-banner.config.yml
@@ -32,7 +32,11 @@ variants:
       banner__success: true
       banner__dismissable: true
       banner__message: Congratulations! You have made something <a class="vf-banner__link" href="JavaScript:Void(0);">awesome</a>!
-
+  - name: phase
+    hidden: true
+    status: deprecated
+    context:
+      component-type: deprecated
   - name: default
     hidden: true
   - name: inline


### PR DESCRIPTION
The `vf-banner--phase` was superseded by a more generic `vf-banner--notice` variant a while back but some things didn't get 'sorted':

- there was no deprecation notice added to `--phase`.
- the `vf-banner--phase` variant is still widely used.

This PR fixes the deprecation of the variant by adding all the relevant codes.

