### PR TITLE
Pattern, docs: add a no-js error page example

### DIFF
--- a/tools/vf-component-library/src/site/_data/siteConfig.js
+++ b/tools/vf-component-library/src/site/_data/siteConfig.js
@@ -39,7 +39,8 @@ module.exports = {
     },
     patterns: {
       url: "/patterns",
-      title: "Patterns"
+      title: "Patterns",
+      summary: "Pattern-level example boilerplates."
     },
     components: {
       url: "/components",

--- a/tools/vf-component-library/src/site/_includes/layouts/section.njk
+++ b/tools/vf-component-library/src/site/_includes/layouts/section.njk
@@ -27,7 +27,7 @@ templateEngineOverride: njk
 {# See if a section has subposts. #}
 {# Unfortunately there's not a more elegant way to see how many posts there are with a data attribute without adding 11ty config overhead #}
 {% set sectionHasSubposts = false %}
-{%- for post in collections.posts %}
+{%- for post in collections.posts | sort(false, true, 'data.title') %}
 {% if section == post.data.section %}
 {% set sectionHasSubposts = true %}
 {# {% break %} #}
@@ -36,32 +36,30 @@ templateEngineOverride: njk
 {%- endfor %}
 
 {% if sectionHasSubposts and hideSubPosts != true %}
-<hr class="vf-divider" />
-<section class="embl-grid embl-grid--has-centered-content">
-  <div></div>
-  <div class="vf-content">
 
-<h2>In this section</h2>
-
-<div class="vf-grid vf-grid__col-2">
-  {%- for post in collections.posts %}
-    {% if section == post.data.section %}
-    {% set absolutePostUrl %}{{ metadata.id }}{{ post.url }}{% endset %}
-    <article class="vf-card vf-card--brand vf-card--bordered">
-      <div class="vf-card__content | vf-stack vf-stack--400">
-        <h3 class="vf-card__heading">
-          <a class="vf-card__link" href="{{ absolutePostUrl | url }}">{{ post.data.title }} <svg aria-hidden="true" class="vf-card__heading__icon | vf-icon vf-icon-arrow--inline-end" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="currentColor" fill-rule="nonzero"></path></svg>
-          </a>
-        </h3>
-      </div>
-    </article>
-
-    <p>{{ post.data.subtitle }}</p>
-
-    {% endif %}
-  {%- endfor %}
-</div>
-
+<section class="vf-card-container | vf-u-background-color--grey--lightest vf-u-fullbleed" style="--vf-card__image--aspect-ratio: 16 / 9;">
+  <div class="vf-card-container__inner">
+    {% render '@vf-section-header', {
+      "section_title": "Also in this section",
+      "id": "inthissection",
+      "vf_section__content": [
+        'More from the <a href="' + siteConfig.sections[section].url + '">' + siteConfig.sections[section].title + '</a> section'
+      ]
+    } %}
+    {%- for post in collections.posts | sort(false, true, 'data.title') %}
+      {% if section == post.data.section %}
+      {% set absolutePostUrl %}{{ metadata.id }}{{ post.url }}{% endset %}
+      <article class="vf-card vf-card--brand vf-card--bordered | vf-content">
+        <div class="vf-card__content | vf-stack vf-stack--400">
+          <h3 class="vf-card__heading">
+            <a class="vf-card__link" href="{{ absolutePostUrl | url }}">{{ post.data.title }} <svg aria-hidden="true" class="vf-card__heading__icon | vf-icon vf-icon-arrow--inline-end" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="currentColor" fill-rule="nonzero"></path></svg>
+            </a>
+          </h3>
+          <p>{{ post.data.subtitle }}</p>
+        </div>
+      </article>
+      {% endif %}
+    {%- endfor %}
   </div>
 </section>
 

--- a/tools/vf-component-library/src/site/building/index.njk
+++ b/tools/vf-component-library/src/site/building/index.njk
@@ -1,6 +1,7 @@
 ---
 is_index: true
 promoted: true
+hideSubPosts: false
 title: Building a site
 subtitle: The when and how to making a project powered with Visual Framework components.
 intro: Visual Framework components can be utilised in many ways, here are a few recommended approaches that will fit most use cases.
@@ -9,102 +10,178 @@ section: building
 tags:
   - building
   - sections
-layout: layouts/section.njk
-templateEngineOverride: njk, md
+layout: layouts/base.njk
+templateEngineOverride: njk
 ---
 
-## Components and patterns
+{% render '@vf-intro', {
+  "vf_intro_heading": title,
+  "vf_intro_lede": subtitle,
+  "vf_intro_text": [
+    intro
+  ],
+  "vf_intro_subheading": subheading,
+  "vf_intro_badge": false
+} %}
 
-If you already have VF CSS and JS available to your project, follow the documentation and guidance on components and patterns.
 
-- [Find buttons, tabs, cards and more in the components](/components)
-- [Example pages, boilerplates and patterns](/patterns) for quick starts and layouts
+<article class="embl-grid embl-grid--has-centered-content">
+  {% render '@vf-section-header', {
+    "section_title": "Working on an existing VF project?",
+    "id": "components",
+    "vf_section__content": [
+      ""
+    ]
+  } %}
+  <div class="vf-content">
+    {% markdown %}
+    If you already have VF CSS and JS available to your project, follow the documentation and guidance on components and patterns.
 
-## Option 1: CSS and JS from a CDN
+    - [Find buttons, tabs, cards and more in the components](/components)
+    - [Example pages, boilerplates and patterns](/patterns) for quick starts and layouts
+    {% endmarkdown %}
+  </div>
+</article>
 
-For getting started quickly (and without customisation) you can use the prebuilt CDN files.
 
-{% codeblock 'html' -%}
-<!-- CSS only -->
-<link rel="stylesheet" href="https://{{ siteConfig.vfVersionPrefix }}assets.emblstatic.net/vf/{{ siteConfig.vfVersion }}/css/styles.css">
-<!-- JS -->
-<script src="https://{{ siteConfig.vfVersionPrefix }}assets.emblstatic.net/vf/{{ siteConfig.vfVersion }}/scripts/scripts.js"></script>
-{%- endcodeblock %}
-<br/>
+<article class="embl-grid embl-grid--has-centered-content">
+  {% render '@vf-section-header', {
+    "section_title": "Option 1",
+    "id": "option-1",
+    "section__subheading": [
+      "CSS and JS from a CDN"
+    ]
+  } %}
+  <div class="vf-content">
+    {% markdown %}
+    For getting started quickly (and without customisation) you can use the prebuilt CDN files.
+    {% endmarkdown %}
 
-## Option 2: Install from npm
+    {% codeblock 'html' -%}
+    <!-- CSS only -->
+    <link rel="stylesheet" href="https://{{ siteConfig.vfVersionPrefix }}assets.emblstatic.net/vf/{{ siteConfig.vfVersion }}/css/styles.css">
+    <!-- JS -->
+    <script src="https://{{ siteConfig.vfVersionPrefix }}assets.emblstatic.net/vf/{{ siteConfig.vfVersion }}/scripts/scripts.js"></script>
+    {%- endcodeblock %}
+  </div>
+</article>
 
-The most basic use of the Visual Framework components allows usage directly into your existing build environment. This approach gets you a components Sass, JS, template and any other assets and lets you build what you need.
 
-This approach is recommended for more advanced developers who are highly familiar with Node and Sass.
+<article class="embl-grid embl-grid--has-centered-content">
+  {% render '@vf-section-header', {
+    "section_title": "Option 2",
+    "id": "option-2",
+    "section__subheading": [
+      "Install from npm"
+    ]
+  } %}
+  <div class="vf-content">
+    {% markdown %}
+    The most basic use of the Visual Framework components allows usage directly into your existing build environment. This approach gets you a components Sass, JS, template and any other assets and lets you build what you need.
 
-{% codeblock 'bash' -%}
+    This approach is recommended for more advanced developers who are highly familiar with Node and Sass.
+    {% endmarkdown %}
 
-# 1. Add the Sass config, starter and any components
+    {% codeblock 'bash' -%}
 
-yarn add @visual-framework/vf-sass-config
-yarn add @visual-framework/vf-sass-starter
-yarn add @visual-framework/vf-content
-yarn add @visual-framework/vf-analytics-google
+    # 1. Add the Sass config, starter and any components
 
-# 2. Import it in your Sass
+    yarn add @visual-framework/vf-sass-config
+    yarn add @visual-framework/vf-sass-starter
+    yarn add @visual-framework/vf-content
+    yarn add @visual-framework/vf-analytics-google
 
-@import 'node_modules/@visual-framework/vf-sass-starter/index.scss';
-@import 'node_modules/@visual-framework/vf-content/vf-content.scss';
+    # 2. Import it in your Sass
 
-# 3. Import JS modules
+    @import 'node_modules/@visual-framework/vf-sass-starter/index.scss';
+    @import 'node_modules/@visual-framework/vf-content/vf-content.scss';
 
-import { vfGaTrackInteraction } from 'node_modules/@visual-framework/vf-analytics-google/vf-analytics-google.js';
+    # 3. Import JS modules
 
-{%- endcodeblock %}
+    import { vfGaTrackInteraction } from 'node_modules/@visual-framework/vf-analytics-google/vf-analytics-google.js';
 
-<br/>
+    {%- endcodeblock %}
+  </div>
+</article>
 
-## Option 3: Starter packages
+<article class="embl-grid embl-grid--has-centered-content">
+  {% render '@vf-section-header', {
+    "section_title": "Option 3",
+    "id": "option-3",
+    "section__subheading": [
+      "Starter packages"
+    ]
+  } %}
+  <div class="vf-content">
+    {% markdown %}
+    If you still need to setup your development environment and code editor, [follow our development getting started guide]({{ "/developing/getting-started/setting-up" | url }}).
 
-If you still need to setup your development environment, [follow our development getting started guide]({{ "/developing/getting-started/setting-up" | url }}).
+    ### Compile CSS, JS
 
-### Compile CSS, JS
+    Need help converting VF components to static CSS and JS to pair with your existing application or site? Use the `vf-build-boilerplate`.
 
-Need help converting VF components to static CSS and JS to pair with your existing application or site? Use the `vf-build-boilerplate`.
+    It's also a good introduction into integrating VF components into an application.
 
-It's also a good introduction into integrating VF components into an application.
+    [`vf-build-boilerplate`](https://github.com/visual-framework/vf-build-boilerplate)
 
-[`vf-build-boilerplate`](https://github.com/visual-framework/vf-build-boilerplate)
+    - `yarn create @visual-framework/vf-project your-new-site-name vf-build-boilerplate`
+    - add Visual Framework components with `yarn add @visual-framework/vf-component-name` or make a new component with [`vf-component-generator`](https://www.npmjs.com/package/@visual-framework/vf-component-generator)
 
-- `yarn create @visual-framework/vf-project your-new-site-name vf-build-boilerplate`
-- add Visual Framework components with `yarn add @visual-framework/vf-component-name` or make a new component with [`vf-component-generator`](https://www.npmjs.com/package/@visual-framework/vf-component-generator)
+    ### A static site generator
 
-### A static site generator
+    Uses the preformat [11ty](https://www.11ty.io/) as a static site generator to build sites with VF components. This approach pre-integrates the VF Core, giving you easy access to component assets and a rollup build process to generate compiled CSS and JS.
 
-Uses the preformat [11ty](https://www.11ty.io/) as a static site generator to build sites with VF components. This approach pre-integrates the VF Core, giving you easy access to component assets and a rollup build process to generate compiled CSS and JS.
+    [`vf-eleventy` boilerplate](https://github.com/visual-framework/vf-eleventy)
 
-[`vf-eleventy` boilerplate](https://github.com/visual-framework/vf-eleventy)
+    - `yarn create @visual-framework/vf-project your-new-site-name`
+    - add Visual Framework components with `yarn add @visual-framework/vf-component-name` or make a new component with [`vf-component-generator`](https://www.npmjs.com/package/@visual-framework/vf-component-generator)
 
-- `yarn create @visual-framework/vf-project your-new-site-name`
-- add Visual Framework components with `yarn add @visual-framework/vf-component-name` or make a new component with [`vf-component-generator`](https://www.npmjs.com/package/@visual-framework/vf-component-generator)
+    ### A design system
 
-### A design system
+    Extends`vf-eleventy`to document your design system, create+document components, patterns and boilerplates. You can also generate static CSS and JS assets for simple use elsewhere in vanilla HTML+CSS+JS pages.
 
-Extends`vf-eleventy`to document your design system, create+document components, patterns and boilerplates. You can also generate static CSS and JS assets for simple use elsewhere in vanilla HTML+CSS+JS pages.
+    [`vf-demo-design-system` boilerplate](https://github.com/visual-framework/vf-demo-design-system)
 
-[`vf-demo-design-system` boilerplate](https://github.com/visual-framework/vf-demo-design-system)
+    - `yarn create @visual-framework/vf-project your-new-site-name vf-demo-design-system`
+    - add Visual Framework components with `yarn add @visual-framework/vf-component-name` or make a new component with [`vf-component-generator`](https://www.npmjs.com/package/@visual-framework/vf-component-generator)
 
-- `yarn create @visual-framework/vf-project your-new-site-name vf-demo-design-system`
-- add Visual Framework components with `yarn add @visual-framework/vf-component-name` or make a new component with [`vf-component-generator`](https://www.npmjs.com/package/@visual-framework/vf-component-generator)
+    ### WordPress theme and plugins
 
-### WordPress theme and plugins
+    Build a WordPress site using VF components.
 
-Build a WordPress site using VF components.
+    - `Pre-alpha, no link yet`
+    - Register your interest ken.hawkins@embl.de
 
-- `Pre-alpha, no link yet`
-- Register your interest ken.hawkins@embl.de
+    ### React boilerplate
 
-### React boilerplate
+    A demonstration React-based project using VF components.
 
-A demonstration React-based project using VF components.
+    - `Pre-alpha, no link yet`
+    - Register your interest ken.hawkins@embl.de
 
-- `Pre-alpha, no link yet`
-- Register your interest ken.hawkins@embl.de
+    Can't find what you need? [Ask for help on Slack](https://join.slack.com/t/visual-framework/shared_invite/enQtNDAxNzY0NDg4NTY0LWFhMjEwNGY3ZTk3NWYxNWVjOWQ1ZWE4YjViZmY1YjBkMDQxMTNlNjQ0N2ZiMTQ1ZTZiMGM4NjU5Y2E0MjM3ZGQ)
 
-Can't find what you need? [Ask for help on Slack](https://join.slack.com/t/visual-framework/shared_invite/enQtNDAxNzY0NDg4NTY0LWFhMjEwNGY3ZTk3NWYxNWVjOWQ1ZWE4YjViZmY1YjBkMDQxMTNlNjQ0N2ZiMTQ1ZTZiMGM4NjU5Y2E0MjM3ZGQ)
+
+    {% endmarkdown %}
+
+    {% codeblock 'bash' -%}
+
+    # 1. Add the Sass config, starter and any components
+
+    yarn add @visual-framework/vf-sass-config
+    yarn add @visual-framework/vf-sass-starter
+    yarn add @visual-framework/vf-content
+    yarn add @visual-framework/vf-analytics-google
+
+    # 2. Import it in your Sass
+
+    @import 'node_modules/@visual-framework/vf-sass-starter/index.scss';
+    @import 'node_modules/@visual-framework/vf-content/vf-content.scss';
+
+    # 3. Import JS modules
+
+    import { vfGaTrackInteraction } from 'node_modules/@visual-framework/vf-analytics-google/vf-analytics-google.js';
+
+    {%- endcodeblock %}
+  </div>
+</article>

--- a/tools/vf-component-library/src/site/guidance/index.njk
+++ b/tools/vf-component-library/src/site/guidance/index.njk
@@ -12,23 +12,16 @@ tags:
   - building
   - sections
 layout: layouts/section.njk
-templateEngineOverride: njk, md
+templateEngineOverride: njk
 ---
 
-{%- for post in collections.guidance  | reverse %}
-
+{%- for post in collections.guidance | sort(false, true, 'data.title') %}
 <article class="vf-summary vf-summary--article">
   <h3 class="vf-summary__title">
     <a href="{{ post.url | url }}" class="vf-summary__link">{{ post.data.title }}</a>
   </h3>
-  {# <div class="vf-summary__meta">
-    left spacing artifact when no author
-    <p class="vf-summary__date">{{ post.date | dateDisplay }}</p>
-  </div> #}
-  {# <p class="vf-text-body--5 | vf-u-margin__bottom--200">{{ date | dateDisplay }}</p> #}
   <p class="vf-summary__text">
     {{ post.data.subtitle | markdown | safe | replace("<p>", "<span class='vf-content'>") | replace("</p>", "</span>") }}
   </p>
 </article>
-
 {% endfor %}

--- a/tools/vf-component-library/src/site/guidance/javascript-required.md
+++ b/tools/vf-component-library/src/site/guidance/javascript-required.md
@@ -1,0 +1,27 @@
+---
+title: "JavaScript: mitigating broken experiences"
+subtitle: If JavaScript fails, some tips on how you can ensure users can still complete their task.
+intro: Many projects may use solutions (React, Angular or similar) or use Visual Framework components that require JavaScript to function but there are many costs.
+date: 2021-05-19 19:33:50
+section: building
+tags:
+  - posts
+  - guidance
+layout: layouts/section.njk
+templateEngineOverride: njk, md
+---
+
+Before using a JavaScript-powered solution, the product team should ask themselves:
+
+1. What are the benefits for the project and user of using a JavaScript solution?
+     - Examples: Improved interactivity and state management or specific features.
+2. What are the downsides?
+    - Examples: Increased page size, computer requirements, technical complexity, SEO complexity.
+3.  What recourse do users have when JavaScript fails, is disabled or an older browser is used?
+    - See also: [Browser support guidance](https://stable.visual-framework.dev/guidance/browser-support/)
+    - The VF supports browsers released within the last five years and have JavaScript enabled.
+    - [Pre-rendering your JavaScript application](https://duckduckgo.com/?q=prerendering+javascript+frameworks) may have many benefits.
+
+You should only use JavaScript frameworks when a high level of interactivity is needed and provide robust text or fallback functionality and make use of [the JavaScript error template](/patterns/error-pages/).
+
+Further reading: [Gov.uk provides additional reasoning](https://www.gov.uk/service-manual/technology/using-progressive-enhancement#do-not-assume-users-turn-off-css-or-javascript) on why you should not assume your JavaScript application works for all users.

--- a/tools/vf-component-library/src/site/guidance/javascript.md
+++ b/tools/vf-component-library/src/site/guidance/javascript.md
@@ -1,5 +1,5 @@
 ---
-title: JavaScript guidelines
+title: JavaScript and Visual Framework components
 subtitle: We use "just enough" JavaScript in the Visual Framework.
 date: 2020-12-11 19:33:50
 section: building

--- a/tools/vf-component-library/src/site/patterns/error-pages.njk
+++ b/tools/vf-component-library/src/site/patterns/error-pages.njk
@@ -1,7 +1,7 @@
 ---
 title: Error pages
-subtitle: Use these boilerplate pattern for 404, 403, 500 and other common pages.
-section: components
+subtitle: Use these boilerplate patterns for JavaScript, 404, 403, 500 and other common pages.
+section: patterns
 date: 2021-02-09 12:24:50
 tags: posts
 layout: layouts/base.njk
@@ -32,6 +32,10 @@ layout: layouts/base.njk
     "svg": true,
     "list": [
       {
+        "text": "JavaScript failure",
+        "link_list_href": "#javascript"
+      },
+      {
         "text": "404",
         "link_list_href": "#404"
       },
@@ -48,6 +52,19 @@ layout: layouts/base.njk
   </div>
 </div>
 
+<hr class="vf-divider" />
+
+{% render '@vf-intro', {
+  "id": "javascript",
+  "vf_intro_badge": false,
+  "vf_intro_heading": "Error: JavaScript failure",
+  "vf_intro_subheading": "",
+  "vf_intro_lede": "JavaScript is required for this webpage or site.",
+  "vf_intro_text": [
+    "It seems you either have JavaScript turned off, there was a network failure, or you have a legacy browser.",
+    "A refresh of the page will hopefully fix the issue, or you might check if <a href='https://enable-javascript.com'>JavaScript is enabled on your browser</a>. You can also <a href='#'>contact web support for this site</a>."
+  ]
+} %}
 
 <hr class="vf-divider" />
 


### PR DESCRIPTION
For #1524

Also:

- adds a bit of section template cleanup
- sorts documentation lists alphabetically (instead of by date)

Aligns with  Discussion/notes: improving the component library browser #1175 