### PR TITLE
Fixed null error

### DIFF
--- a/components/vf-back-to-top/CHANGELOG.md
+++ b/components/vf-back-to-top/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.0.0-alpha.2
-* fixed a null reference error
+
+* Fixed a null reference error.
   * [Tracking issue](https://github.com/visual-framework/vf-core/issues/1567)
 
 ### 1.0.0-alpha.1

--- a/components/vf-back-to-top/CHANGELOG.md
+++ b/components/vf-back-to-top/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.0-alpha.2
+* fixed a null reference error
+  * [Tracking issue](https://github.com/visual-framework/vf-core/issues/1567)
+
 ### 1.0.0-alpha.1
 
 * Basic implementation of vf-back-to-top component

--- a/components/vf-back-to-top/vf-back-to-top.js
+++ b/components/vf-back-to-top/vf-back-to-top.js
@@ -32,6 +32,11 @@ export function vfBackToTop() {
     //only handle first floating element, ignore additional elements
     const floatingElement = document.querySelector("[data-vf-js-back-to-top-floating]");
 
+    if (!floatingElement) {
+      //exit, no floating button element found
+      return;
+    }
+
     //hide initially
     setVisible(floatingElement, false);
 


### PR DESCRIPTION
Fixes #1567 

Note that in case of 
```
const links = document.querySelectorAll("[data-vf-js-back-to-top]"); 
```
`querySelectorAll` call returns empty list if no element found, and we are iterating on that list, so no null check necessary.