### PR TITLE
the one that updates blockquote to allow for use with context and a bit more

### DIFF
--- a/components/vf-blockquote/CHANGELOG.md
+++ b/components/vf-blockquote/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.2.0
+
+* adds context `if` statement to make it useable in vf-11ty.
+* adds `cite` element.
+* adds `vf-stack`.
+
 ### 1.1.1
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-blockquote/CHANGELOG.md
+++ b/components/vf-blockquote/CHANGELOG.md
@@ -3,6 +3,7 @@
 * adds context `if` statement to make it useable in vf-11ty.
 * adds `cite` element.
 * adds `vf-stack`.
+* kept `{{- html | safe if html else text -}}` so it shouldn't break
 
 ### 1.1.1
 

--- a/components/vf-blockquote/vf-blockquote.config.yml
+++ b/components/vf-blockquote/vf-blockquote.config.yml
@@ -8,4 +8,5 @@ context:
 variants:
   - name: default
     context:
-      text: “Look back to move forwards” is a well-known saying. Thus, I recently turned to VF’s archivist, Anne-Flore Laloë, who helped me to search VF’s amazing archive to learn how VF has depicted itself through the years. Maybe knowing more about our first visual identity could help us better.“
+      blockquote_text: '"Look back to move forwards" is a well-known saying. Thus, I recently turned to VF’s archivist, Anne-Flore Laloë, who helped me to search VF’s amazing archive to learn how VF has depicted itself through the years. Maybe knowing more about our first visual identity could help us better.'
+      blockquote_citation: 'Someone <a href="#">Really F. Amous</a> said this.'

--- a/components/vf-blockquote/vf-blockquote.njk
+++ b/components/vf-blockquote/vf-blockquote.njk
@@ -6,10 +6,8 @@
 {% endif %}
 
 <blockquote{% if id %} id="{{-id-}}"{% endif %} class="vf-blockquote{%- if override_class %} | {{override_class}}{% endif %} | vf-stack vf-stack--400">
-  {% if blockquote_text %}
-    <p class="vf-blockquote__text">{{- blockquote_text | safe -}}</p>
-  {% else %}
-    {{- html | safe if html else text -}}
+  {% if (blockquote_text) or (html) or (text) %}
+    <p class="vf-blockquote__text">{{- (html) or (blockquote_text) | safe if (html) or (blockquote_text) else text -}}</p>
   {% endif %}
 
   {% if blockquote_citation %}

--- a/components/vf-blockquote/vf-blockquote.njk
+++ b/components/vf-blockquote/vf-blockquote.njk
@@ -6,8 +6,11 @@
 {% endif %}
 
 <blockquote{% if id %} id="{{-id-}}"{% endif %} class="vf-blockquote{%- if override_class %} | {{override_class}}{% endif %} | vf-stack vf-stack--400">
-
-  <p class="vf-blockquote__text">{{- blockquote_text | safe -}}</p>
+  {% if blockquote_text %}
+    <p class="vf-blockquote__text">{{- blockquote_text | safe -}}</p>
+  {% else %}
+    {{- html | safe if html else text -}}
+  {% endif %}
 
   {% if blockquote_citation %}
   <footer class="vf-blockquote__footer">

--- a/components/vf-blockquote/vf-blockquote.njk
+++ b/components/vf-blockquote/vf-blockquote.njk
@@ -1,3 +1,20 @@
-<blockquote{% if id %} id="{{-id-}}"{% endif %} class="vf-blockquote{%- if override_class %} | {{override_class}}{% endif -%}">
-{{- html | safe if html else text -}}
+{% if context %}
+  {% set id = context.id %}
+  {% set override_class = context.override_class %}
+  {% set blockquote_text = context.blockquote_text %}
+  {% set blockquote_citation = context.blockquote_citation %}
+{% endif %}
+
+<blockquote{% if id %} id="{{-id-}}"{% endif %} class="vf-blockquote{%- if override_class %} | {{override_class}}{% endif %} | vf-stack vf-stack--400">
+
+  <p class="vf-blockquote__text">{{- blockquote_text | safe -}}</p>
+
+  {% if blockquote_citation %}
+  <footer class="vf-blockquote__footer">
+    <cite class="vf-blockquote__citation">
+      {{- blockquote_citation | safe -}}
+    </cite>
+  </footer>
+  {% endif %}
+
 </blockquote>

--- a/components/vf-blockquote/vf-blockquote.scss
+++ b/components/vf-blockquote/vf-blockquote.scss
@@ -12,3 +12,5 @@
 .vf-blockquote {
   @include blockquote;
 }
+
+


### PR DESCRIPTION
This includes:

- an update to allow for using `vf-blockquote` as an 'include' in VF Eleventy sites
- includes the option for a `cite` element to help make block quote be a little more usable. 
- makes use of `vf-stack` for vertical layout
- lets `cite` just 'do it's thing' from the browser agent and just apply `font-style: italic` to the element.