### PR TITLE
enhancement: vf-hero safe text

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.2.2
+
+* Allows html (for links) in vf-hero__subheading (and a few other fields) when using the Nunjucks template.
+
 ### 3.2.1
 
 * Resolves a Nunjucks bug on `vf_hero_text` from a yaml file under certain contexts.

--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 3.2.2
 
 * Allows html (for links) in vf-hero__subheading (and a few other fields) when using the Nunjucks template.
+  * https://github.com/visual-framework/vf-core/pull/1485
 
 ### 3.2.1
 

--- a/components/vf-hero/vf-hero.njk
+++ b/components/vf-hero/vf-hero.njk
@@ -32,18 +32,18 @@
   ">
   <div class="vf-hero__content | vf-box | vf-stack vf-stack--400">
     {%- if vf_hero_kicker -%}
-      <p class="vf-hero__kicker">{{- vf_hero_kicker -}}</p>
+      <p class="vf-hero__kicker">{{- vf_hero_kicker | safe -}}</p>
     {%- endif -%}
 
     {%- if vf_hero_heading %}
     <h2 class="vf-hero__heading">
       {%- if vf_hero_heading_href %}<a class="vf-hero__heading_link" href="{{vf_hero_heading_href}}">{%- endif -%}
-      {{- vf_hero_heading -}}
+      {{- vf_hero_heading | safe -}}
       {%- if vf_hero_heading_href -%}</a>{%- endif -%}
     </h2>
     {% endif %}
 
-    {% if vf_hero_subheading %}<p class="vf-hero__subheading">{{vf_hero_subheading}}</p>{% endif %}
+    {% if vf_hero_subheading %}<p class="vf-hero__subheading">{{vf_hero_subheading | safe}}</p>{% endif %}
 
     {%- if vf_hero_text %}
       {% for hero_text in vf_hero_text %}
@@ -54,7 +54,7 @@
     {%- endif %}
     {%- if (vf_hero_link_href) and (vf_hero_link_text) %}
       <a class="vf-hero__link" href="{{ vf_hero_link_href }}">
-      {{- vf_hero_link_text -}}
+      {{- vf_hero_link_text | safe -}}
       <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="" fill-rule="nonzero"></path></svg>
       </a>
     {%- endif -%}


### PR DESCRIPTION
Allows html (for links) in vf-hero__subheading (and a few other fields) when using the Nunjucks template.
