### PR TITLE
bug: vf-flag image widths

### DIFF
--- a/components/vf-flag/CHANGELOG.md
+++ b/components/vf-flag/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.0-alpha.2
+
+* Handle image widths: as vf-flag uses a table layout, this does not mix well with `vf-content img` and max-width 100%.
+
 ### 1.0.0-alpha.1
 
 * introduces the flag layout component.

--- a/components/vf-flag/vf-flag.scss
+++ b/components/vf-flag/vf-flag.scss
@@ -22,6 +22,11 @@
   padding-right: space(400);
   padding-right: var(--vf-flag--spacing, #{space(400)});
 
+  img:not([class*='vf-']) {
+    // as vf-flag uses a table layout, this does not mix well with `vf-content img` and max-width 100%
+    max-width: max-content;
+  }
+
   > * {
     display: block;
   }


### PR DESCRIPTION
After the improvement for `.vf-content img` in #1566, it exposed an issue in vf-flag images.

* Handle image widths: as vf-flag uses a table layout, this does not mix well with `vf-content img` and max-width 100%.