### PR TITLE
Enhancement: more flexible module import

### DIFF
--- a/components/embl-breadcrumbs-lookup/CHANGELOG.md
+++ b/components/embl-breadcrumbs-lookup/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.4
+
+* Improve JS module import support.
+
 ### 1.0.3
 
 * changes any `set-` style functions to cleaner version

--- a/components/embl-breadcrumbs-lookup/CHANGELOG.md
+++ b/components/embl-breadcrumbs-lookup/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.4
 
 * Improve JS module import support.
+  * https://github.com/visual-framework/vf-core/pull/1476/
 
 ### 1.0.3
 

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -1,6 +1,10 @@
 // embl-breadcrumbs-lookup
 
-import { emblContentMetaProperties_Read } from "embl-content-meta-properties/embl-content-meta-properties";
+try {
+  import { emblContentMetaProperties_Read } from "embl-content-meta-properties/embl-content-meta-properties";
+} catch (e) {
+  import { emblContentMetaProperties_Read } from "../embl-content-meta-properties/embl-content-meta-properties";
+}
 
 // to hold the EMBL taxonomy
 var emblTaxonomy = {};

--- a/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
+++ b/components/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.js
@@ -1,10 +1,5 @@
 // embl-breadcrumbs-lookup
-
-try {
-  import { emblContentMetaProperties_Read } from "embl-content-meta-properties/embl-content-meta-properties";
-} catch (e) {
-  import { emblContentMetaProperties_Read } from "../embl-content-meta-properties/embl-content-meta-properties";
-}
+import { emblContentMetaProperties_Read } from "../embl-content-meta-properties/embl-content-meta-properties";
 
 // to hold the EMBL taxonomy
 var emblTaxonomy = {};

--- a/components/embl-content-hub-loader/CHANGELOG.md
+++ b/components/embl-content-hub-loader/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.9
 
 * Improve JS module import support.
+  * https://github.com/visual-framework/vf-core/pull/1476/
 
 ### 1.0.8
 

--- a/components/embl-content-hub-loader/CHANGELOG.md
+++ b/components/embl-content-hub-loader/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.9
+
+* Improve JS module import support.
+
 ### 1.0.8
 
 * Fix a bug when vfBanner or vfTabs are not present

--- a/components/embl-content-hub-loader/embl-content-hub-loader.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.js
@@ -1,7 +1,15 @@
 // embl-content-hub-loader
 
