### PR TITLE
bug: vf-content images

### DIFF
--- a/components/vf-content/CHANGELOG.md
+++ b/components/vf-content/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.5.6
+
+* Adds support for responsive `img` and `figure` elements
+  * https://github.com/visual-framework/vf-core/issues/1412
+
 ### 1.5.4
 
 * dependency bump

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -132,6 +132,11 @@
     margin-bottom: map-get($vf-spacing-map, vf-spacing--400);
   }
 
+  img {
+    height: auto;
+    max-width: 100%;
+  }
+
   hr:not([class*='vf-']) {
     @include divider;
   }
@@ -203,6 +208,10 @@
   .vf-video {
     // TODO: Make a function for vf-spacing map
     margin-bottom: 32px;
+  }
+
+  figure {
+    @include figure;
   }
 
   .vf-figure--align-inline-start {


### PR DESCRIPTION
Adds support for responsive `img` and `figure` elements.

closes #1412