### PR TITLE
the one that reduces the variants of pagination

### DIFF
--- a/components/vf-pagination/CHANGELOG.md
+++ b/components/vf-pagination/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.1.0-rc.2
+
+* reduces the amount of variants to 'start again'.
+* centres the default variant
+
 ### 1.0.1
 
 * Fixes CSS to match stylelint rules.

--- a/components/vf-pagination/vf-pagination--full.scss
+++ b/components/vf-pagination/vf-pagination--full.scss
@@ -1,5 +1,8 @@
-.vf-pagination__item--pages-per {
-  &:hover {
-    background: unset;
+html:not(.vf-disable-deprecated) {
+  .vf-pagination__item--pages-per {
+    @warn 'The variant of vf-pagination has been deprecated';
+    &:hover {
+      background: unset;
+    }
   }
 }

--- a/components/vf-pagination/vf-pagination.config.yml
+++ b/components/vf-pagination/vf-pagination.config.yml
@@ -41,6 +41,7 @@ variants:
           item_modifier: vf-pagination__item--next-page
   - name: compact
     hidden: true
+    status: deprecated
     context:
       pagination__list:
         - page_number: Previous
@@ -51,6 +52,7 @@ variants:
           item_modifier: vf-pagination__item--next-page
   - name: expanded
     hidden: true
+    status: deprecated
     context:
       pagination__list:
         - page_number: First
@@ -73,6 +75,7 @@ variants:
           item_modifier: vf-pagination__item--jump-forward
   - name: First Last
     hidden: true
+    status: deprecated
     context:
       pagination__list:
         - page_number: First (1)
@@ -89,3 +92,4 @@ variants:
           item_modifier: vf-pagination__item--jump-forward
   - name: full
     hidden: true
+    status: deprecated

--- a/components/vf-pagination/vf-pagination.config.yml
+++ b/components/vf-pagination/vf-pagination.config.yml
@@ -20,9 +20,6 @@ variants:
         - page_number: Previous
           page_href: 'JavaScript:Void(0);'
           item_modifier: vf-pagination__item--previous-page
-        - page_number: -10
-          page_href: 'JavaScript:Void(0);'
-          item_modifier: vf-pagination__item--jump-back
         - page_number: 1
           page_href: 'JavaScript:Void(0);'
         - page_number: 2
@@ -39,13 +36,11 @@ variants:
           page_href: 'JavaScript:Void(0);'
         - page_number: 92
           page_href: 'JavaScript:Void(0);'
-        - page_number: +10
-          page_href: 'JavaScript:Void(0);'
-          item_modifier: vf-pagination__item--jump-forward
         - page_number: Next
           page_href: 'JavaScript:Void(0);'
           item_modifier: vf-pagination__item--next-page
   - name: compact
+    hidden: true
     context:
       pagination__list:
         - page_number: Previous
@@ -55,6 +50,7 @@ variants:
           page_href: 'JavaScript:Void(0);'
           item_modifier: vf-pagination__item--next-page
   - name: expanded
+    hidden: true
     context:
       pagination__list:
         - page_number: First
@@ -76,6 +72,7 @@ variants:
           page_href: 'JavaScript:Void(0);'
           item_modifier: vf-pagination__item--jump-forward
   - name: First Last
+    hidden: true
     context:
       pagination__list:
         - page_number: First (1)
@@ -90,3 +87,5 @@ variants:
         - page_number: Last (88)
           page_href: 'JavaScript:Void(0);'
           item_modifier: vf-pagination__item--jump-forward
+  - name: full
+    hidden: true

--- a/components/vf-pagination/vf-pagination.scss
+++ b/components/vf-pagination/vf-pagination.scss
@@ -13,7 +13,8 @@
 
 .vf-pagination__list {
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
+  padding-left: 0;
   list-style-type: none;
 }
 .vf-pagination__item {

--- a/components/vf-pagination/vf-pagination.scss
+++ b/components/vf-pagination/vf-pagination.scss
@@ -14,8 +14,8 @@
 .vf-pagination__list {
   display: flex;
   justify-content: center;
-  padding-left: 0;
   list-style-type: none;
+  padding-left: 0;
 }
 .vf-pagination__item {
   align-self: baseline;


### PR DESCRIPTION
Like most things - we are looking to pair back components, re-thinking, and redesigning where necessary.

This is a 'stop gap' that hides variants that are not necessarily on notice - but where more discussion is needed and use cases required to validate the need, and the design and functionality.

What I have done is deprecate variants except for the default one. Most of the variants are 'for example' and no CSS (except for the vey bust 'full' version) has been deprecated.