### PR TITLE
Deprecate: vf-header

### DIFF
--- a/components/vf-componenet-rollup/CHANGELOG.md
+++ b/components/vf-componenet-rollup/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.4.3
 
 * Removes the unused vf-header component.
+  * https://github.com/visual-framework/vf-core/pull/1656
 
 ## 1.4.0
 

--- a/components/vf-componenet-rollup/CHANGELOG.md
+++ b/components/vf-componenet-rollup/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.3
+
+* Removes the unused vf-header component.
+
 ## 1.4.0
 
 * removes navigation variants as they're now part of base Sass file.

--- a/components/vf-componenet-rollup/index.scss
+++ b/components/vf-componenet-rollup/index.scss
@@ -79,7 +79,6 @@ button {
 @import 'vf-code-example/vf-code-example.scss';
 @import 'vf-page-header/vf-page-header.scss';
 @import 'vf-link-list/vf-link-list.scss';
-@import 'vf-header/vf-header.scss';
 @import 'vf-hero/vf-hero.scss';
 
 @import 'vf-lede/vf-lede.scss';

--- a/components/vf-header/CHANGELOG.md
+++ b/components/vf-header/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Therefore it is being deprecated.
     * No migration guidance is supplied as it is not used in production.
     * It is also being removed from the default rollup Sass/CSS.
+* https://github.com/visual-framework/vf-core/pull/1656
 
 ### 1.0.4
 

--- a/components/vf-header/CHANGELOG.md
+++ b/components/vf-header/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 1.1.0
+
+* vf-header was an early concept on how we might accommodate multi-layers of branding ... but:
+    * It was never successfully used in production
+    * Is out of date technically and visually
+    * Has questionable IA/UX merritt in the current context
+* Therefore it is being deprecated.
+    * No migration guidance is supplied as it is not used in production.
+    * It is also being removed from the default rollup Sass/CSS.
+
 ### 1.0.4
 
 * changes any `set-` style functions to cleaner version

--- a/components/vf-header/README.md
+++ b/components/vf-header/README.md
@@ -4,6 +4,8 @@
 
 ## About
 
+This component has been <span style="color: rgb(228, 0, 70);">deprecated</span>. No alternative is provided and the pattern should not be used.
+
 ## Install
 
 This component is distributed with npm. After [installing npm](https://www.npmjs.com/get-npm), you can install the `vf-header` with this command.

--- a/components/vf-header/vf-header.config.yml
+++ b/components/vf-header/vf-header.config.yml
@@ -1,6 +1,8 @@
 title: Header
 label: Header
-status: live
+status: deprecated
+component-type: deprecated
+hidden: true
 preview: '@preview--nogrid'
 context:
   component-type: container

--- a/components/vf-header/vf-header.scss
+++ b/components/vf-header/vf-header.scss
@@ -9,33 +9,35 @@
  * Location: #{map-get($componentInfo, 'location')}
  */
 
-.vf-header {
-  background-position: top center;
-  background-size: cover;
-  box-sizing: border-box;
-  display: grid;
-  grid-column: 1 / -1;
-  width: 100%;
-}
-
-.vf-header {
-  .vf-navigation--main {
+html:not(.vf-disable-deprecated) {
+  .vf-header {
+    background-position: top center;
+    background-size: cover;
+    box-sizing: border-box;
+    display: grid;
     grid-column: 1 / -1;
+    width: 100%;
   }
-  .vf-navigation--additional {
-    grid-column: 1 / -1;
+
+  .vf-header {
+    .vf-navigation--main {
+      grid-column: 1 / -1;
+    }
+    .vf-navigation--additional {
+      grid-column: 1 / -1;
+      grid-row: 2;
+    }
+  }
+
+  .vf-header__navigation--site {
+    background-color: color(grey--dark);
+    & > * {
+      margin-left: -16px;
+    }
+  }
+
+  .vf-header__navigation--additional {
+    background-color: color(grey--dark);
     grid-row: 2;
   }
-}
-
-.vf-header__navigation--site {
-  background-color: color(grey--dark);
-  & > * {
-    margin-left: -16px;
-  }
-}
-
-.vf-header__navigation--additional {
-  background-color: color(grey--dark);
-  grid-row: 2;
 }


### PR DESCRIPTION
vf-header was an early concept on how we might accommodate multi-layers of branding ... but:

- It was never successfully used in production
- Is out of date technically and visually
- Has questionable IA/UX merrits in the current context

Therefore it is being deprecated.

No migration guidance is supplied as it is not used in production.

It is also being removed from the default rollup Sass/CSS.