### PR TITLE
Refactore: template markdown

### DIFF
--- a/tools/vf-component-library/src/site/_includes/layouts/section.njk
+++ b/tools/vf-component-library/src/site/_includes/layouts/section.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/base.njk
 pageClass: posts
-templateEngineOverride: njk, md
+templateEngineOverride: njk
 ---
 
 {# Use this template for main sections of a site. #}

--- a/tools/vf-component-library/src/site/building/index.njk
+++ b/tools/vf-component-library/src/site/building/index.njk
@@ -10,7 +10,7 @@ tags:
   - building
   - sections
 layout: layouts/section.njk
-templateEngineOverride: njk
+templateEngineOverride: njk, md
 ---
 
 ## Components and patterns

--- a/tools/vf-component-library/src/site/components/index.njk
+++ b/tools/vf-component-library/src/site/components/index.njk
@@ -10,7 +10,7 @@ tags:
   - building
   - sections
   - components
-templateEngineOverride: njk
+templateEngineOverride: njk, md
 layout: layouts/section.njk
 hideSubPosts: true
 ---

--- a/tools/vf-component-library/src/site/design-kit/index.njk
+++ b/tools/vf-component-library/src/site/design-kit/index.njk
@@ -12,6 +12,7 @@ tags:
   - designkit
   - sections
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 The Figma library is in early development, watch this space for updates.

--- a/tools/vf-component-library/src/site/design-tokens/index.njk
+++ b/tools/vf-component-library/src/site/design-tokens/index.njk
@@ -8,9 +8,9 @@ section: designtokens
 tags:
   - sections
   - designtokens
-templateEngineOverride: njk
 layout: layouts/section.njk
 hideSubPosts: false
+templateEngineOverride: njk, md
 ---
 
 The Design Tokens used within `vf-core` are generated from several `.yml` files. These are then compiled into various Sass files as needed.

--- a/tools/vf-component-library/src/site/developing/components/deprecating-components.njk
+++ b/tools/vf-component-library/src/site/developing/components/deprecating-components.njk
@@ -10,6 +10,7 @@ tags:
   - contributing components
   - developing
   - documentation
+templateEngineOverride: njk, md
 ---
 
 Here's what we need to make sure we do:

--- a/tools/vf-component-library/src/site/developing/getting-started/code-of-conduct.njk
+++ b/tools/vf-component-library/src/site/developing/getting-started/code-of-conduct.njk
@@ -8,6 +8,7 @@ tags:
   - getting started
   - developing
   - documentation
+templateEngineOverride: njk, md
 ---
 
 We don't yet have a full policy but, in general: be nice, respectful

--- a/tools/vf-component-library/src/site/developing/getting-started/pull-requests.njk
+++ b/tools/vf-component-library/src/site/developing/getting-started/pull-requests.njk
@@ -8,6 +8,7 @@ tags:
   - getting started
   - developing
   - documentation
+templateEngineOverride: njk, md
 ---
 
 To contribute code back, you'll need to make a PR ([Pull Request](https://help.github.com/en/articles/about-pull-requests)),

--- a/tools/vf-component-library/src/site/developing/getting-started/setting-up.njk
+++ b/tools/vf-component-library/src/site/developing/getting-started/setting-up.njk
@@ -10,6 +10,7 @@ tags:
   - getting started
   - developing
   - documentation
+templateEngineOverride: njk, md
 ---
 
 ## Development tools

--- a/tools/vf-component-library/src/site/developing/getting-started/structure.njk
+++ b/tools/vf-component-library/src/site/developing/getting-started/structure.njk
@@ -9,6 +9,7 @@ tags:
   - getting started
   - developing
   - documentation
+templateEngineOverride: njk, md
 ---
 
 ## Design decisions and tokens

--- a/tools/vf-component-library/src/site/developing/guidelines/governance.njk
+++ b/tools/vf-component-library/src/site/developing/guidelines/governance.njk
@@ -2,6 +2,7 @@
 title: Governance of the Visual Framework
 date: 2019-04-09 12:24:50
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 [This has been superseded by the consultation process]({{ '/about/consultation/' | url }}).

--- a/tools/vf-component-library/src/site/guidance/browser-support.md
+++ b/tools/vf-component-library/src/site/guidance/browser-support.md
@@ -7,6 +7,7 @@ tags:
   - posts
   - guidance
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 For browser support, aim for content and functionality to be unobstructed on browsers released within the last five years and have JavaScript enabled; this is represents virtually all users of the EMBL sites (in excess of 99.9%).

--- a/tools/vf-component-library/src/site/guidance/content-guidelines.md
+++ b/tools/vf-component-library/src/site/guidance/content-guidelines.md
@@ -8,6 +8,7 @@ tags:
   - posts
   - guidance
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 ### Read more and click here <a id="read-more"></a>

--- a/tools/vf-component-library/src/site/guidance/css-and-sass.md
+++ b/tools/vf-component-library/src/site/guidance/css-and-sass.md
@@ -7,6 +7,7 @@ tags:
   - posts
   - guidance
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 ## CSS Naming conventions

--- a/tools/vf-component-library/src/site/guidance/discussing-the-vf.njk
+++ b/tools/vf-component-library/src/site/guidance/discussing-the-vf.njk
@@ -9,6 +9,7 @@ tags:
   - posts
   - guidance
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 {% set context = {

--- a/tools/vf-component-library/src/site/guidance/image-handling.md
+++ b/tools/vf-component-library/src/site/guidance/image-handling.md
@@ -7,6 +7,7 @@ tags:
   - posts
   - guidance
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 <br/>

--- a/tools/vf-component-library/src/site/guidance/index.njk
+++ b/tools/vf-component-library/src/site/guidance/index.njk
@@ -12,6 +12,7 @@ tags:
   - building
   - sections
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 {%- for post in collections.guidance  | reverse %}

--- a/tools/vf-component-library/src/site/guidance/javascript.md
+++ b/tools/vf-component-library/src/site/guidance/javascript.md
@@ -7,6 +7,7 @@ tags:
   - posts
   - guidance
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 The Visual Framework isn't intended as a general-purpose JavaScript solution, however we know it is helpful that a minimal amount of basic functionality is supported.

--- a/tools/vf-component-library/src/site/guidance/language-british-american-english.md
+++ b/tools/vf-component-library/src/site/guidance/language-british-american-english.md
@@ -8,6 +8,7 @@ tags:
   - posts
   - guidance
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 The `vf-core` project is being led by [EMBL](//www.embl.org) where British English is used, we're also aware that most code is American English (`colour` vs `color`); so:

--- a/tools/vf-component-library/src/site/guidance/user-base.md
+++ b/tools/vf-component-library/src/site/guidance/user-base.md
@@ -7,6 +7,7 @@ tags:
   - posts
   - guidance
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 The Visual Framework core ('vf-core') is not intended for direct consumption into

--- a/tools/vf-component-library/src/site/patterns/index.njk
+++ b/tools/vf-component-library/src/site/patterns/index.njk
@@ -10,6 +10,7 @@ tags:
   - sections
 date: 2019-07-22 12:24:50
 layout: layouts/section.njk
+templateEngineOverride: njk, md
 ---
 
 If you're looking for guidance on how to integrate a different technical approach like React or a custom Sass build, [see the building guide]({{ '/building' | url }}).


### PR DESCRIPTION
For #1467, this opts in to markdown processing at the page level rather than the template. Which will resolve the search page formatting as well as other issues that have occured in the past.