### PR TITLE
the one that updates and deprecates bits of the table

### DIFF
--- a/components/vf-table/CHANGELOG.md
+++ b/components/vf-table/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.2.0
+
+* makes the `--striped` variant the default styling.
+* deprecates `--striped`, `--bordered`, `--tight`, `--loose` variants.
+* tidies up CSS ordering of rulesets to match more the component.
+* makes the `--sortable` icons on by default before a bigger refactor.
+
 ### 1.1.2
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-table/CHANGELOG.md
+++ b/components/vf-table/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.2.0
+### 1.2.0-rc.0
 
 * makes the `--striped` variant the default styling.
 * deprecates `--striped`, `--bordered`, `--tight`, `--loose` variants.

--- a/components/vf-table/vf-table.config.yml
+++ b/components/vf-table/vf-table.config.yml
@@ -6,26 +6,7 @@ status: alpha
 
 variants:
   - name: default
-  - name: striped
-    hidden: true
-    status: deprecated
-    context:
-      striped: true
-  - name: bordered
-    hidden: true
-    status: deprecated
-    context:
-      bordered: true
-  - name: compact
-    hidden: true
-    status: deprecated
-    context:
-      table_variant: "vf-table--tight"
-  - name: loose
-    hidden: true
-    status: deprecated
-    context:
-      table_variant: "vf-table--loose"
+
   - name: has footer
     context:
       table_footer:
@@ -39,11 +20,6 @@ variants:
   - name: has row heading
     context:
       firstCellIsHeader: true
-  - name: fixed header
-    hidden: true
-    status: deprecated
-    context:
-      tableLayoutFixed: true
   - name: actions
     context:
       inline_actions:
@@ -64,6 +40,34 @@ variants:
         - delete
         - download
         - cancel
+
+
+
+  - name: striped
+    hidden: true
+    status: deprecated
+    context:
+      striped: true
+  - name: bordered
+    hidden: true
+    status: deprecated
+    context:
+      bordered: true
+  - name: fixed header
+    hidden: true
+    status: deprecated
+    context:
+      tableLayoutFixed: true
+  - name: compact
+    hidden: true
+    status: deprecated
+    context:
+      table_variant: "vf-table--tight"
+  - name: loose
+    hidden: true
+    status: deprecated
+    context:
+      table_variant: "vf-table--loose"
   - name: kitchen sink
     hidden: true
     status: deprecated

--- a/components/vf-table/vf-table.config.yml
+++ b/components/vf-table/vf-table.config.yml
@@ -6,17 +6,24 @@ status: alpha
 
 variants:
   - name: default
-    hidden: false
   - name: striped
+    hidden: true
+    status: deprecated
     context:
       striped: true
   - name: bordered
+    hidden: true
+    status: deprecated
     context:
       bordered: true
   - name: compact
+    hidden: true
+    status: deprecated
     context:
       table_variant: "vf-table--tight"
   - name: loose
+    hidden: true
+    status: deprecated
     context:
       table_variant: "vf-table--loose"
   - name: has footer
@@ -33,6 +40,8 @@ variants:
     context:
       firstCellIsHeader: true
   - name: fixed header
+    hidden: true
+    status: deprecated
     context:
       tableLayoutFixed: true
   - name: actions
@@ -56,6 +65,8 @@ variants:
         - download
         - cancel
   - name: kitchen sink
+    hidden: true
+    status: deprecated
     context:
       table_caption: Hello Caption
       firstCellIsHeader: true

--- a/components/vf-table/vf-table.scss
+++ b/components/vf-table/vf-table.scss
@@ -24,9 +24,7 @@
   border-collapse: collapse;
 }
 
