### PR TITLE
chore: vf-card-container formatting

### DIFF
--- a/components/vf-card-container/CHANGELOG.md
+++ b/components/vf-card-container/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.1.3
+
+* Fix README formatting.
+
 ### 3.1.2
 
 * Updates example to use content of different lengths.

--- a/components/vf-card-container/README.md
+++ b/components/vf-card-container/README.md
@@ -6,11 +6,14 @@
 
 A three-column container for `vf-card`.
 
+## Usage
+
 ### CSS Custom Properties
 
 The `vf-card` component allows for a CSS custom property to be set to define the `aspect-ratio` of the card image. This can be set per card, but with the `vf-card-container` you should aim for consistency across the `vf-card`s it is displaying. Therefore we can pass the `aspect-ratio` value from this component and it will cascade through the CSS onto the cards. This is encapsulated to this container, which allows you to set different `aspect-ratio` values for different containers as needed.
 
-To set the `aspect-ratio` you will need to set the `card_custom_aspect_ratio` key/value pair in the `.yml` or the `&#x7B;&#x25;&#x20; render &#x20;&#x25;&#x7D;`   api of the `vf-card-container as needed.
+To set the `aspect-ratio` you will need to set the `card_custom_aspect_ratio` key/value pair in the `.yml` or the `&#x7B;&#x25;&#x20; render &#x20;&#x25;&#x7D;` api of the `vf-card-container as needed.
+
 ## Install
 
 This repository is distributed with [npm](https://www.npmjs.com/). After [installing npm](https://nodejs.org/), you can install `vf-card-container` with this command.

--- a/tools/vf-component-library/src/site/developing/getting-started/setting-up.njk
+++ b/tools/vf-component-library/src/site/developing/getting-started/setting-up.njk
@@ -18,7 +18,7 @@ First you'll need to see if you have the needed tools installed.
 1. Open a command line/terminal
     - how? [Mac](https://www.wikihow.com/Open-a-Terminal-Window-in-Mac), [Linux/Ubuntu](https://www.wikihow.com/Open-a-Terminal-Window-in-Ubuntu), [Windows 10](https://www.howtogeek.com/235101/10-ways-to-open-the-command-prompt-in-windows-10/), [VS Code integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal)
 1. Enter `node -v`
-    - note: as of May 2021 we require at least Node version 12
+    - note: as of May 2021 we require at least Node version 12. Version 14 or newer is recommended.
 1. Enter `yarn -v`
 1. Enter `gulp -v`
 


### PR DESCRIPTION
The README was missing it's `## Usage` header.