### PR TITLE
bug: vf-card arrow alignment

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -35,10 +35,10 @@ A reference guide on how to do releases of the VF [monorepo](https://www.toptal.
 ### 4. Post-release
 
 1. commit and push changes to the `develop` branch
-    - commit message in a format of: `Component release 20200330-01`
+    - commit message in a format of: `Component release 20210531-01`
 1. add a tag"
     - see last tag `git describe --abbrev=0 --tags`
-    - add a semantic versioned tag `git tag -a v2.4.10 -m 'Release of precompiled CSS, JS, assets'`
+    - add a semantic versioned tag `git tag -a v2.5.0-beta.1 -m 'Release of precompiled CSS, JS, assets'`
     - Why like this?
        - We do not add tags per individual component version, Lerna needs a named tag to see what has changed. This way we get one tag per release "bundle" avoiding tag spamming in the release history.
        - Trigger a deploy to the CDN (i.e. `v2.4.5-rc.1`) https://assets.emblstatic.net/vf/v2.4.10/css/styles.css

--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.5.7
 
 * Fixes the vertical centering of the svg arrow on vf-card titles. Also aligns better with the Figma design kit.
+  * https://github.com/visual-framework/vf-core/pull/1562
 
 ### 2.5.6
 

--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.5.7
+
+* Fixes the vertical centering of the svg arrow on vf-card titles. Also aligns better with the Figma design kit.
+
 ### 2.5.6
 
 * Fixes issue with modifiers

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -95,9 +95,6 @@
     align-items: center;
     color: color(blue);
     display: flex;
-
-    // grid-column-gap: space(100);
-    // grid-template-columns: auto 1fr;
     text-decoration: none;
 
     &::after {

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -70,7 +70,7 @@
 
 .vf-card__heading__icon {
   fill: currentColor;
-  height: 1.1em; // to ensure optical vertical centering
+  height: 1.3em; // to ensure optical vertical centering
   padding-left: map-get($vf-spacing-map, vf-spacing--100);
   transform: translateX(map-get($vf-spacing-map, vf-spacing--100));
   // @todo: some sort of centralised and reusable docs, tokens, guidance on animations

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -70,14 +70,12 @@
 
 .vf-card__heading__icon {
   fill: currentColor;
-  height: 1.3em; // to ensure optical vertical centering
-  padding-left: map-get($vf-spacing-map, vf-spacing--100);
+  padding-top: 0.1em; // to compensate for ascender, this value should be fairly consistent across most type families
   transform: translateX(map-get($vf-spacing-map, vf-spacing--100));
   // @todo: some sort of centralised and reusable docs, tokens, guidance on animations
   transition-duration: 125ms;
   transition-property: transform;
   transition-timing-function: cubic-bezier(.45, .05, .55, .95);
-  width: 1em;
 }
 
 .vf-card__title,
@@ -92,9 +90,10 @@
   word-break: break-word;
 
   .vf-card__link {
-    align-items: center;
     color: color(blue);
-    display: flex;
+    display: grid;
+    grid-column-gap: space(100);
+    grid-template-columns: auto 1fr;
     text-decoration: none;
 
     &::after {

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -70,11 +70,14 @@
 
 .vf-card__heading__icon {
   fill: currentColor;
+  height: 1.1em; // to ensure optical vertical centering
+  padding-left: map-get($vf-spacing-map, vf-spacing--100);
   transform: translateX(map-get($vf-spacing-map, vf-spacing--100));
   // @todo: some sort of centralised and reusable docs, tokens, guidance on animations
   transition-duration: 125ms;
   transition-property: transform;
   transition-timing-function: cubic-bezier(.45, .05, .55, .95);
+  width: 1em;
 }
 
 .vf-card__title,
@@ -89,10 +92,12 @@
   word-break: break-word;
 
   .vf-card__link {
+    align-items: center;
     color: color(blue);
-    display: grid;
-    grid-column-gap: space(100);
-    grid-template-columns: auto 1fr;
+    display: flex;
+
+    // grid-column-gap: space(100);
+    // grid-template-columns: auto 1fr;
     text-decoration: none;
 
     &::after {
@@ -116,7 +121,6 @@
         box-shadow: 0 0 .125rem .125rem rgba(color(grey), .75);
       }
     }
-
   }
 
   .vf-card__link:hover .vf-card__heading__icon,

--- a/components/vf-section-header/CHANGELOG.md
+++ b/components/vf-section-header/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.5.1
+
+* Fixes the vertical centering of the svg arrow on vf-section-header. Also aligns better with the Figma design kit.
+  * https://github.com/visual-framework/vf-core/pull/1562
+
 ### 1.5.0
 
 * makes if possible to use HTML in the section header text.

--- a/components/vf-section-header/vf-section-header.scss
+++ b/components/vf-section-header/vf-section-header.scss
@@ -19,19 +19,20 @@
 }
 .vf-section-header__heading--is-link {
   @include inline-link($vf-link--visited-color: map-get($vf-colors-map, vf-color--blue));
-
+  align-items: center;
   cursor: pointer;
-  display: grid;
-  grid-column-gap: space(100);
-  grid-template-columns: auto 1fr;
+  display: flex;
 
   .vf-section-header__icon {
     fill: currentColor;
+    height: 1.1em; // to ensure optical vertical centering
+    padding-left: map-get($vf-spacing-map, vf-spacing--100);
     transform: translateX(map-get($vf-spacing-map, vf-spacing--100));
     // @todo: some sort of centralised and reusable docs, tokens, guidance on animations
     transition-duration: 125ms;
     transition-property: transform;
     transition-timing-function: cubic-bezier(.45, .05, .55, .95);
+    width: 1em;
   }
 
   &:hover,

--- a/components/vf-section-header/vf-section-header.scss
+++ b/components/vf-section-header/vf-section-header.scss
@@ -21,18 +21,18 @@
   @include inline-link($vf-link--visited-color: map-get($vf-colors-map, vf-color--blue));
   align-items: center;
   cursor: pointer;
-  display: flex;
+  display: grid;
+  grid-column-gap: space(100);
+  grid-template-columns: auto 1fr;
 
   .vf-section-header__icon {
     fill: currentColor;
-    height: 1.1em; // to ensure optical vertical centering
-    padding-left: map-get($vf-spacing-map, vf-spacing--100);
+    padding-top: 0.1em; // to compensate for ascender, this value should be fairly consistent across most type families
     transform: translateX(map-get($vf-spacing-map, vf-spacing--100));
     // @todo: some sort of centralised and reusable docs, tokens, guidance on animations
     transition-duration: 125ms;
     transition-property: transform;
     transition-timing-function: cubic-bezier(.45, .05, .55, .95);
-    width: 1em;
   }
 
   &:hover,

--- a/components/vf-section-header/vf-section-header.scss
+++ b/components/vf-section-header/vf-section-header.scss
@@ -19,7 +19,6 @@
 }
 .vf-section-header__heading--is-link {
   @include inline-link($vf-link--visited-color: map-get($vf-colors-map, vf-color--blue));
-  align-items: center;
   cursor: pointer;
   display: grid;
   grid-column-gap: space(100);


### PR DESCRIPTION
This fixes the vertical centring of the svg arrow on vf-card titles. Also aligns better with the Figma design kit.

This effectively lowers the position of the SVF by ~2px

### With fix

![image](https://user-images.githubusercontent.com/928100/120289513-ab19bf00-c2c1-11eb-9786-d0f0ee2b1c33.png)

### Currently 

![image](https://user-images.githubusercontent.com/928100/120288780-df40b000-c2c0-11eb-89fa-710bf4856529.png)

### Figma

![image](https://user-images.githubusercontent.com/928100/120289282-6a21aa80-c2c1-11eb-9c43-cad3ec9532e6.png)


### Note

- there is some slight browser inconsistency here. A SVG height of 1.1em or 1.2em are treated visually different in Chrome vs FF. 1.3em is consistent.
