### PR TITLE
Enhancment: vf-details interactivity

### DIFF
--- a/components/vf-details/CHANGELOG.md
+++ b/components/vf-details/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.2.0
+
+* Fixes the missing "about" in the readme.
+* Shows "pointer" on hover.
+* uses interactive blue colour.
+* Shows summary child elements as inline.
+* https://github.com/visual-framework/vf-core/issues/1417
+
 ### 1.1.1
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-details/README.md
+++ b/components/vf-details/README.md
@@ -2,11 +2,14 @@
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Fvf-details.svg)](https://badge.fury.io/js/%40visual-framework%2Fvf-details)
 
+## About
+
+Use this interactive accordion-link component in places where information is optional.
+
 ## Usage
 
-This component makes use of the [HTML `details` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#attr-open). Use it in places where information is optional.
-
-You can add the `open` attribute to toggle the default state (`<details class="vf-details" open>`).
+- This component makes use of the [HTML `details` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#attr-open).
+- To toggle the default state, the `open` attribute: `<details class="vf-details" open>`.
 
 ## Install
 
@@ -22,7 +25,7 @@ This component does not use JS.
 
 ### Sass/CSS
 
-The style files included are written in [Sass](https://sass-lang.com/). If you're using a VF-core project, you can import it like this:
+The source files included are written in [Sass](http://sass-lang.com)(`scss`). You can point your Sass `include-path` at your `node_modules` directory and import it like this.
 
 ```
 @import "@visual-framework/vf-details/index.scss";

--- a/components/vf-details/vf-details.scss
+++ b/components/vf-details/vf-details.scss
@@ -28,6 +28,12 @@
   @include set-type(text-body--2);
   @include margin(#{'-'+map-get($vf-spacing-map, vf-spacing--200)},#{'-'+map-get($vf-spacing-map, vf-spacing--200)},0,#{'-'+map-get($vf-spacing-map, vf-spacing--200)});
   @include padding(map-get($vf-spacing-map, vf-spacing--200));
+  @include inline-link($vf-link--visited-color: map-get($vf-colors-map, vf-color--blue));
+  cursor: pointer;
+}
+
+.vf-details--summary > * {
+  display: inline; // keep any child elements on the same line
 }
 
 .vf-details[open] {


### PR DESCRIPTION
This closes #1417

- fixes the missing "about" in the readme
- shows "pointer" on hover
- uses interactive blue colour
- shows summary child elements as inline

We may have other stylistic changes in the future, but this fixes major not-quite-right things.

## Before

https://stable.visual-framework.dev/components/vf-details/

![image](https://user-images.githubusercontent.com/928100/120500271-041c4c80-c3c1-11eb-9912-e9d3012904d5.png)


## After

![image](https://user-images.githubusercontent.com/928100/120500166-ee0e8c00-c3c0-11eb-99d4-f287c57611df.png)


cc: @cindyebi @nikiforosk 