### PR TITLE
the one that changes how width works so it responds to viewport

### DIFF
--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 3.3.3.
+### 3.2.3.
 
 * fixes width issue on mobile introduced when making the hero content a little wider.
 

--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.3.3.
+
+* fixes width issue on mobile introduced when making the hero content a little wider.
+
 ### 3.2.2
 
 * Allows html (for links) in vf-hero__subheading (and a few other fields) when using the Nunjucks template.

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -38,7 +38,8 @@
     0 2px 3px rgba(0, 0, 0, .1);
   position: relative;
   z-index: set-layer(vf-z-index--hero);
-  width: max-content;
+  max-width: max-content;
+  width: auto;
 }
 
 .vf-hero__kicker {


### PR DESCRIPTION
When introducing the new `--400` variant of the `vf-hero` we also made some small changes to how width works in the component to try and appease the academy team as much as possible without degenerating the component.

This introduced a bug on smaller viewports where the `vf-hero__content` would not resize accordingly. 

This fixes that. 