### PR TITLE
enhancement: favicon urls

### DIFF
--- a/components/embl-favicon/CHANGELOG.md
+++ b/components/embl-favicon/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.3
+
+* Point favicon urls to 2.5.0 stable release.
+
 ### 1.0.2
 
 * missing a link to favicon.ico

--- a/components/embl-favicon/embl-favicon.njk
+++ b/components/embl-favicon/embl-favicon.njk
@@ -1,8 +1,8 @@
-<link rel="shortcut icon" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/favicon.ico">
-<link rel="apple-touch-icon" sizes="180x180" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/favicon-16x16.png">
-<link rel="manifest" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/site.webmanifest">
-<link rel="mask-icon" href="https://www.embl.org/guidelines/design/assets/embl-favicon/assets/safari-pinned-tab.svg" color="#ffffff">
+<link rel="shortcut icon" href="https://assets.emblstatic.net/vf/v2.5.0/assets/embl-favicon/assets/favicon.ico">
+<link rel="apple-touch-icon" sizes="180x180" href="https://assets.emblstatic.net/vf/v2.5.0/assets/embl-favicon/assets/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://assets.emblstatic.net/vf/v2.5.0/assets/embl-favicon/assets/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://assets.emblstatic.net/vf/v2.5.0/assets/embl-favicon/assets/favicon-16x16.png">
+<link rel="manifest" href="https://assets.emblstatic.net/vf/v2.5.0/assets/embl-favicon/assets/site.webmanifest">
+<link rel="mask-icon" href="https://assets.emblstatic.net/vf/v2.5.0/assets/embl-favicon/assets/safari-pinned-tab.svg" color="#ffffff">
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="theme-color" content="#ffffff">

--- a/components/vf-favicon/CHANGELOG.md
+++ b/components/vf-favicon/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.3
+
+* Point favicon urls to 2.5.0 stable release.
+
 ### 1.0.2
 
 * missing a link to favicon.ico

--- a/components/vf-favicon/vf-favicon.config.yml
+++ b/components/vf-favicon/vf-favicon.config.yml
@@ -6,12 +6,12 @@ context:
 variants:
   - name: default
     context:
-      apple_touch_icon: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/apple-touch-icon.png
-      icon_favicon: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/favicon.ico
-      icon_32: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/favicon-32x32.png
-      icon_16: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/favicon-16x16.png
-      manifest: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/site.webmanifest
-      icon_mask: https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/safari-pinned-tab.svg
+      apple_touch_icon: https://assets.emblstatic.net/vf/v2.5.0/assets/vf-favicon/assets/apple-touch-icon.png
+      icon_favicon: https://assets.emblstatic.net/vf/v2.5.0/assets/vf-favicon/assets/favicon.ico
+      icon_32: https://assets.emblstatic.net/vf/v2.5.0/assets/vf-favicon/assets/favicon-32x32.png
+      icon_16: https://assets.emblstatic.net/vf/v2.5.0/assets/vf-favicon/assets/favicon-16x16.png
+      manifest: https://assets.emblstatic.net/vf/v2.5.0/assets/vf-favicon/assets/site.webmanifest
+      icon_mask: https://assets.emblstatic.net/vf/v2.5.0/assets/vf-favicon/assets/safari-pinned-tab.svg
       color_mask: '#ffffff'
       color_msapplication: '#ffffff'
       color_theme: '#ffffff'


### PR DESCRIPTION
This uses the production emblstatic CDN repo for both vf-favicon and embl-favicon to improve stability and perofrmance.

The url will not resolve until we cut the 2.5.0 release (later today).