### PR TITLE
bug: string type for striptags

### DIFF
--- a/tools/vf-extensions/CHANGELOG.md
+++ b/tools/vf-extensions/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.0
 
 * Bug: in `gulp-build-search-index` ensure `body` is a string for `striptags`.
+  * https://github.com/visual-framework/vf-core/pull/1601
 
 ### 1.0.0-rc.1
 

--- a/tools/vf-extensions/CHANGELOG.md
+++ b/tools/vf-extensions/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.0
+
+* Bug: in `gulp-build-search-index` ensure `body` is a string for `striptags`.
+
 ### 1.0.0-rc.1
 
 * Updates highlightjs syntax of render and codeblock tags

--- a/tools/vf-extensions/gulp-tasks/gulp-build-search-index.js
+++ b/tools/vf-extensions/gulp-tasks/gulp-build-search-index.js
@@ -47,20 +47,15 @@ module.exports = function(gulp, path, buildDestionation) {
             a.set_content('');
           })
           body = new String(bodyHtml);
-
-
-
-          body = stripJs(striptags(body));
+          body = stripJs(striptags(body.toString()));
           body = body.replace(/&quot;/g, ' '); // remove white space
           body = body.replace(/class\=/g, ' '); // remove white space
-
           body = body.replace(/<body.[\s\S]*?>(.[\s\S]*?)<\/body>/gi, '$1');
           body = body.replace(/\r?\n|\r/g, ' '); // remove white space
           body = body.replace(/    /g, ' '); // remove white space
           body = body.replace(/   /g, ' '); // remove white space
           body = body.replace(/  /g, ' '); // remove white space
           body = body.replace(/"/g, '\''); // remove double quotes
-
 
       output += endOfLine + '{"id":"'+counter+'", "title": "'+title+'", "text": "'+body+'", "tags": "", ';
       counter = counter + 1;


### PR DESCRIPTION
* Bug: in `gulp-build-search-index` ensure `body` is a string for `striptags`.

striptags will error if an array is sent.