### PR TITLE
Chore: rever grey for headers in #1606

### DIFF
--- a/components/vf-design-tokens/dist/json/vf-color__text.ios.json
+++ b/components/vf-design-tokens/dist/json/vf-color__text.ios.json
@@ -4,11 +4,11 @@
       "type": "color",
       "category": "color",
       "name": "vfColorTextPrimary",
-      "value": "#373a36",
+      "value": "#1a1c1a",
       "meta": {
         "friendlyName": "Primary Text Colour",
         "sassFunction": "text-color",
-        "sassMap": "secondary",
+        "sassMap": "primary",
         "sassVariable": "vf-color__text--primary",
         "CSSCustomProperty": "-vf-color__text--primary",
         "comment": null
@@ -18,7 +18,7 @@
       "type": "color",
       "category": "color",
       "name": "vfColorTextSecondary",
-      "value": "#1a1c1a",
+      "value": "#373a36",
       "meta": {
         "friendlyName": "Secondary Text Colour",
         "sassFunction": "text-color",

--- a/components/vf-design-tokens/dist/sass/custom-properties/vf-color__text.custom-properties.scss
+++ b/components/vf-design-tokens/dist/sass/custom-properties/vf-color__text.custom-properties.scss
@@ -4,8 +4,8 @@
 // Source: maps/vf-color__text.yml
 
 :root {
-  --vf-color__text--primary: #373a36;
-  --vf-color__text--secondary: #1a1c1a;
+  --vf-color__text--primary: #1a1c1a;
+  --vf-color__text--secondary: #373a36;
   --vf-color__link: #3b6fb6;
   --vf-color__link--hover: #193f90;
   --vf-color__link--focus: #193f90;

--- a/components/vf-design-tokens/dist/sass/maps/vf-color__text.map.scss
+++ b/components/vf-design-tokens/dist/sass/maps/vf-color__text.map.scss
@@ -4,8 +4,8 @@
 // Source: maps/vf-color__text.yml
 
 $vf-color__text-map: (
-  'vf-color__text--primary': (#373a36),
-  'vf-color__text--secondary': (#1a1c1a),
+  'vf-color__text--primary': (#1a1c1a),
+  'vf-color__text--secondary': (#373a36),
   'vf-color__link': (#3b6fb6),
   'vf-color__link--hover': (#193f90),
   'vf-color__link--focus': (#193f90),

--- a/components/vf-design-tokens/src/maps/vf-color__text.yml
+++ b/components/vf-design-tokens/src/maps/vf-color__text.yml
@@ -14,7 +14,7 @@ props:
     meta:
       friendlyName: Primary Text Colour
       sassFunction: text-color
-      sassMap: secondary
+      sassMap: primary
       sassVariable: vf-color__text--primary
       CSSCustomProperty: -vf-color__text--primary
       comment:

--- a/components/vf-design-tokens/src/theme.palette.alias.yml
+++ b/components/vf-design-tokens/src/theme.palette.alias.yml
@@ -9,8 +9,8 @@ aliases:
   # Text Colours
   # ------------
 
-  vf-color__text--primary: '#373a36'
-  vf-color__text--secondary: '#1a1c1a'
+  vf-color__text--primary: '#1a1c1a'
+  vf-color__text--secondary: '#373a36'
 
   # Interactive Text Colours
 

--- a/components/vf-sass-config/mixins/_typography.scss
+++ b/components/vf-sass-config/mixins/_typography.scss
@@ -31,19 +31,19 @@
     color: text-color(primary);
   }
   @else if $font-size == text-heading--3 {
-    color: text-color(secondary);
+    color: text-color(primary);
   }
   @else if $font-size == text-heading--4 {
-    color: text-color(secondary);
+    color: text-color(primary);
   }
   @else if $font-size == text-heading--5 {
-    color: text-color(secondary);
+    color: text-color(primary);
   }
   @else if $font-size == text-body--1 {
     color: text-color(primary);
   }
   @else if $font-size == text-body--2 {
-    color: text-color(secondary);
+    color: text-color(primary);
   }
   @else if $font-size == text-body--3 {
     color: text-color(secondary);


### PR DESCRIPTION
Feedback has been unclear on using `#373a36` for the main text.

This keeps the clearly more accesibile (and less perceptable change of using `#1a1c1a` for main text) and unblocks the release of 2.5.0-beta.4.

![image](https://user-images.githubusercontent.com/928100/124229101-62963100-db0d-11eb-9840-c84a95a517f8.png)