-import { emblContentHubLoaderHtmlImports } from "embl-content-hub-loader/embl-content-hub-loader__html-imports";
-import { emblContentHubFetch } from "embl-content-hub-loader/embl-content-hub-loader__fetch";
+try {
+  import { emblContentHubLoaderHtmlImports } from "embl-content-hub-loader/embl-content-hub-loader__html-imports";
+} catch (e) {
+  import { emblContentHubLoaderHtmlImports } from "../embl-content-hub-loader/embl-content-hub-loader__html-imports";
+}
+try {
+  import { emblContentHubFetch } from "embl-content-hub-loader/embl-content-hub-loader__fetch";
+} catch (e) {
+  import { emblContentHubFetch } from "../embl-content-hub-loader/embl-content-hub-loader__fetch";
+}
 
 function emblContentHub() {
 

--- a/components/embl-content-hub-loader/embl-content-hub-loader.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.js
@@ -1,19 +1,10 @@
 // embl-content-hub-loader
 
-try {
-  import { emblContentHubLoaderHtmlImports } from "embl-content-hub-loader/embl-content-hub-loader__html-imports";
-} catch (e) {
-  import { emblContentHubLoaderHtmlImports } from "../embl-content-hub-loader/embl-content-hub-loader__html-imports";
-}
-try {
-  import { emblContentHubFetch } from "embl-content-hub-loader/embl-content-hub-loader__fetch";
-} catch (e) {
-  import { emblContentHubFetch } from "../embl-content-hub-loader/embl-content-hub-loader__fetch";
-}
+import { emblContentHubLoaderHtmlImports } from "../embl-content-hub-loader/embl-content-hub-loader__html-imports";
+import { emblContentHubFetch } from "../embl-content-hub-loader/embl-content-hub-loader__fetch";
 
 function emblContentHub() {
-
-  // 1. make sure we have imports or a pollyfill
+  // 1. make sure we have imports or a polyfill
   emblContentHubLoaderHtmlImports();
 
   // 2. import the content

--- a/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
@@ -1,10 +1,26 @@
 // embl-content-hub-loader__fetch
 
 // load optional dependencies
-import { vfBanner } from "vf-banner/vf-banner";
-import { vfTabs } from "vf-tabs/vf-tabs";
-import { emblConditionalEdit } from "embl-conditional-edit/embl-conditional-edit";
-import { emblNotifications } from "embl-notifications/embl-notifications";
+try {
+  import { vfBanner } from "vf-banner/vf-banner";
+} catch (e) {
+  import { vfBanner } from "../vf-banner/vf-banner";
+}
+try {
+  import { vfTabs } from "vf-tabs/vf-tabs";
+} catch (e) {
+  import { vfTabs } from "../vf-tabs/vf-tabs";
+}
+try {
+  import { emblConditionalEdit } from "embl-conditional-edit/embl-conditional-edit";
+} catch (e) {
+  import { emblConditionalEdit } from "../embl-conditional-edit/embl-conditional-edit";
+}
+try {
+  import { emblNotifications } from "embl-notifications/embl-notifications";
+} catch (e) {
+  import { emblNotifications } from "../embl-notifications/embl-notifications";
+}
 
 /**
  * Fetch html links from content.embl.org

--- a/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
+++ b/components/embl-content-hub-loader/embl-content-hub-loader__fetch.js
@@ -1,26 +1,10 @@
 // embl-content-hub-loader__fetch
 
 // load optional dependencies
-try {
-  import { vfBanner } from "vf-banner/vf-banner";
-} catch (e) {
-  import { vfBanner } from "../vf-banner/vf-banner";
-}
-try {
-  import { vfTabs } from "vf-tabs/vf-tabs";
-} catch (e) {
-  import { vfTabs } from "../vf-tabs/vf-tabs";
-}
-try {
-  import { emblConditionalEdit } from "embl-conditional-edit/embl-conditional-edit";
-} catch (e) {
-  import { emblConditionalEdit } from "../embl-conditional-edit/embl-conditional-edit";
-}
-try {
-  import { emblNotifications } from "embl-notifications/embl-notifications";
-} catch (e) {
-  import { emblNotifications } from "../embl-notifications/embl-notifications";
-}
+import { vfBanner } from "../vf-banner/vf-banner";
+import { vfTabs } from "../vf-tabs/vf-tabs";
+import { emblConditionalEdit } from "../embl-conditional-edit/embl-conditional-edit";
+import { emblNotifications } from "../embl-notifications/embl-notifications";
 
 /**
  * Fetch html links from content.embl.org

--- a/components/embl-notifications/CHANGELOG.md
+++ b/components/embl-notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.2
+
+* Improve JS module import support.
+
 ### 1.0.1
 
 * JS linting

--- a/components/embl-notifications/CHANGELOG.md
+++ b/components/embl-notifications/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.2
 
 * Improve JS module import support.
+  * https://github.com/visual-framework/vf-core/pull/1476/
 
 ### 1.0.1
 

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -1,7 +1,11 @@
 // embl-notifications
 
 // if you need to import any other components' JS to use here
-import { vfBanner } from "vf-banner/vf-banner";
+try {
+  import { vfBanner } from "vf-banner/vf-banner";
+} catch (e) {
+  import { vfBanner } from "../vf-banner/vf-banner";
+}
 
 /**
   * After a notifications has been chosen, build it and insert into the document

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -1,11 +1,7 @@
 // embl-notifications
 
 // if you need to import any other components' JS to use here
-try {
-  import { vfBanner } from "vf-banner/vf-banner";
-} catch (e) {
-  import { vfBanner } from "../vf-banner/vf-banner";
-}
+import { vfBanner } from "../vf-banner/vf-banner";
 
 /**
   * After a notifications has been chosen, build it and insert into the document
@@ -18,10 +14,10 @@ function emblNotificationsInject(message) {
   // @todo:
   // - add support in contentHub for extra button text, link
 
-  // preperation
-  message.body = message.body.replace(/<[/]?[p>]+>/g, " "); // no <p> tags allowed in inline messages, preserve a space to not colide words
+  // preparation
+  message.body = message.body.replace(/<[/]?[p>]+>/g, " "); // no <p> tags allowed in inline messages, preserve a space to not collide words
   // add vf-link to link
-  message.body = message.body.replace("<a href=", "<a class=\"vf-banner__link\" href="); // we might need a more clever regex, but this should also avoid links that aleady have a class
+  message.body = message.body.replace("<a href=", "<a class=\"vf-banner__link\" href="); // we might need a more clever regex, but this should also avoid links that already have a class
   // Learn more link is conditionally shown
   if (message.field_notification_link) {
     message.body = `${message.body} <a class="vf-banner__link" href="${message.field_notification_link}">Learn more</a>`;

--- a/tools/vf-component-generator/CHANGELOG.md
+++ b/tools/vf-component-generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.3
+
+* For JS module imports, also try a relative path, as this improves support in some scenarios
+
 ### 1.1.2
 
 * Add changelog style guidance.

--- a/tools/vf-component-generator/CHANGELOG.md
+++ b/tools/vf-component-generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 1.1.3
 
-* For JS module imports, also try a relative path, as this improves support in some scenarios
+* For JS module imports, use a relative path, as this improves support in some scenarios.
 
 ### 1.1.2
 

--- a/tools/vf-component-generator/templates/_component.js
+++ b/tools/vf-component-generator/templates/_component.js
@@ -13,13 +13,19 @@
  * 🚫 Don't: const tabs = document.querySelectorAll('.vf-tabs');
  * ✅ Do:    const tabs = document.querySelectorAll('[data-vf-js-tabs]');
  *
- * This allows users who would prefer not to have this JS engange on an element
+ * This allows users who would prefer not to have this JS engage on an element
  * to drop `data-vf-js-component` and still maintain CSS styling.
  */
 
 // Uncomment this boilerplate
 // // if you need to import any other components' JS to use here
 // import { vfOthercomponent } from 'vf-other-component/vf-other-component';
+// try {
+//   import { vfOthercomponent } from "vf-other-component/vf-other-component";
+// } catch (e) {
+//   // Also try a relative path, as this improves support in some scenarios
+//   import { vfOthercomponent } from "../vf-other-component/vf-other-component";
+// }
 //
 //  /**
 //   * The global function for this component

--- a/tools/vf-component-generator/templates/_component.js
+++ b/tools/vf-component-generator/templates/_component.js
@@ -19,13 +19,7 @@
 
 // Uncomment this boilerplate
 // // if you need to import any other components' JS to use here
-// import { vfOthercomponent } from 'vf-other-component/vf-other-component';
-// try {
-//   import { vfOthercomponent } from "vf-other-component/vf-other-component";
-// } catch (e) {
-//   // Also try a relative path, as this improves support in some scenarios
-//   import { vfOthercomponent } from "../vf-other-component/vf-other-component";
-// }
+// import { vfOthercomponent } from vfImportPrefix + '../vf-other-component/vf-other-component';
 //
 //  /**
 //   * The global function for this component


### PR DESCRIPTION
In React (and I imagine other places) they're more particular about the location of the JS module, by adding a `try/catch` we can improve the ability to use VF JS in places.

This idea won't work how I've currently done it. parking it here for now.