### PR TITLE
Deprecate: vf-link-list

### DIFF
--- a/components/vf-link-list/CHANGELOG.md
+++ b/components/vf-link-list/CHANGELOG.md
@@ -1,3 +1,18 @@
+### 1.5.0
+
+This deprecates vf-link-list as many components are either widely unused or only seldom used — for the components that aren't yet used much we also have major revisions coming and we wish to discourage use of components that are about to be overhauled.
+
+* Links List Default: use vf-list + vf-heading
+* Links List no heading: use vf-list
+* Links List Tight: use vf-list  (we may add a vf-list--tight variant subject to demand)
+* Links List Very Easy: see above
+* Links List Easy: to be overhauled as vf-navigation--on-page
+* Links List Has Images: use vf-summary--has-image or vf-flag--middle
+
+Additionally there has been a confusion between when to use vf-list and vf-link-list that we're want to address.
+
+https://github.com/visual-framework/vf-core/issues/1649
+
 ### 1.4.0
 
 * Requires at least `@visual-framework@vf-sass-config@2.6.1`.

--- a/components/vf-link-list/README.md
+++ b/components/vf-link-list/README.md
@@ -4,9 +4,26 @@
 
 ## About
 
-The Links List component is a robust list group that can be used in a variety of grid layouts.
+This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. See "usage" for information on migrating.
 
 ## Usage
+
+### Migrating
+
+This deprecates vf-links-list as many components are either widely unused or only seldom used — for the components that aren't yet used much we also have major revisions coming and we wish to discourage use of components that are about to be overhauled.
+
+Usage of this component can by substituted with other components or new ones under development:
+
+- Links List Default: use vf-list + vf-heading
+- Links List no heading: use vf-list
+- Links List Tight: use vf-list  (we may add a vf-list--tight variant subject to demand)
+- Links List Very Easy: see above
+- Links List Easy: to be overhauled as vf-navigation--on-page
+- Links List Has Images: use vf-summary--has-image or vf-flag--middle
+
+### Original guidance
+
+The Links List component is a robust list group that can be used in a variety of grid layouts.
 
 The Links List can have a title `<h3 class="vf-links__heading">Example Title</h3>`.
 

--- a/components/vf-link-list/vf-link-list.config.yml
+++ b/components/vf-link-list/vf-link-list.config.yml
@@ -2,7 +2,9 @@ title: Links List
 label: Links List
 context:
   component-type: block
-status: live
+status: deprecated
+component-type: deprecated
+hidden: true
 variants:
   - name: default
     context:

--- a/components/vf-link-list/vf-link-list.scss
+++ b/components/vf-link-list/vf-link-list.scss
@@ -1,4 +1,4 @@
-// vf-links
+// vf-link-list
 
 @import 'package.variables.scss';
 // Debug information from component's `package.json`:
@@ -9,136 +9,138 @@
  * Location: #{map-get($componentInfo, 'location')}
  */
 
