### PR TITLE
bug: notifcations and banner data handling

### DIFF
--- a/components/embl-notifications/CHANGELOG.md
+++ b/components/embl-notifications/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0
+
+* Capture all links without `vf-banner__link` class.
+
 ### 1.0.2
 
 * Improve JS module import support.

--- a/components/embl-notifications/embl-notifications.js
+++ b/components/embl-notifications/embl-notifications.js
@@ -17,7 +17,7 @@ function emblNotificationsInject(message) {
   // preparation
   message.body = message.body.replace(/<[/]?[p>]+>/g, " "); // no <p> tags allowed in inline messages, preserve a space to not collide words
   // add vf-link to link
-  message.body = message.body.replace("<a href=", "<a class=\"vf-banner__link\" href="); // we might need a more clever regex, but this should also avoid links that already have a class
+  message.body = message.body.replaceAll("<a href=", "<a class=\"vf-banner__link\" href="); // we might need a more clever regex, but this should also avoid links that already have a class
   // Learn more link is conditionally shown
   if (message.field_notification_link) {
     message.body = `${message.body} <a class="vf-banner__link" href="${message.field_notification_link}">Learn more</a>`;
@@ -106,7 +106,7 @@ function emblNotifications(currentHost, currentPath) {
   // don't treat `wwwdev` as distinct from `www`
   currentHost = currentHost.replace(/wwwdev/g, "www");
 
-  // console.log('emblNotifications','Checking for notifcaitons.');
+  // console.log('emblNotifications','Checking for notifications.');
   // console.log('emblNotifications, Current url info:', currentHost + "," + currentPath);
 
   // Process each message against a URLs
@@ -170,7 +170,7 @@ function emblNotifications(currentHost, currentPath) {
     return false;
   }
 
-  // Process each message, and its URL fragmenets
+  // Process each message, and its URL fragments
   function processNotifications(messages) {
     // console.log('emblNotifications', messages);
 

--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.9.0
+
+* Correct an issue in naming of Yaml keys that resulted in null values.
+  * `vf-data-protection-banner__text` -> `banner__text`
+  * `vf-data-protection-banner__link` -> `banner__link`
+  * `vf-banner--inline_href` -> `banner__inline_href`
+
 ### 1.8.0
 
 * adds overrides for more permutations of where the vf-global header lives

--- a/components/vf-banner/CHANGELOG.md
+++ b/components/vf-banner/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.9.0
 
+* Correct "tertary" typo in "vf-button--tertiary".
 * Correct an issue in naming of Yaml keys that resulted in null values.
   * `vf-data-protection-banner__text` -> `banner__text`
   * `vf-data-protection-banner__link` -> `banner__link`

--- a/components/vf-banner/vf-banner--fixed.njk
+++ b/components/vf-banner/vf-banner--fixed.njk
@@ -2,7 +2,7 @@
 <div class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--notice"
 data-vf-js-banner
 data-vf-js-banner-state="dismissible"
-data-vf-js-banner-button-text="{{vf-data-protection-banner__text}}"
+data-vf-js-banner-button-text="{{banner__text}}"
 data-vf-js-banner-cookie-name="{{data-service-id}}"
 data-vf-js-banner-cookie-version="{{data-protection-version}}"
 data-vf-js-banner-extra-button="<a href='#'>Optional button</a><a target='_blank' href='#'>New tab button</a>"
@@ -42,7 +42,7 @@ data-vf-js-banner-cookie-version="{{data-protection-version}}">
   </div>
 </div> -->
 
-<!-- programatic banner -->
+<!-- programmatic banner -->
 <!-- <div class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--notice"
       data-vf-js-banner-id="32423"
 ></div> -->

--- a/components/vf-banner/vf-banner--inline.njk
+++ b/components/vf-banner/vf-banner--inline.njk
@@ -2,6 +2,6 @@
 
 <div class="vf-banner vf-banner--phase">
   <div class="vf-banner__content">
-    <p class="vf-banner__text">This is a new web page. <a href="{{ vf-banner--inline_href }}" class="vf-link">Complete our quick survey</a> to help us make it better.</p>
+    <p class="vf-banner__text">This is a new web page. <a href="{{ banner__inline_href }}" class="vf-link">Complete our quick survey</a> to help us make it better.</p>
   </div>
 </div>

--- a/components/vf-banner/vf-banner--top.njk
+++ b/components/vf-banner/vf-banner--top.njk
@@ -5,6 +5,6 @@ data-vf-js-banner-button-text="Close notice"
 data-vf-js-banner-button-theme="primary">
   <div class="vf-banner__content" data-vf-js-banner-text>
     <span class="vf-badge vf-badge--primary">BETA</span>
-    <p class="vf-banner__text">This is the new EMBL.org <a href="{{ vf-banner--inline__url }}" class="vf-banner__link">Complete our quick survey</a> to help us make it better.</p>
+    <p class="vf-banner__text">This is the new EMBL.org <a href="{{ banner__inline_href }}" class="vf-banner__link">Complete our quick survey</a> to help us make it better.</p>
   </div>
 </div>

--- a/components/vf-banner/vf-banner.config.yml
+++ b/components/vf-banner/vf-banner.config.yml
@@ -6,9 +6,9 @@ context:
   component-type: container
   data-service-id: MyService
   data-protection-version: 0.1
-  vf-data-protection-banner__text: I agree, dismiss this banner
-  vf-data-protection-banner__link:
-  vf-banner--inline_href: 'JavaScript:Void(0);'
+  banner__text: I agree, dismiss this banner
+  banner__link:
+  banner__inline_href: 'JavaScript:Void(0);'
   alert_icon_text: dismiss
 variants:
 

--- a/components/vf-banner/vf-banner.js
+++ b/components/vf-banner/vf-banner.js
@@ -207,7 +207,7 @@ function vfBannerInsert(banner,bannerId,scope) {
       generatedBannerHtml += "<button class=\"vf-button vf-button--secondary\" data-vf-js-banner-close>"+banner.vfJsBannerButtonText+"</button>";
     }
     else if (banner.vfJsBannerButtonTheme == "tertiary") {
-      generatedBannerHtml += "<button class=\"vf-button vf-button--tertary\" data-vf-js-banner-close>"+banner.vfJsBannerButtonText+"</button>";
+      generatedBannerHtml += "<button class=\"vf-button vf-button--tertiary\" data-vf-js-banner-close>"+banner.vfJsBannerButtonText+"</button>";
     }
     else {
       // default


### PR DESCRIPTION
This corrects a pair of slightly connected issues.

`embl-notifications`:

* Capture all links without `vf-banner__link` class.

`vf-banner`:

* Correct an issue in naming of Yaml keys that resulted in null values.
  * `vf-data-protection-banner__text` -> `banner__text`
  * `vf-data-protection-banner__link` -> `banner__link`