### PR TITLE
Bug/gulp watch dependency

### DIFF
--- a/tools/vf-core/gulp-tasks/_gulp_rollup.js
+++ b/tools/vf-core/gulp-tasks/_gulp_rollup.js
@@ -5,8 +5,6 @@
  */
 
 module.exports = function(gulp, path, componentPath, componentDirectories, buildDestionation) {
-  const watch = require('gulp-watch');
-
   // Local Server Stuff
   const browserSync = require('browser-sync').create();
   const reload = browserSync.reload;

--- a/tools/vf-core/package.json
+++ b/tools/vf-core/package.json
@@ -37,7 +37,6 @@
     "del": "^6.0.0",
     "fast-glob": "^3.1.0",
     "gulp": "^4.0.2",
-    "gulp-watch": "^5.0.1",
     "highlight.js": "^11.0.0",
     "marked": "2.1.3"
   },


### PR DESCRIPTION
This issue addresses #1644 by removing the unused `gulp-watch` dependency.

(It seems the reporting account for ticket #1644 has been deleted, taking the ticket with it.)