### PR TITLE
bug: vf-tabs missing import

### DIFF
--- a/components/vf-tabs/CHANGELOG.md
+++ b/components/vf-tabs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.0.1
 
 * Bug: Add missing `@import 'vf-global-variables';` to generate standalone `vf-tabs.css`.
+  * https://github.com/visual-framework/vf-core/pull/1581
 
 ### 2.0.0
 

--- a/components/vf-tabs/CHANGELOG.md
+++ b/components/vf-tabs/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.1
+
+* Bug: Add missing `@import 'vf-global-variables';` to generate standalone `vf-tabs.css`.
+
 ### 2.0.0
 
 * Updates the styling to match the design direction.

--- a/components/vf-tabs/index.scss
+++ b/components/vf-tabs/index.scss
@@ -1,6 +1,7 @@
 // setup files required
 
 // sass-lint:disable clean-import-paths
+@import 'vf-global-variables';
 @import 'vf-variables';
 @import 'vf-functions';
 @import 'vf-mixins';


### PR DESCRIPTION
Bug: Add missing `@import 'vf-global-variables';` to generate standalone `vf-tabs.css`.

```
Error: Undefined variable.
  ╷
6 │ @mixin set-type($font-size, $font-family: $global-font-family, $custom-margin-bottom: auto) {
  │                                           ^^^^^^^^^^^^^^^^^^^
  ╵
  ../../components/vf-sass-config/mixins/_typography.scss 6:43  set-type()
  ../../components/vf-tabs/vf-tabs.scss 37:3                    @import
  ../../components/vf-tabs/index.scss 10:9                      root stylesheet
```