-.vf-table--fixed {
-  table-layout: fixed;
-}
+
 
 .vf-table__caption {
   @include set-type(text-heading--4);
@@ -42,6 +40,7 @@
 
   @include set-type(text-heading--5, $custom-margin-bottom: 0);
 
+  padding: 8px 16px;
   text-align: left;
 
   .vf-button--icon {
@@ -49,7 +48,6 @@
     color: currentColor;
     display: flex;
     font-weight: 700;
-    padding: 8px 16px;
 
     svg {
       height: 20px;
@@ -69,7 +67,12 @@
 
 .vf-table__row:nth-of-type(even) {
   background-color: ui-color(grey--light);
+
+  .vf-table--no-strpe  & {
+    background-color: neutral(0);
+  }
 }
+
 
 .vf-table__row .vf-table__heading {
   @include set-type(text-heading--5, $custom-margin-bottom: 0);
@@ -160,8 +163,6 @@
   }
 }
 
-
-
 // Deprecated Variants 04-13-21
 html:not(.vf-disable-deprecated) {
   .vf-table--bordered {
@@ -203,4 +204,10 @@ html:not(.vf-disable-deprecated) {
       padding: 8px 24px;
     }
   }
+
+  .vf-table--fixed {
+    @warn 'This variant has been deprecated';
+    table-layout: fixed;
+  }
 }
+

--- a/components/vf-table/vf-table.scss
+++ b/components/vf-table/vf-table.scss
@@ -20,32 +20,9 @@
 
 
 .vf-table {
-  background-color: ui-color(white);
+  background-color: neutral(0);
   border-collapse: collapse;
 }
-
-.vf-table__heading {
-  .vf-button--icon {
-    align-items: center;
-    color: currentColor;
-    display: flex;
-    font-weight: 700;
-
-    svg {
-      height: 20px;
-      margin-left: 4px;
-      opacity: 0;
-      padding: 2px;
-    }
-
-    &:hover {
-      svg {
-        opacity: 1;
-      }
-    }
-  }
-}
-
 
 .vf-table--fixed {
   table-layout: fixed;
@@ -59,17 +36,29 @@
 
 .vf-table__header {
   background-color: color(grey--lightest);
-
-  .vf-table__heading {
-    padding: 8px 16px;
-  }
 }
 
 .vf-table__heading {
+
   @include set-type(text-heading--5, $custom-margin-bottom: 0);
 
   text-align: left;
+
+  .vf-button--icon {
+    align-items: center;
+    color: currentColor;
+    display: flex;
+    font-weight: 700;
+    padding: 8px 16px;
+
+    svg {
+      height: 20px;
+      margin-left: 4px;
+      padding: 2px;
+    }
+  }
 }
+
 
 .vf-table__cell {
   @include set-type(text-body--2, $custom-margin-bottom: 0);
@@ -78,22 +67,8 @@
   vertical-align: top;
 }
 
-.vf-table--tight {
-  .vf-table__heading {
-    padding: 4px 4px;
-  }
-  .vf-table__cell {
-    padding: 4px 4px;
-  }
-}
-
-.vf-table--loose {
-  .vf-table__heading {
-    padding: 16px 24px;
-  }
-  .vf-table__cell {
-    padding: 8px 24px;
-  }
+.vf-table__row:nth-of-type(even) {
+  background-color: ui-color(grey--light);
 }
 
 .vf-table__row .vf-table__heading {
@@ -102,26 +77,6 @@
   text-align: left;
 }
 
-.vf-table--striped {
-  .vf-table__body {
-    & .vf-table__row:nth-of-type(even) {
-      background-color: ui-color(grey--light);
-    }
-  }
-}
-
-.vf-table--bordered {
-
-  border: 1px solid color(grey);
-
-  .vf-table__heading {
-    border: 1px solid color(grey);
-  }
-
-  .vf-table__cell {
-    border: 1px solid color(grey);
-  }
-}
 
 
 .vf-table__body {
@@ -135,12 +90,12 @@
   text-align: center;
 }
 
+.vf-table__footer {
+  background-color: color(grey--lightest);
+}
 
 // Selectable
 
-.vf-table__cell--selectable {
-  // vertical-align: middle;
-}
 .vf-table__cell--actions {
   .vf-button--icon {
     color: color(blue);
@@ -180,6 +135,7 @@
   }
 }
 
+// Table Actions
 
 .vf-table__actions {
   background-color: color(blue);;
@@ -205,11 +161,46 @@
 }
 
 
-.vf-table__footer {
-  background-color: color(grey--lightest);
-  border-top: 1px solid ui-color(black);
 
-  .vf-table__cell {
-    padding: 8px 16px;
+// Deprecated Variants 04-13-21
+html:not(.vf-disable-deprecated) {
+  .vf-table--bordered {
+    @warn 'This variant has been deprecated';
+    border: 1px solid color(grey);
+    .vf-table__heading {
+      border: 1px solid color(grey);
+    }
+    .vf-table__cell {
+      border: 1px solid color(grey);
+    }
+  }
+
+  .vf-table--striped {
+    @warn 'This variant has been deprecated and is now the default styling';
+    .vf-table__body {
+      & .vf-table__row:nth-of-type(even) {
+        background-color: ui-color(grey--light);
+      }
+    }
+  }
+
+  .vf-table--tight {
+    @warn 'This variant has been deprecated';
+    .vf-table__heading {
+      padding: 4px 4px;
+    }
+    .vf-table__cell {
+      padding: 4px 4px;
+    }
+  }
+
+  .vf-table--loose {
+    @warn 'This variant has been deprecated';
+    .vf-table__heading {
+      padding: 16px 24px;
+    }
+    .vf-table__cell {
+      padding: 8px 24px;
+    }
   }
 }


### PR DESCRIPTION
- makes the `--striped` variant the default styling.
- deprecates `--striped`, `--bordered`, `--tight`, `--loose` variants.
- tidies up CSS ordering of rulesets to match more the component.
- makes the `--sortable` icons on by default before a bigger refactor.