### PR TITLE
enhancement: hide-ebi-1-cookie-banner

### DIFF
--- a/components/ebi-header-footer/CHANGELOG.md
+++ b/components/ebi-header-footer/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.1.0
+
+* Fix readme for proper display in component library docs.
+* For ebi-header-footer--footer.njk add context `disable_ebi_1x_cookie_banner` to disable EBI 1.x cookie banner (defaults to true).
+
 ### 2.0.3
 
 * Directly load CSS for global header to prevent flashes of non-styled elements.

--- a/components/ebi-header-footer/README.md
+++ b/components/ebi-header-footer/README.md
@@ -4,15 +4,18 @@
 
 ## About
 
-This provides support for using the EMBL-EBI header and footer from the EMBL-EBI VF 1.3. It provides the minimum amount of legacy CSS to make the header and footer work while avoiding conflicts with other 2.0 styles.
+Support for using the EMBL-EBI header and footer from the EMBL-EBI VF 1.3.
 
-### Note
+## Usage
+
+This component provides the minimum amount of legacy CSS to make the header and footer work while avoiding conflicts with other 2.0 styles.
 
 - This component requires the EMBL contentHub loader, which is included in most EMBL VF builds.
 - This requires VF 2.0 footer CSS and other styles.
 - If you do not currently have VF 2.0 CSS and JS as part of your project, [you can use the CDN JS](https://stable.visual-framework.dev/#cdn).
 - This uses the existing `//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/script.js` to load the HTML for the header.
 - The EBI VF 1.x will also included a data protection banner, to disable this with 1.4 you can an included an element with `data-protection-message-disable="true"`
+  - This will be inserted by default when using the `ebi-header-footer--footer` template.
 
 ## Install
 

--- a/components/ebi-header-footer/ebi-header-footer--embl-selector.scss
+++ b/components/ebi-header-footer/ebi-header-footer--embl-selector.scss
@@ -1,7 +1,7 @@
 // ebi-header-footer--footer
 // Custom tag class for Foundation-based EBI framework
 
-/// Classses to theme the embl dropdown selector for the .masthead-black-bar
+/// Classes to theme the embl dropdown selector for the .masthead-black-bar
 
 &.masthead-black-bar {
   li.embl-selector {

--- a/components/ebi-header-footer/ebi-header-footer--footer.njk
+++ b/components/ebi-header-footer/ebi-header-footer--footer.njk
@@ -1,2 +1,14 @@
+{%- if context %}
+  {% set disable_ebi_1x_cookie_banner = context.disable_ebi_1x_cookie_banner %}
+{% endif -%}
+
 <!-- embl-ebi global footer -->
 <link rel="import" href="https://www.embl.org/api/v1/pattern.html?filter-content-type=article&filter-id=106902&pattern=node-body&source=contenthub" data-target="self" data-embl-js-content-hub-loader>
+
+{% if disable_ebi_1x_cookie_banner == true %}
+<!--
+  When using legacy EBI 1.x JS, we disable the old cookie banner.
+  https://stable.visual-framework.dev/components/ebi-header-footer/
+  -->
+<div class="vf-u-display-none" data-protection-message-disable="true"></div>
+{% endif %}

--- a/components/ebi-header-footer/ebi-header-footer.config.yml
+++ b/components/ebi-header-footer/ebi-header-footer.config.yml
@@ -12,6 +12,7 @@ status: live
 # preview: '@preview--nogrid'
 context:
   component-type: utility
+  disable_ebi_1x_cookie_banner: true
   # custom-values: passed as {{custom-values}}
   # title: Title text
   # text: String of text

--- a/components/ebi-vf1-integration/CHANGELOG.md
+++ b/components/ebi-vf1-integration/CHANGELOG.md
@@ -1,6 +1,11 @@
+### 1.0.7
+
+* Minor tweaks to docs.
+
 ### 1.0.6
 
 * changes any `set-` style functions to cleaner version
+
 ### 1.0.5
 
 * Handle text color on vf-button--outline.

--- a/components/ebi-vf1-integration/README.md
+++ b/components/ebi-vf1-integration/README.md
@@ -1,10 +1,10 @@
-# Compatibility with EBI-VF 1.x component
+# Compatibility with EBI-VF 1.x components
 
 [![npm version](https://badge.fury.io/js/%40visual-framework%2Febi-vf1-integration.svg)](https://badge.fury.io/js/%40visual-framework%2Febi-vf1-integration)
 
 ## About
 
-This adds fixes, compatibility and workarounds for sites that use the EBI VF versions 1.1, 1.2 or 1.3.
+Fixes, compatibility and workarounds for sites that use the EBI VF versions 1.1, 1.2, 1.3 or 1.4.
 
 ## Usage
 
@@ -17,14 +17,14 @@ Enable its use by:
 
 ### Option 1
 
-Use the global VF 2.0 CSS along side your existing VF 1.x CSS; see: https://www.embl.org/guidelines/design/patterns/
+Use the global VF 2.0 CSS along side your existing VF 1.x CSS; see: https://stable.visual-framework.dev/
 
 ### Option 2
 
 If you don't want to include all the VF 2.0 CSS, add only the compatibility CSS:
 
 ```
-https://dev.assets.emblstatic.net/embl-design-system/develop/assets/ebi-vf1-integration/ebi-vf1-integration.css
+https://assets.emblstatic.net/vf/v2.4.15/assets/ebi-vf1-integration/ebi-vf1-integration.css
 ```
 
 ### Option 3

--- a/components/ebi-vf1-integration/ebi-vf1-integration.config.yml
+++ b/components/ebi-vf1-integration/ebi-vf1-integration.config.yml
@@ -1,5 +1,5 @@
 # The title shown on the component page
-title: Compatibility with EBI-VF 1.x Component
+title: Compatibility with EBI-VF 1.x Components
 # Label shown on index pages
 label: EBI-VF 1.x Compatibility Component
 status: live

--- a/tools/vf-component-library/src/site/patterns/boilerplate-generic-embl-ebi.njk
+++ b/tools/vf-component-library/src/site/patterns/boilerplate-generic-embl-ebi.njk
@@ -190,7 +190,7 @@ layout: layouts/boilerplate.njk
 
   {% render "@ebi-header-footer--footer" %}
 
-  {# {% include "./templates/notice-boilerplate.njk" %} #}
+  {#- {% include "./templates/notice-boilerplate.njk" %} -#}
   {% include "scripts.njk" %}
 </body>
 </html>


### PR DESCRIPTION
Imrpoves clarity on how to hide old 1.x cookie banner when using the 2.0 JS (to avoild a double cookie banner from 1.x and 2.0).

* Fix readme for proper display in component library docs.
* For ebi-header-footer--footer.njk add context `disable_ebi_1x_cookie_banner` to disable EBI 1.x cookie banner (defaults to true).