### PR TITLE
enhancement: vf-content heading spacing

### DIFF
--- a/components/vf-code-example/CHANGELOG.md
+++ b/components/vf-code-example/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.2.2
 
 * Add a bottom margin to `.vf-code-example__pre`
+* https://github.com/visual-framework/vf-core/pull/1589
 
 ### 1.2.1
 

--- a/components/vf-code-example/CHANGELOG.md
+++ b/components/vf-code-example/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.2.2
+
+* Add a bottom margin to `.vf-code-example__pre`
+
 ### 1.2.1
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-code-example/CHANGELOG.md
+++ b/components/vf-code-example/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 1.2.2
 
-* Add a bottom margin to `.vf-code-example__pre`
+* Add a bottom margin to `vf-code-example__pre`
 * https://github.com/visual-framework/vf-core/pull/1589
 
 ### 1.2.1

--- a/components/vf-code-example/vf-code-example.scss
+++ b/components/vf-code-example/vf-code-example.scss
@@ -34,6 +34,7 @@ $vf-code-example-enable-hljs: true !default;
 .vf-code-example__pre {
   border: 1px;
   display: block;
+  margin-bottom: map-get($vf-spacing-map, vf-spacing--400);
   min-width: 0;
   overflow: auto;
   white-space: pre-wrap;

--- a/components/vf-content/CHANGELOG.md
+++ b/components/vf-content/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.6.0
+
+* Use vf-spacing tokens for heading margins.
+* Reduce bottom margin on headings to be more consistent with overall typography, design kit.
+
 ### 1.5.6
 
 * Adds support for responsive `img` and `figure` elements

--- a/components/vf-content/CHANGELOG.md
+++ b/components/vf-content/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Use vf-spacing tokens for heading margins.
 * Reduce bottom margin on headings to be more consistent with overall typography, design kit.
+* https://github.com/visual-framework/vf-core/pull/1589
 
 ### 1.5.6
 

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -29,9 +29,8 @@
   }
 
   h2:not([class*='vf-']) {
-    @include set-type(text-heading--2, $custom-margin-bottom: 39px);
-
-    margin-top: 13px;
+    // @include set-type(text-heading--2, $custom-margin-bottom: map-get($vf-spacing-map, vf-spacing--400));
+    @include set-type(text-heading--2);
 
     b,
     strong {
@@ -40,9 +39,7 @@
   }
 
   h3:not([class*='vf-']) {
-    @include set-type(text-heading--3, $custom-margin-bottom: 13px);
-
-    margin-top: 24px;
+    @include set-type(text-heading--3);
 
     b,
     strong {
@@ -51,9 +48,7 @@
   }
 
   h4:not([class*='vf-']) {
-    @include set-type(text-heading--4, $custom-margin-bottom: 13px);
-
-    margin-top: 24px;
+    @include set-type(text-heading--4);
 
     b,
     strong {
@@ -62,9 +57,7 @@
   }
 
   h5:not([class*='vf-']) {
-    @include set-type(text-heading--5, $custom-margin-bottom: 13px);
-
-    margin-top: 24px;
+    @include set-type(text-heading--5);
 
     b,
     strong {
@@ -73,9 +66,7 @@
   }
 
   h6:not([class*='vf-']) {
-    @include set-type(text-heading--5, $custom-margin-bottom: 13px);
-
-    margin-top: 24px;
+    @include set-type(text-heading--5);
 
     b,
     strong {
@@ -83,7 +74,7 @@
     }
   }
 
-  // remove the top margin from first items becasue some times the first item is an h3
+  // remove the top margin from first items because some times the first item is an h3
   & > :first-child {
     margin-top: 0 !important;
   }
@@ -231,7 +222,7 @@
   margin-top: 0;
 
   + .vf-content__standfirst {
-    margin-bottom: 24px;
+    margin-bottom: map-get($vf-spacing-map, vf-spacing--400);
   }
 
   + small {

--- a/components/vf-content/vf-content.scss
+++ b/components/vf-content/vf-content.scss
@@ -29,7 +29,6 @@
   }
 
   h2:not([class*='vf-']) {
-    // @include set-type(text-heading--2, $custom-margin-bottom: map-get($vf-spacing-map, vf-spacing--400));
     @include set-type(text-heading--2);
 
     b,


### PR DESCRIPTION
A bit of a "reset" that uses the central `set-type` mixin. It makes things more consistent with fewer exceptions and less technical complications.

Also adopts the vf-stack style mantra of "pushing down" and removes top margins.

* Use vf-spacing tokens for heading margins.
* Reduce bottom margin on headings to be more consistent with overall typography, design kit.