### PR TITLE
bug: box component typography

### DIFF
--- a/components/vf-box/CHANGELOG.md
+++ b/components/vf-box/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.3.2
+
+* Don't set vf-box typography colours via revised set-type function.
+  * https://github.com/visual-framework/vf-core/issues/1619
+
 ### 2.3.1
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-box/vf-box.scss
+++ b/components/vf-box/vf-box.scss
@@ -49,7 +49,7 @@
 
 .vf-box__heading {
   // @include set-type(text-heading--4); // replaced for 2020 homepage updates
-  @include set-type(text-heading--3);
+  @include set-type(text-heading--3, $color: ignore);
 }
 
 .vf-box__link {
@@ -71,7 +71,7 @@
 }
 
 .vf-box__text {
-  @include set-type(text-body--3);
+  @include set-type(text-body--3, $color: ignore);
 
   // some times there's a link inside the text in old WP posts.
   // the vf-box might also be inside of `vf-content`


### PR DESCRIPTION
When updating the design tokens and sass utilities in #1606`, the change wasn't carried through for vf-box. This fixes it.

Closes #1619