### PR TITLE
the one that makes it possible to use HTML in a section header text item

### DIFF
--- a/components/vf-section-header/CHANGELOG.md
+++ b/components/vf-section-header/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.5.0
+
+* makes if possible to use HTML in the section header text.
+
 ### 1.4.0
 
 * changes value of SVG to use `em`s so it scales with the typeface size.

--- a/components/vf-section-header/vf-section-header.config.yml
+++ b/components/vf-section-header/vf-section-header.config.yml
@@ -31,7 +31,7 @@ variants:
       section__subheading: News from EMBL’s six sites
       vf_section__content:
       - Hello everyone who are doing?
-      - Pizza
+      - Buy <a href="#">Pizza</a>.
   - name: has a link and text
     context:
       href: JavaScript:Void(0);

--- a/components/vf-section-header/vf-section-header.njk
+++ b/components/vf-section-header/vf-section-header.njk
@@ -34,7 +34,7 @@
 
   {%- if vf_section__content -%}
     {%- asyncEach section__content in vf_section__content -%}
-      <p class="vf-section-header__text">{{section__content}}</p>
+      <p class="vf-section-header__text">{{section__content | safe }}</p>
     {%- endeach -%}
   {%- endif -%}
 </div>

--- a/components/vf-section-header/vf-section-header.scss
+++ b/components/vf-section-header/vf-section-header.scss
@@ -53,6 +53,10 @@
 .vf-section-header__text {
   @include set-type(text-body--2, $custom-margin-bottom: 8px);
 
+  a, .vf-link {
+    @include inline-link;
+  }
+
   &:last-of-type {
     @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--0));
   }


### PR DESCRIPTION
Spilios needed to include a link in the section header text for a card container and it wasn't possible without the ` | safe` being in the .njk file.

This fixes that. 