### PR TITLE
bug: vf-component-generator-fixes

### DIFF
--- a/tools/vf-component-generator/CHANGELOG.md
+++ b/tools/vf-component-generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.1.5
+
+* Fix a bug in `camelize` function that only replaced first `-`.
+* In `README.md` template, reference the component `vfName.scss` file and not `index.scss`
+
 ### 1.1.4
 
 * Add accessibility section to README.md template.

--- a/tools/vf-component-generator/index.js
+++ b/tools/vf-component-generator/index.js
@@ -12,12 +12,12 @@ vfComponentPath = config.vfConfig.vfComponentPath || path.resolve(__dirname, '..
 function camelize(str,upperCaseFirst) {
   var upperCaseFirst = upperCaseFirst || false;
   return str.replace(/(?:^\w|[A-Z]|\b\w)/g, function(word, index) {
-    if (upperCaseFirst) { 
+    if (upperCaseFirst) {
       return word.toUpperCase();
     } else {
       return index === 0 ? word.toLowerCase() : word.toUpperCase();
     }
-  }).replace(/\s+/g, '').replace('-', '');
+  }).replace(/\s+/g, '').replace(/-/g, '');
 }
 
 module.exports = class extends Generator {

--- a/tools/vf-component-generator/templates/_README.md
+++ b/tools/vf-component-generator/templates/_README.md
@@ -31,7 +31,7 @@ This component targets WCAG 2.1 AA accessibility. Below you can find additional 
 
 - Add any do's and do nots
 
-You can also read about [the Visual Framework's approach to accessibility](stable.visual-framework.dev/guidance/accessibility/).
+You can also read about [the Visual Framework's approach to accessibility](https://stable.visual-framework.dev/guidance/accessibility/).
 
 ## Install
 

--- a/tools/vf-component-generator/templates/_README.md
+++ b/tools/vf-component-generator/templates/_README.md
@@ -61,7 +61,7 @@ vfComponentName(); // if needed, invoke it
 The style files included are written in [Sass](https://sass-lang.com/). If you're using a VF-core project, you can import it like this:
 
 ```
-@import "@visual-framework/<%= componentName %>/index.scss";
+@import "@visual-framework/<%= componentName %>/<%= componentName %>.scss";
 ```
 
 Make sure you import Sass requirements along with the modules. You can use a [project boilerplate](https://stable.visual-framework.dev/building/) or the [`vf-sass-starter`](https://stable.visual-framework.dev/components/vf-sass-starter/)


### PR DESCRIPTION
* Fix a bug in `camelize` function that only replaced first `-`.
* In `README.md` template, reference the component `vfName.scss` file and not `index.scss`