-.vf-links {
-  margin-bottom: map-get($vf-spacing-map, vf-spacing-xxl);
-}
-
-.vf-links__heading {
-  @include set-type(text-heading--4);
-}
-
-.vf-links__list {
-
-  .vf-list__item {
-    @include set-type(text-body--2);
-    @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--500));
+html:not(.vf-disable-deprecated) {
+  .vf-links {
+    margin-bottom: map-get($vf-spacing-map, vf-spacing-xxl);
   }
-
-  .vf-list__link {
-    margin-right: 8px;
-  }
-
-  .vf-badge {
-    margin-right: 8px;
-  }
-}
-
-.vf-links__list--has-image {
-
-  .vf-list__link {
-    align-items: center;
-    column-gap: 8px;
-    display: grid;
-    grid-template-columns: minmax(0, 32px) auto;
-  }
-
-  .vf-links__meta {
-    margin-left: -4px;
-    margin-right: 8px;
-  }
-}
-
-.vf-list__image {
-  height: auto;
-  justify-self: center;
-  max-width: 100%;
-  width: 100%;
-}
-
-.vf-links__meta {
-  @include set-type(text-body--5, $custom-margin-bottom: 0, $color: text-color(primary));
-
-  display: inline;
-  margin-right: 4px;
-}
-
-.vf-links__list--secondary {
-
-  .vf-list__link {
-    @include inline-link(
-      $vf-link--color: text-color(primary),
-      $vf-link--visited-color: text-color(primary),
-      $vf-link--hover-color: link-color(hover)
-    );
-
-    text-decoration: none;
-  }
-
-  .vf-list__meta {
-    color: text-color(secondary);
-    position: relative;
-
-    &::before {
-      content: '(';
-    }
-
-    &::after {
-      content: ')';
-    }
-  }
-}
-
-.vf-links--tight {
-  .vf-links__heading {
-    @include set-type(text-heading--5);
-  }
-
-  .vf-links__item {
-    margin-bottom: map-get($vf-spacing-map, vf-spacing--200);
-  }
-}
-
-.vf-links__list--s {
-  .vf-list__item {
-    @include set-type(text-body--5, $custom-margin-bottom: 8px);
-  }
-}
-
-.vf-links__list--very-easy .vf-links__list {
-  list-style-position: outside;
-  list-style-type: square;
-  margin-left: 1em;
-}
-
-
-.vf-links__list--easy {
 
   .vf-links__heading {
-    grid-column: 1 / -1;
+    @include set-type(text-heading--4);
   }
 
   .vf-links__list {
-    column-gap: 40px;
-    display: grid;
-    grid-column: 1 / -1;
-    grid-template-columns: repeat( auto-fit, minmax(300px, 1fr) );
-    row-gap: 24px;
+
+    .vf-list__item {
+      @include set-type(text-body--2);
+      @include margin--block(bottom, map-get($vf-spacing-map, vf-spacing--500));
+    }
+
+    .vf-list__link {
+      margin-right: 8px;
+    }
+
+    .vf-badge {
+      margin-right: 8px;
+    }
   }
 
-  .vf-list__item {
-    margin-bottom: 0;
+  .vf-links__list--has-image {
+
+    .vf-list__link {
+      align-items: center;
+      column-gap: 8px;
+      display: grid;
+      grid-template-columns: minmax(0, 32px) auto;
+    }
+
+    .vf-links__meta {
+      margin-left: -4px;
+      margin-right: 8px;
+    }
   }
 
-  .vf-list__link {
-    display: block;
-    position: relative;
+  .vf-list__image {
+    height: auto;
+    justify-self: center;
+    max-width: 100%;
+    width: 100%;
   }
 
-  .vf-list__icon {
-    fill: currentcolor;
-    height: 1em;
-    margin-left: 6px;
-    transform: translateY(3px);
-    width: 1em;
+  .vf-links__meta {
+    @include set-type(text-body--5, $custom-margin-bottom: 0, $color: text-color(primary));
+
+    display: inline;
+    margin-right: 4px;
+  }
+
+  .vf-links__list--secondary {
+
+    .vf-list__link {
+      @include inline-link(
+        $vf-link--color: text-color(primary),
+        $vf-link--visited-color: text-color(primary),
+        $vf-link--hover-color: link-color(hover)
+      );
+
+      text-decoration: none;
+    }
+
+    .vf-list__meta {
+      color: text-color(secondary);
+      position: relative;
+
+      &::before {
+        content: '(';
+      }
+
+      &::after {
+        content: ')';
+      }
+    }
+  }
+
+  .vf-links--tight {
+    .vf-links__heading {
+      @include set-type(text-heading--5);
+    }
+
+    .vf-links__item {
+      margin-bottom: map-get($vf-spacing-map, vf-spacing--200);
+    }
+  }
+
+  .vf-links__list--s {
+    .vf-list__item {
+      @include set-type(text-body--5, $custom-margin-bottom: 8px);
+    }
+  }
+
+  .vf-links__list--very-easy .vf-links__list {
+    list-style-position: outside;
+    list-style-type: square;
+    margin-left: 1em;
+  }
+
+
+  .vf-links__list--easy {
+
+    .vf-links__heading {
+      grid-column: 1 / -1;
+    }
+
+    .vf-links__list {
+      column-gap: 40px;
+      display: grid;
+      grid-column: 1 / -1;
+      grid-template-columns: repeat( auto-fit, minmax(300px, 1fr) );
+      row-gap: 24px;
+    }
+
+    .vf-list__item {
+      margin-bottom: 0;
+    }
+
+    .vf-list__link {
+      display: block;
+      position: relative;
+    }
+
+    .vf-list__icon {
+      fill: currentcolor;
+      height: 1em;
+      margin-left: 6px;
+      transform: translateY(3px);
+      width: 1em;
+    }
   }
 }


### PR DESCRIPTION
This deprecates vf-link-list as many components are either widely unused or only seldom used — for the components that aren't yet used much we also have major revisions coming and we wish to discourage use of components that are about to be overhauled.

- Links List Default: use vf-list + vf-heading
- Links List no heading: use vf-list
- Links List Tight: use vf-list  (we may add a vf-list--tight variant subject to demand)
- Links List Very Easy: see above
- Links List Easy: to be overhauled as vf-navigation--on-page
- Links List Has Images: use vf-summary--has-image or vf-flag--middle

Additionally there has been a confusion between when to use vf-list and vf-link-list that we're want to address.

Closes #1649