### PR TITLE
bug: vf-sass-config utility mixins import

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.5.3
+
+* Adds `mixins/vf-utility-mixins.scss` to index.scss
+
 ### 2.5.2
 
 * Fix key name in `vf-color--neutral` lookup.

--- a/components/vf-sass-config/index.scss
+++ b/components/vf-sass-config/index.scss
@@ -2,4 +2,5 @@
 @import 'variables/vf-global-variables.scss';
 @import 'functions/vf-functions.scss';
 @import 'mixins/vf-mixins.scss';
+@import 'mixins/vf-utility-mixins.scss';
 @import 'variables/vf-global-custom-properties.scss';


### PR DESCRIPTION
`mixins/vf-utility-mixins.scss` was missing from the rollup import, which breaks use in some projects (like vf-react that use the React sass build)