### PR TITLE
the one. that corrects link colour when hovering on visited link

### DIFF
--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.5.5
+
+* corrects colouring of visited link in heading on striped variant.
+
 ### 2.5.4
 
 * adds `word-break: break-word;` to text so the text won't exceed the box model.

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -220,6 +220,9 @@
 
     .vf-card__link {
       color: currentColor;
+      &:visited {
+        color: currentColor;
+      }
     }
   }
 

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -220,7 +220,7 @@
 
     .vf-card__link {
       color: currentColor;
-      &:visited {
+      &:hover {
         color: currentColor;
       }
     }


### PR DESCRIPTION
currently if the `--striped` variant of the card has a heading that is a link, which is visited … the colour turns to blue on hover -- it should be white - and this fixes that. 