### PR TITLE
the one that makes `vf-stack` dictate the flow of things a bit better

### DIFF
--- a/components/embl-content-hub-loader/CHANGELOG.md
+++ b/components/embl-content-hub-loader/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0
+
+* adds overrides for more permutations of where the vf-global header lives
+
 ### 1.0.9
 
 * Improve JS module import support.

--- a/components/embl-content-hub-loader/embl-content-hub-loader.scss
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.scss
@@ -27,3 +27,14 @@
 .vf-body > .embl-content-hub-html {
   grid-column: main;
 }
+
+// This is to target the links that load things like the global header
+.vf-stack link[data-embl-js-content-hub-loader] {
+  --vf-stack-margin--custom: 0;
+}
+
+// targets anything that's loaded from content hub
+// as nine times out of ten - it's ok.
+.vf-content-hub-html {
+  --vf-stack-margin--custom: 0;
+}

--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.8gst.0
+
+* adds overrides for more permutations of where the vf-global header lives
+
 ### 1.7.2
 
 * adds deprecation notices around the `--phase` variant.

--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.8gst.0
+### 1.8.0
 
 * adds overrides for more permutations of where the vf-global header lives
 

--- a/components/vf-banner/vf-banner.scss
+++ b/components/vf-banner/vf-banner.scss
@@ -131,3 +131,12 @@
 
   background-color: $vf-notice-banner-color--background;
 }
+
+
+// CSS to target the GDPR banner when it's hidden but making vf-stack think it
+// should add top margin to the next element
+
+// This is for the WP build
+.vf-banner + div {
+  --vf-stack-margin--custom: space(200);
+}

--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.2.0
+
+* removes any margins to allow `vf-stack` to dictate spacing.
+
 ### 1.1.1
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,7 +1,3 @@
-### 1.2.0
-
-* adds overrides for more permutations of where the vf-global header lives
-
 ### 1.1.1
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-global-header/CHANGELOG.md
+++ b/components/vf-global-header/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 1.2.0
 
-* removes any margins to allow `vf-stack` to dictate spacing.
+* adds overrides for more permutations of where the vf-global header lives
 
 ### 1.1.1
 

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -19,6 +19,7 @@ $vf-global-header__link-text--color: ui-color(black);
   display: flex;
   flex-wrap: wrap;
   gap: space(200);
+  margin-top: space(200);
 
   & > [class*='logo'] {
     flex: 1; // necessary for when a logo is inside flex-based containers like vf-global-header
@@ -35,4 +36,22 @@ $vf-global-header__link-text--color: ui-color(black);
     margin-left: .5rem;
     margin-right: .5rem;
   }
+}
+
+// Currently the GDPR banner stays in the DOM rather than getting destroyed.
+// Because of this it becomes the first item in the `vf-stack` so the next item,
+// the vf-global-header, has a top margin of 1rem.
+// This fixes that:
+// Note: we duplicate the top margin that's already on line 22.
+
+// These are for static html pages
+link {
+  --vf-stack-margin--custom: 0;
+}
+link > div {
+  --vf-stack-margin--custom: 0;
+}
+// This is for the WP build
+.vf-banner + div {
+  --vf-stack-margin--custom: space(200);
 }

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -37,21 +37,3 @@ $vf-global-header__link-text--color: ui-color(black);
     margin-right: .5rem;
   }
 }
-
-// Currently the GDPR banner stays in the DOM rather than getting destroyed.
-// Because of this it becomes the first item in the `vf-stack` so the next item,
-// the vf-global-header, has a top margin of 1rem.
-// This fixes that:
-// Note: we duplicate the top margin that's already on line 22.
-
-// These are for static html pages
-link {
-  --vf-stack-margin--custom: 0;
-}
-link > div {
-  --vf-stack-margin--custom: 0;
-}
-// This is for the WP build
-.vf-banner + div {
-  --vf-stack-margin--custom: space(200);
-}

--- a/components/vf-global-header/vf-global-header.scss
+++ b/components/vf-global-header/vf-global-header.scss
@@ -19,7 +19,6 @@ $vf-global-header__link-text--color: ui-color(black);
   display: flex;
   flex-wrap: wrap;
   gap: space(200);
-  margin-top: space(200);
 
   & > [class*='logo'] {
     flex: 1; // necessary for when a logo is inside flex-based containers like vf-global-header
@@ -36,14 +35,4 @@ $vf-global-header__link-text--color: ui-color(black);
     margin-left: .5rem;
     margin-right: .5rem;
   }
-}
-
-// Currently the GDPR banner stays in the DOM rather than getting destroyed.
-// Because of this it becomes the first item in the `vf-stack` so the next item,
-// the vf-global-header, has a top margin of 1rem.
-// This fixes that:
-// Note: we duplicate the top margin that's already on line 22.
-
-.vf-banner + div {
-  --vf-stack-margin--custom: space(200);
 }


### PR DESCRIPTION
Initially - we want the `vf-global-header` to have a top margin of `8px` so it's close to the top of the viewport but not 'on top of it'.

This worked ok until we added `vf-stack`. 

But this is not because of `vf-stack` but because we have the GDPR `vf-banner` in the DOM as well as the `link` to the `vf-global-header` because it comes from content hub. 

This adds more ways to make the `vf-global-header` sit on the page correctly.