### PR TITLE
Enhancement: vf-profile colour and spacing

### DIFF
--- a/components/vf-profile/CHANGELOG.md
+++ b/components/vf-profile/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Links of `.vf-profile__link` use `inline-link` mixin.
 * Remove need for `.vf-u-last-item` on last phone number.
+* https://github.com/visual-framework/vf-core/pull/1612
 
 ### 1.3.0
 

--- a/components/vf-profile/CHANGELOG.md
+++ b/components/vf-profile/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.4.0
+
+* Links of `.vf-profile__link` use `inline-link` mixin.
+* Remove need for `.vf-u-last-item` on last phone number.
+
 ### 1.3.0
 
 * deprecates the Mortal Kombat variants.

--- a/components/vf-profile/vf-profile.njk
+++ b/components/vf-profile/vf-profile.njk
@@ -70,7 +70,7 @@
   {% if profile__emails %}
     {% if hide_profile__emails == true %}{% else %}
       {% for item in profile__emails %}
-        <p class="vf-profile__email {% if loop.last %}| vf-u-last-item {% endif %}">
+        <p class="vf-profile__email">
           <a href="mailto:{{- item.profile__email_address -}}" class="vf-profile__link vf-profile__link--secondary">
             {{- item.profile__email_address -}}
           </a>

--- a/components/vf-profile/vf-profile.scss
+++ b/components/vf-profile/vf-profile.scss
@@ -31,27 +31,14 @@
 
 .vf-profile__title {
   @include set-type(text-heading--3, $custom-margin-bottom: 0);
-
-  color: color(blue);
 }
 
 .vf-profile__job-title {
   @include set-type(text-heading--4, $custom-margin-bottom: .25rem);
 }
 
-.vf-profile__link {
-  color: inherit;
-  text-decoration: none;
-
-  &:hover,
-  &:focus {
-    text-decoration: underline;
-  }
-}
-
 .vf-profile__text {
   @include set-type(text-body--2, $custom-margin-bottom: 0);
-
   line-height: 1.2;
 
   .vf-profile__job-title + & {
@@ -63,11 +50,8 @@
   @include set-type(text-body--3, $custom-margin-bottom: 0);
 
   line-height: 1.2;
+  margin-bottom: space(200);
   word-break: break-all;
-
-  &.vf-u-last-item {
-    margin-bottom: .75rem;
-  }
 }
 
 .vf-profile__phone {
@@ -75,21 +59,21 @@
 
   line-height: 1.2;
   word-break: break-all;
-
-  &.vf-u-last-item {
-    margin-bottom: .5rem;
-  }
 }
 
 .vf-profile__uuid {
   @include set-type(text-body--4, $custom-margin-bottom: 0);
 
   line-height: 1;
+  margin-top: space(200);
   word-break: break-all;
 }
 
-// Layout
+.vf-profile__link {
+  @include inline-link();
+}
 
+// Layout
 .vf-profile--inline {
   @media (min-width: $vf-breakpoint--xs) {
     display: grid;
@@ -109,7 +93,6 @@
 }
 
 // Sizes
-
 .vf-profile--small {
   --vf-profile-avatar--size: 64px;
 
@@ -147,10 +130,8 @@
   --vf-profile-avatar--size: 160px;
 }
 
-
 html:not(.vf-disable-deprecated) {
   // variants
-
   .vf-profile--easy {
     @warn 'This variant has been deprecated';
     border-bottom: 8px solid var(--vf-profile__border--color);
@@ -159,7 +140,6 @@ html:not(.vf-disable-deprecated) {
 
 
   // themes
-
   .vf-profile-theme--primary {
     @warn 'This variant has been deprecated';
     --vf-profile__border--color: #{color(blue)};


### PR DESCRIPTION
This removes the need for complicated for loop logic, and removes an issue where links were showing as black. 

* Links of `.vf-profile__link` use `inline-link` mixin.
* Remove need for `.vf-u-last-item` on last phone number.
* https://gitlab.ebi.ac.uk/emblorg/backlog/-/issues/524#note_126059