### PR TITLE
Accesibility: vf-card striped variant subheading contrast

### DIFF
--- a/components/vf-card/CHANGELOG.md
+++ b/components/vf-card/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### 2.6.0
 
+* Resolves an accessibility issue with contrast for the striped card subheading variant.
+  * https://github.com/visual-framework/vf-core/issues/1657
+
+### 2.6.0
+
 * Requires at least `@visual-framework@vf-sass-config@2.6.1`.
 * Use design tokens for text colours.
   * https://github.com/visual-framework/vf-core/pull/1606

--- a/components/vf-card/vf-card.scss
+++ b/components/vf-card/vf-card.scss
@@ -227,15 +227,14 @@
   }
 
   .vf-card__subheading {
-    background-color: color(green);
-    background-color: var(--vf-card-bg-color, #{color(green)});
+    background-color: color(green--dark);
+    background-color: var(--vf-card--striped-bg-color, #{color(green--dark)});
     color: ui-color(white);
     margin: map-get($vf-spacing-map, vf-spacing--400) * -1;
-    margin-bottom: 0;
-    margin-top: -.5rem !important;
+    margin-bottom: -1rem;
     padding: map-get($vf-spacing-map, vf-spacing--400);
     padding-bottom: map-get($vf-spacing-map, vf-spacing--200);
-    padding-top: 0;
+    padding-top: .5rem;
   }
 
   .vf-card__text {


### PR DESCRIPTION
Resolves an accessibility issue with contrast for the striped card subheading variant.

Closes #1657