### PR TITLE
deprecate: vf-activity-list and vf-activity-group

### DIFF
--- a/components/vf-activity-group/CHANGELOG.md
+++ b/components/vf-activity-group/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.0-alpha.12
 
 * Deprecated as the component never saw wide adoption and neither the technical tooling nor use case was ever proven.
+  * https://github.com/visual-framework/vf-core/pull/1650
 
 ### 1.0.0-alpha.10
 

--- a/components/vf-activity-group/CHANGELOG.md
+++ b/components/vf-activity-group/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.0-alpha.12
+
+* Deprecated as the component never saw wide adoption and neither the technical tooling nor use case was ever proven.
+
 ### 1.0.0-alpha.10
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-activity-group/README.md
+++ b/components/vf-activity-group/README.md
@@ -4,6 +4,10 @@
 
 ## About
 
+This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>.
+
+## Usage
+
 A list of updates on activities.
 
 ## Install

--- a/components/vf-activity-group/vf-activity-group.config.yml
+++ b/components/vf-activity-group/vf-activity-group.config.yml
@@ -1,7 +1,9 @@
 title: Acivity List Group
 label: Acivity List Group
 preview: '@preview--nogrid'
-status: alpha
+status: deprecated
+component-type: deprecated
+hidden: true
 context:
   component-type: container
   heading: Recent activity

--- a/components/vf-activity-group/vf-activity-group.scss
+++ b/components/vf-activity-group/vf-activity-group.scss
@@ -9,15 +9,17 @@
  * Location: #{map-get($componentInfo, 'location')}
  */
 
-.vf-activity-group {
-  background-color: color(grey--lightest);
-  grid-column: 1 / -1;
-}
-.vf-activity-group__heading {
-  @include set-type(text-heading--4);
-  @include margin--block(bottom, 16px);
-}
+html:not(.vf-disable-deprecated) {
+  .vf-activity-group {
+    background-color: color(grey--lightest);
+    grid-column: 1 / -1;
+  }
+  .vf-activity-group__heading {
+    @include set-type(text-heading--4);
+    @include margin--block(bottom, 16px);
+  }
 
-.vf-activity {
-  grid-column: 2 / auto;
+  .vf-activity {
+    grid-column: 2 / auto;
+  }
 }

--- a/components/vf-activity-list/CHANGELOG.md
+++ b/components/vf-activity-list/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.0-alpha.11
 
 * Deprecated as the component never saw wide adoption and neither the technical tooling nor use case was ever proven.
+  * https://github.com/visual-framework/vf-core/pull/1650
 
 ### 1.0.0-alpha.9
 

--- a/components/vf-activity-list/CHANGELOG.md
+++ b/components/vf-activity-list/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.0-alpha.11
+
+* Deprecated as the component never saw wide adoption and neither the technical tooling nor use case was ever proven.
+
 ### 1.0.0-alpha.9
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-activity-list/README.md
+++ b/components/vf-activity-list/README.md
@@ -4,6 +4,10 @@
 
 ## About
 
+<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>.
+
+## Usage
+
 An activity list.
 
 ## Install

--- a/components/vf-activity-list/README.md
+++ b/components/vf-activity-list/README.md
@@ -4,7 +4,7 @@
 
 ## About
 
-<h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>.
+This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>.
 
 ## Usage
 

--- a/components/vf-activity-list/vf-activity-list.config.yml
+++ b/components/vf-activity-list/vf-activity-list.config.yml
@@ -1,7 +1,8 @@
 title: Activity List
 label: Activity List
-status: alpha
-
+status: deprecated
+component-type: deprecated
+hidden: true
 context:
   component-type: block
   date: Tuesday 20th February 2018

--- a/components/vf-activity-list/vf-activity-list.scss
+++ b/components/vf-activity-list/vf-activity-list.scss
@@ -13,36 +13,38 @@ $vf-activity-list__item-background--color: ui-color(white);
 $vf-activity-list__item-border--color: color(grey);
 $vf-activity-list__blockquote-text--color: color(grey--dark);
 
-.vf-activity {
-  margin-bottom: 54px;
-}
-
-.vf-activity__date {
-  @include margin--block(bottom, 32px);
-  @include set-type(text-heading--5);
-}
-
-.vf-activity__list {
-  padding: 0;
-}
-
-.vf-activity__item {
-  @include set-type(text-body--2);
-  @include margin--block(bottom, 8px);
-
-  background-color: $vf-activity-list__item-background--color;
-  border: 1px solid $vf-activity-list__item-border--color;
-  padding: 22px 16px;
-
-  > a {
-    @include inline-link;
+html:not(.vf-disable-deprecated) {
+  .vf-activity {
+    margin-bottom: 54px;
   }
-}
 
-.vf-activity__blockquote {
-  @include set-type(text-body--5);
+  .vf-activity__date {
+    @include margin--block(bottom, 32px);
+    @include set-type(text-heading--5);
+  }
 
-  color: $vf-activity-list__blockquote-text--color;
-  margin-bottom: 8px;
-  margin-top: 16px;
+  .vf-activity__list {
+    padding: 0;
+  }
+
+  .vf-activity__item {
+    @include set-type(text-body--2);
+    @include margin--block(bottom, 8px);
+
+    background-color: $vf-activity-list__item-background--color;
+    border: 1px solid $vf-activity-list__item-border--color;
+    padding: 22px 16px;
+
+    > a {
+      @include inline-link;
+    }
+  }
+
+  .vf-activity__blockquote {
+    @include set-type(text-body--5);
+
+    color: $vf-activity-list__blockquote-text--color;
+    margin-bottom: 8px;
+    margin-top: 16px;
+  }
 }

--- a/tools/vf-component-library/src/site/guidance/deprecating-components.njk
+++ b/tools/vf-component-library/src/site/guidance/deprecating-components.njk
@@ -32,7 +32,7 @@ Here's what we need to make sure we do:
     - what component(s) developers should instead use
     - Use this template
     ```html
-    <h2>This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="#"new</a> component.</h2> in the README.md file.
+    This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. Please use the <a class="vf-link" href="#"new</a> component.</h2> in the README.md file.
     ```
 1. Publish on npm
     - see [`PUBLISHING.md`](https://github.com/visual-framework/vf-core/blob/develop/PUBLISHING.md)


### PR DESCRIPTION
These two components never saw wide adoption and neither the technical tooling nor use case was ever proven.

- https://stable.visual-framework.dev/components/vf-activity-list/
- https://stable.visual-framework.dev/components/vf-activity-group/

This deprecates them by following the guide at https://stable.visual-framework.dev/guidance/deprecating-components/