### PR TITLE
Featuer: pin marked

### DIFF
--- a/tools/vf-core/CHANGELOG.md
+++ b/tools/vf-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.2.28
 
 * Pin `marked` dependency to 2.0.7, as 2.1.0 breaks support in node 12.
+  * https://github.com/visual-framework/vf-core/pull/1590
 
 ### 2.2.27
 

--- a/tools/vf-core/CHANGELOG.md
+++ b/tools/vf-core/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.28
+
+* Pin `marked` dependency to 2.0.7, as 2.1.0 breaks support in node 12.
+
 ### 2.2.27
 
 * Require node 12 or greater. Node 10 is now out of support and many dependencies no longer work.

--- a/tools/vf-core/package.json
+++ b/tools/vf-core/package.json
@@ -39,7 +39,7 @@
     "gulp": "^4.0.2",
     "gulp-watch": "^5.0.1",
     "highlight.js": "^11.0.0",
-    "marked": "^2.0.0"
+    "marked": "2.0.7"
   },
   "devDependencies": {
     "@percy/script": "1.1.0",


### PR DESCRIPTION
* Pin `marked` dependency to 2.0.7, as 2.1.0 breaks support in node 12.
* Background: https://github.com/markedjs/marked/issues/2106