### PR TITLE
draft home page and card improvements

### DIFF
--- a/components/_previews/_preview--body.njk
+++ b/components/_previews/_preview--body.njk
@@ -21,7 +21,7 @@
   }
   </style>
 </head>
-<body class="vf-body">
+<body class="vf-body | vf-stack vf-stack--400">
   {{ yield | safe }}
 
   <script src="{{ '/scripts/scripts.js' | path }}"></script>

--- a/components/_previews/_preview--nogrid.njk
+++ b/components/_previews/_preview--nogrid.njk
@@ -17,7 +17,7 @@
   {% endif %}
   <style>body { margin: 0; }</style>
 </head>
-<body class="vf-body">
+<body class="vf-body | vf-stack vf-stack--400">
   {{ yield | safe }}
   <script src="{{ '/scripts/scripts.js' | path }}"></script>
 </body>

--- a/components/_previews/_preview.njk
+++ b/components/_previews/_preview.njk
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="https://dev.assets.emblstatic.net/vf/develop/css/styles.css">
   {% endif %}
 </head>
-<body class="vf-body">
+<body class="vf-body | vf-stack vf-stack--400">
   <div class="vf-grid">
     <div class="vf-component__container">
       {{ yield | safe }}

--- a/components/vf-card-container/CHANGELOG.md
+++ b/components/vf-card-container/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 3.1.3
+### 3.2.0
 
 * Fix README formatting.
 * Halves vertical spacing between `vf-section-header` and vf-cards.

--- a/components/vf-card-container/CHANGELOG.md
+++ b/components/vf-card-container/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### 3.1.3
 
 * Fix README formatting.
+* Halves vertical spacing between `vf-section-header` and vf-cards.
+* Refines container vertical by using `--page-grid-gap)`.
+* Adds 4 column card support for when cards have no imagery.
 
 ### 3.1.2
 

--- a/components/vf-card-container/README.md
+++ b/components/vf-card-container/README.md
@@ -4,9 +4,13 @@
 
 ## About
 
-A three-column container for `vf-card`.
+A multi-column container for `vf-card`.
 
 ## Usage
+
+### Columns
+
+The containier defaults to three columns (the recommended number of image-based cards per row). However if text-only cards are being used, a 4-column variant is supported `cards_per_row: 4` which appends CSS class `vf-card-container__col-4`.
 
 ### CSS Custom Properties
 

--- a/components/vf-card-container/vf-card-container.config.yml
+++ b/components/vf-card-container/vf-card-container.config.yml
@@ -19,6 +19,7 @@ variants:
     context:
       modifier: vf-u-background-color--grey--lightest vf-u-fullbleed
       cards_aspect_ratio: 16 / 9
+      cards_per_row: 3
       container_section__header:
         section_title: Missions
         href: "JavaScript:Void(0);"

--- a/components/vf-card-container/vf-card-container.njk
+++ b/components/vf-card-container/vf-card-container.njk
@@ -1,15 +1,14 @@
 {% if context %}
-
-{% set modifier = context.modifier %}
-{% set vf_cards = context.vf_cards %}
-{% set container_section__header = context.container_section__header %}
-{% set cardtype = context.variant %}
-{% set cards_aspect_ratio = context.cards_aspect_ratio %}
-
+  {% set modifier = context.modifier %}
+  {% set vf_cards = context.vf_cards %}
+  {% set container_section__header = context.container_section__header %}
+  {% set cardtype = context.variant %}
+  {% set cards_aspect_ratio = context.cards_aspect_ratio %}
+  {% set cards_per_row = context.cards_per_row %}
 {% endif %}
 
 <section
-  class="vf-card-container{% if modifier %} | {{modifier}}{% endif %}"
+  class="vf-card-container{% if cards_per_row %} vf-card-container__col-{{cards_per_row}}{% endif %}{% if modifier %} | {{modifier}}{% endif %}"
   style="--vf-card__image--aspect-ratio: {{cards_aspect_ratio}};"
 >
   <div class="vf-card-container__inner">

--- a/components/vf-card-container/vf-card-container.scss
+++ b/components/vf-card-container/vf-card-container.scss
@@ -20,8 +20,10 @@
 
 .vf-card-container {
   grid-column: 1 / -1;
-  margin: 0 0 3rem 0;
-  padding: 2rem 0;
+  margin: 0 0 3rem 0; // IE11 fallback
+  margin: 0 0 calc(var(--page-grid-gap) * 2) 0;
+  padding: 2rem 0; // IE11 fallback
+  padding: var(--page-grid-gap) 0;
 }
 
 .vf-card-container__inner {
@@ -33,7 +35,7 @@
   @supports (display: grid) {
     --vf-card-container__grid--size: 18rem;
     display: grid;
-    gap: var(--page-grid-gap);
+    gap: calc(var(--page-grid-gap) / 2) var(--page-grid-gap);
     grid-template-columns: repeat(auto-fit, minmax(var(--vf-card-container__grid--size--overide, var(--vf-card-container__grid--size)), 1fr));
     margin: 0 auto;
     max-width: $vf-layout--comfortable;
@@ -55,6 +57,23 @@
   .vf-card {
     margin-bottom: 40px;
     width: 30%;
+    @supports (display: grid) {
+      margin-bottom: unset;
+      width: unset;
+    }
+  }
+}
+
+.vf-card-container__col-4 .vf-card-container__inner {
+  @supports (display: grid) {
+    --vf-card-container__grid--size: 18rem;
+    // @media (min-width: $vf-breakpoint--sm) {
+    // --vf-card-container__grid--size: 20rem;
+    // }
+  }
+
+  .vf-card {
+    width: 24%;
     @supports (display: grid) {
       margin-bottom: unset;
       width: unset;

--- a/components/vf-card-container/vf-card-container.scss
+++ b/components/vf-card-container/vf-card-container.scss
@@ -20,8 +20,8 @@
 
 .vf-card-container {
   grid-column: 1 / -1;
-  margin: 0 0 3rem 0; // IE11 fallback
-  margin: 0 0 calc(var(--page-grid-gap) * 2) 0;
+  margin: 0 0 2rem 0; // IE11 fallback
+  margin: 0 0 calc(var(--page-grid-gap)) 0;
   padding: 2rem 0; // IE11 fallback
   padding: var(--page-grid-gap) 0;
 }

--- a/components/vf-divider/README.md
+++ b/components/vf-divider/README.md
@@ -11,7 +11,7 @@ The `vf-divider` component creates a horizontal dividing rule that can help sepa
 The `vf-divider` component will be the width of if's container. So inside of `<body>` of your page it will be a maximum of 1300px.
 
 ```
-<body class="vf-body">
+<body class="vf-body | vf-stack vf-stack--400">
   <hr class="vf-divider">
 </body>
 ```

--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 3.3.1
 
 * Reduces vf-hero bottom margin.
+* Makes vf-hero bottom margin "smarter" by no applying when the following element uses `vf-u-fullwidth` or `vf-navigation`. In these cases vf-stack is sufficient.
 
 ### 3.3.0
 

--- a/components/vf-hero/CHANGELOG.md
+++ b/components/vf-hero/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.3.1
+
+* Reduces vf-hero bottom margin.
+
 ### 3.3.0
 
 * Updates the default hero spacing to be equivalent to 1200 (was: 800). This better matches the actual default usage in practice and is based off design feedback for consistency.

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -12,13 +12,11 @@
 @import 'vf-hero.variables.scss';
 
 .vf-hero {
-
   background-color: color(green);
   background-image: url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/roundels.png');
   background-image: var(--vf-hero--bg-image, url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/roundels.png'));
 
   margin-bottom: map-get($vf-spacing-map, vf-spacing--800);
-  margin-bottom: var(--vf-hero--spacing, #{map-get($vf-spacing-map, vf-spacing--1200)});
   padding: map-get($vf-spacing-map, vf-spacing--800) 0;
   padding: var(--vf-hero--spacing, #{map-get($vf-spacing-map, vf-spacing--1200)}) 0;
 }

--- a/components/vf-hero/vf-hero.scss
+++ b/components/vf-hero/vf-hero.scss
@@ -16,9 +16,15 @@
   background-image: url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/roundels.png');
   background-image: var(--vf-hero--bg-image, url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/roundels.png'));
 
-  margin-bottom: map-get($vf-spacing-map, vf-spacing--800);
   padding: map-get($vf-spacing-map, vf-spacing--800) 0;
   padding: var(--vf-hero--spacing, #{map-get($vf-spacing-map, vf-spacing--1200)}) 0;
+
+  // Hero only has gap when not followed by fullwidth background or navigation
+  // The hero bottom margin is created by pushing the next element "down"
+  & + :not(.vf-u-fullbleed):not(.vf-navigation) {
+    margin-top: map-get($vf-spacing-map, vf-spacing--800);
+    --vf-stack-margin--custom: #{map-get($vf-spacing-map, vf-spacing--800)};
+  }
 }
 
 .vf-hero.vf-u-fullbleed::before {
@@ -103,7 +109,6 @@
   }
 }
 
-
 .vf-hero__link {
   @include set-type(text-heading--4, $custom-margin-bottom: 0);
 
@@ -164,3 +169,4 @@
     --vf-box-padding: calc(var(--vf-hero--spacing) / 2);
   }
 }
+

--- a/components/vf-news-container/CHANGELOG.md
+++ b/components/vf-news-container/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0
+
+* Standardizes the featured news variant as 4 columns.
+
 ### 1.0.0
 
 * Fixes CSS to match stylelint rules.

--- a/components/vf-news-container/vf-news-container--featured.njk
+++ b/components/vf-news-container/vf-news-container--featured.njk
@@ -1,10 +1,39 @@
-<section class="vf-news-container vf-news-container--featured | embl-grid">
+<section class="vf-news-container vf-news-container--featured | vf-stack">
   {% render '@vf-section-header'%}
 
-  <div class="vf-news-container__content vf-grid">
-    {% render '@vf-summary--news-has-image' %}
-    {% render '@vf-summary--news-has-image' %}
-    {% render '@vf-summary--news-has-image' %}
+  <div class="vf-news-container__content | vf-grid vf-grid__col-4">
+    {% render '@vf-summary--news-has-image', {
+      summary__href: 'JavaScript:Void(0);',
+      summary__image: "../../assets/vf-summary/assets/vf-summary--news-has-image.jpg",
+      summary__image_alt: "BioSamples",
+      summary__title: "news article summary",
+      "summary__text": "",
+      summary__date: "4 September 2019"
+    } %}
+    {% render '@vf-summary--news-has-image', {
+      summary__href: 'JavaScript:Void(0);',
+      summary__image: "../../assets/vf-summary/assets/vf-summary--news-has-image.jpg",
+      summary__image_alt: "BioSamples",
+      summary__title: "news article summary",
+      "summary__text": "",
+      summary__date: "4 September 2019"
+    } %}
+    {% render '@vf-summary--news-has-image', {
+      summary__href: 'JavaScript:Void(0);',
+      summary__image: "../../assets/vf-summary/assets/vf-summary--news-has-image.jpg",
+      summary__image_alt: "BioSamples",
+      summary__title: "news article summary",
+      "summary__text": "",
+      summary__date: "4 September 2019"
+    } %}
+    {% render '@vf-summary--news-has-image', {
+      summary__href: 'JavaScript:Void(0);',
+      summary__image: "../../assets/vf-summary/assets/vf-summary--news-has-image.jpg",
+      summary__image_alt: "BioSamples",
+      summary__title: "news article summary",
+      "summary__text": "",
+      summary__date: "4 September 2019"
+    } %}
   </div>
 
   <!--

--- a/components/vf-news-container/vf-news-container.scss
+++ b/components/vf-news-container/vf-news-container.scss
@@ -9,7 +9,6 @@
  * Location: #{map-get($componentInfo, 'location')}
  */
 
-
 .vf-news-container--featured {
   .vf-summary {
     grid-template-columns: none;

--- a/components/vf-search/CHANGELOG.md
+++ b/components/vf-search/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.0.0-alpha.1
+
+* Refine spacing when more than 1 inline `vf-form__item`.
+
 ### 3.0.0-alpha.0
 
 * updates to code and documentation based on consultation and decisions made.

--- a/components/vf-search/vf-search.scss
+++ b/components/vf-search/vf-search.scss
@@ -40,13 +40,17 @@
 }
 
 .vf-form--search.vf-sidebar {
-  --vf-sidebar-spacing: #{space(400)};
+  --vf-sidebar-spacing: #{space(200)};
   --vf-sidebar-main-width: 60%;
 
   overflow: visible;
 
   .vf-form__item {
     position: relative;
+  }
+
+  .vf-form__item:last-of-type {
+    padding-right: #{space(100)};
   }
 
   .vf-form__helper {

--- a/components/vf-stack/CHANGELOG.md
+++ b/components/vf-stack/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.1.2
+
+* vf-stack no longer applies between a `vf-hero` and `vf-u-fullbleed`.
+
 ### 2.1.1
 
 * adds usage guideline for inlcude the default `vf-stack` and the size variant.

--- a/components/vf-stack/CHANGELOG.md
+++ b/components/vf-stack/CHANGELOG.md
@@ -1,10 +1,11 @@
 ### 2.1.2
 
 * vf-stack no longer applies between a `vf-hero` and `vf-u-fullbleed`.
+* Gives more margin-top to `vf-u-fullbleed` after most items.
 
 ### 2.1.1
 
-* adds usage guideline for inlcude the default `vf-stack` and the size variant.
+* adds usage guideline for include the default `vf-stack` and the size variant.
 
 ### 2.1.0
 
@@ -20,8 +21,8 @@
 
 ### 1.2.0
 
-* now uses Nunjucks 'blocks' so we can use this layout more programatically
-* hides the defauly Nunjcuks file as it renders what looks like a blank page (because it's waiting for the block content)
+* now uses Nunjucks 'blocks' so we can use this layout more programmatically
+* hides the default Nunjucks file as it renders what looks like a blank page (because it's waiting for the block content)
 * creates separate Nunjucks files to display variants in Fractal
 * updates naming conventions of variables available
   * introduces `stack__spacing__custom` which will replace `custom_spacing_property` in the `2.0.0` component release

--- a/components/vf-stack/vf-stack.scss
+++ b/components/vf-stack/vf-stack.scss
@@ -22,7 +22,7 @@
  *
  * notes:
  * a: We are using `!important` here because some components have
- *    margin set that we need to overide.
+ *    margin set that we need to override.
  * b: We can probably remove the custom property when all components
  *    have been purged of margin-bottom too.
  *
@@ -64,4 +64,9 @@
 
 .vf-stack--1600 > * + * {
   --vf-stack-margin: #{map-get($vf-spacing-map, vf-spacing--1600)};
+}
+
+// vf-stack should not apply between a hero and vf-u-fullbleed
+.vf-stack > .vf-hero + .vf-u-fullbleed {
+  margin-top: unset !important;
 }

--- a/components/vf-stack/vf-stack.scss
+++ b/components/vf-stack/vf-stack.scss
@@ -67,7 +67,7 @@
 }
 
 // vf-u-fullbleed should get more spacing after most items
-.vf-stack > * + .vf-u-fullbleed:not(.vf-hero) {
+.vf-stack > :not(.vf-hero) + .vf-u-fullbleed:not(.vf-hero):not(.ebi-header-footer) {
   margin-top: #{map-get($vf-spacing-map, vf-spacing--1200)} !important;
 }
 

--- a/components/vf-stack/vf-stack.scss
+++ b/components/vf-stack/vf-stack.scss
@@ -66,6 +66,11 @@
   --vf-stack-margin: #{map-get($vf-spacing-map, vf-spacing--1600)};
 }
 
+// vf-u-fullbleed should get more spacing after most items
+.vf-stack > * + .vf-u-fullbleed {
+  margin-top: #{map-get($vf-spacing-map, vf-spacing--1200)} !important;
+}
+
 // vf-stack should not apply between a hero and vf-u-fullbleed
 .vf-stack > .vf-hero + .vf-u-fullbleed {
   margin-top: unset !important;

--- a/components/vf-stack/vf-stack.scss
+++ b/components/vf-stack/vf-stack.scss
@@ -67,7 +67,7 @@
 }
 
 // vf-u-fullbleed should get more spacing after most items
-.vf-stack > * + .vf-u-fullbleed {
+.vf-stack > *:not(.vf-hero) + .vf-u-fullbleed {
   margin-top: #{map-get($vf-spacing-map, vf-spacing--1200)} !important;
 }
 

--- a/components/vf-stack/vf-stack.scss
+++ b/components/vf-stack/vf-stack.scss
@@ -67,7 +67,7 @@
 }
 
 // vf-u-fullbleed should get more spacing after most items
-.vf-stack > *:not(.vf-hero) + .vf-u-fullbleed {
+.vf-stack > * + .vf-u-fullbleed:not(.vf-hero) {
   margin-top: #{map-get($vf-spacing-map, vf-spacing--1200)} !important;
 }
 

--- a/components/vf-summary/CHANGELOG.md
+++ b/components/vf-summary/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.6.0
+
+* Removes support for styling of `vf-summary` inside of `vf-box`. (this is no longer encouraged)
+* Adds support for conditional display of `vf-summary__text`.
+
 ### 1.5.1
 
 * Documentation: clarity on using card vs summary components.

--- a/components/vf-summary/vf-summary--news-has-image.njk
+++ b/components/vf-summary/vf-summary--news-has-image.njk
@@ -6,7 +6,7 @@
   {% set summary__image_alt = context.summary__image_alt %}
   {% set summary__date = context.summary__date %}
   {% set summary__category = context.summary__category %}
-{%- endif %}
+{%- endif -%}
 
 <article class="vf-summary vf-summary--news">
   <span class="vf-summary__date">{{summary__date}}</span>
@@ -16,12 +16,14 @@
       {{ summary__title }}
     </a>
   </h3>
+  {% if summary__text -%}
   <p class="vf-summary__text">
-    {% if summary__category %}
+    {% if summary__category -%}
     <span class="vf-summary__category">
       {{summary__category}}
     </span>
-    {% endif %}
+    {%- endif %}
     {{summary__text}}
   </p>
+  {%- endif %}
 </article>

--- a/components/vf-summary/vf-summary.scss
+++ b/components/vf-summary/vf-summary.scss
@@ -21,31 +21,6 @@
   & > *:last-child {
     margin-bottom: 0;
   }
-
-  // vf-summary can also sit inside a vf-box - so we need to adjust some things to match
-  .vf-box & {
-    .vf-summary__title {
-      color: inherit;
-    }
-    .vf-summary__link {
-      color: inherit;
-    }
-    .vf-summary__date {
-      color: inherit;
-    }
-    .vf-summary__text {
-      color: inherit;
-    }
-    .vf-summary__source {
-      color: inherit;
-    }
-    .vf-summary__author {
-      color: inherit;
-    }
-    .vf-link {
-      color: inherit;
-    }
-  }
 }
 
 .vf-summary__category {

--- a/tools/vf-component-library/src/site/index.njk
+++ b/tools/vf-component-library/src/site/index.njk
@@ -6,15 +6,14 @@ layout: layouts/base.njk
 ---
 
 {% set context = {
-  "spacing": 400,
+  "spacing": 800,
   "vf_hero_heading": "The Visual Framework",
   "vf_hero_heading_href": "/about",
   "vf_hero_subheading": "Good defaults and technical flexibility for life science websites",
   "vf_hero_text": [
-    "With compatibility with existing CSS and JS, you can bring your Bootstrap, React or vanilla code base. The VF will not break your existing code.",
-    '<a href="about" class="vf-link">Learn more</a>, <a href="/building" class="vf-link">build something</a> or <a class="vf-link" href="guidance/discussing-the-vf/">get help</a>.'
+    "With compatibility with existing CSS and JS, you can bring your Bootstrap, React or vanilla code base. The VF will not break your existing code."
   ],
-  "vf_hero_link_text": false,
+  "vf_hero_link_text": "About the VF",
   "vf_hero_link_href": "/about",
   "vf_hero_image_size": "auto 28.5rem"
 }
@@ -23,9 +22,9 @@ layout: layouts/base.njk
 {% include "vf-core-components/vf-hero/vf-hero.njk" %}
 
 {# Global navigation #}
-{% include "navigation.njk" %}
+{# {% include "navigation.njk" %} #}
 
-<section class="embl-grid embl-grid--has-centered-content | vf-u-padding__top--1200 vf-u-margin__top--800">
+<section class="embl-grid embl-grid--has-centered-content">
 {% render '@vf-section-header', {
   "section_title": "Search",
   "id": "search",

--- a/tools/vf-component-library/src/site/patterns/boilerplate-generic-embl-ebi.njk
+++ b/tools/vf-component-library/src/site/patterns/boilerplate-generic-embl-ebi.njk
@@ -40,29 +40,14 @@ layout: layouts/boilerplate.njk
   <!-- See the VF Breadcrumbs docs: https://stable.visual-framework.dev/components/embl-breadcrumbs-lookup/ -->
   {% include "./templates/breadcrumbs-boilerplate.njk" %}
 
-  <!-- See the VF Hero docs: https://stable.visual-framework.dev/components/vf-hero/ -->
-  {% set context = {
-    "vf_hero_kicker": "<a href=\"//www.ebi.ac.uk/about\">About EMBL-EBI</a> | Structural Biology",
-    "spacing": 400,
-    "vf_hero_heading": "Sample content page",
-    "vf_hero_subheading": subtitle,
-    "vf_hero_text": [
-    ],
-    "vf_hero_link_text": "",
-    "vf_hero_link_href": "",
-    "vf_hero_image": "url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/EBI_webbanner_test_V3.jpg');"
-  }
-  %}
-  {% include "vf-core-components/vf-hero/vf-hero.njk" %}
-
   <!-- See the VF Navigation docs: https://stable.visual-framework.dev/components/vf-navigation/ -->
   {% render '@vf-navigation--main' %}
 
   <!-- See the VF Intro docs: https://stable.visual-framework.dev/components/vf-intro/ -->
   {% set context = {
-    "vf_intro_heading": "Further information about a topic",
+    "vf_intro_heading": "Sample content page",
     "vf_intro_badge": false,
-    "vf_intro_subheading": "",
+    "vf_intro_subheading": subtitle,
     "vf_intro_lede": "At EMBL-EBI we have a diverse, multidisciplinary team of over 850 people from 78 countries.",
     "vf_intro_text": [
     ]

--- a/tools/vf-component-library/src/site/patterns/boilerplate-generic.njk
+++ b/tools/vf-component-library/src/site/patterns/boilerplate-generic.njk
@@ -1,7 +1,6 @@
 ---
-title: Directory page
-subtitle: A gateway to many areas of child information and related content.
-section: patterns
+title: Deprecated
+subtitle: See the landing page instead
 date: 2021-09-22 12:24:50
 tags: posts
 layout: layouts/boilerplate.njk
@@ -30,142 +29,14 @@ layout: layouts/boilerplate.njk
     "vf_hero_kicker": "<a href=\"JavaScript:Void(0);\">VF Hamburg</a> | Structural Biology",
     "spacing": 400,
     "vf_hero_heading": title,
-    "vf_hero_subheading": subtitle,
-    "vf_hero_text": [
-      "It is good to have a 20 to 40 words summary of the activity or action to be driven about the example pattern."
-    ],
-    "vf_hero_link_text": "See more Visual Framework patterns",
+    "vf_hero_subheading": "",
+    "vf_hero_text": false,
+    "vf_hero_link_text": subtitle,
     "vf_hero_link_href": "/components",
     "vf_hero_image": "url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/vf-hero-intense.png');"
   }
   %}
   {% include "vf-core-components/vf-hero/vf-hero.njk" %}
-
-  {% set context = {
-    "component-type": "block",
-    "classModifier": "main",
-    "navigation": [
-      {
-        "text": "Home",
-        "navigation_href": "JavaScript:Void(0);",
-        "currentPage": "balls"
-      },
-      {
-        "text": "Download",
-        "navigation_href": "JavaScript:Void(0);"
-      },
-      {
-        "text": "Release Notes",
-        "navigation_href": "JavaScript:Void(0);"
-      },
-      {
-        "text": "FAQ",
-        "navigation_href": "JavaScript:Void(0);"
-      },
-      {
-        "text": "Help",
-        "navigation_href": "JavaScript:Void(0);"
-      },
-      {
-        "text": "Licence",
-        "navigation_href": "JavaScript:Void(0);"
-      },
-      {
-        "text": "About",
-        "navigation_href": "JavaScript:Void(0);"
-      },
-      {
-        "text": "Feedback",
-        "navigation_href": "JavaScript:Void(0);"
-      }
-    ]
-  }
-  %}
-  {% include "vf-core-components/vf-navigation/vf-navigation.njk" %}
-
-  {% set context = {
-    "id": "intro",
-    "vf_intro_heading": "Here you will find it",
-    "vf_intro_badge": false,
-    "vf_intro_subheading": false,
-    "vf_intro_lede": "EMBL’s future directions will be driven by the goal of understanding life in the context of its environment.",
-    "vf_intro_text": [
-      "We now have the tools and technologies to explore these processes, allowing us to understand life in its natural context from the level of molecules to whole ecosystems."
-    ]
-  }
-  %}
-  {% include "vf-core-components/vf-intro/vf-intro.njk" %}
-
-  <div class="embl-grid | vf-content">
-    <div class="vf-section-header">
-      <h2 class="vf-section-header__heading">
-        Science is international
-      </h2>
-      <p class="vf-section-header__text"></p>
-      </div>
-    <div>
-      <div class="vf-embed vf-embed--16x9" style=""><iframe src="https://www.youtube.com/embed/8mg5VhRF7Pk" controls="" allowfullscreen="" frameborder="0"></iframe></div>
-    </div>
-    <div>
-      <p>Over 3/4 of our workforce has joined us from outside the UK and we are proud of the diverse and multicultural working environment we offer.</p>
-      <p>Working at EMBL-EBI, you will join an inclusive community of 850+ amazing employees from 78 countries.</p>
-
-      <p><a href="https://www.embl.org/editorhub/wp-content/uploads/2020/12/Current-staff-members-map.jpg" data-type="URL" data-id="https://www.embl.org/editorhub/wp-content/uploads/2020/12/Current-staff-members-map.jpg" target="_blank" rel="noreferrer noopener">See our employee map</a></p>
-    </div>
-  </div>
-
-  {% set context = {
-    "modifier": "vf-u-background-color--grey--lightest vf-u-fullbleed",
-    "cards_aspect_ratio": "16 / 9",
-    "container_section__header": {
-      "section_title": "Missions",
-      "href": "JavaScript:Void(0);",
-      "vf_section__content": [
-        "To promote molecular biology across Europe",
-        "To create a centre of excellence for Europe's leading young molecular biologists"
-      ]
-    },
-    "vf_cards": [
-      {
-        "variant": "bordered",
-        "newTheme": "primary",
-        "card_title": "One card",
-        "card_href": "JavaScript:Void(0);",
-        "card_image": "https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg",
-        "card_text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos? Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?"
-      },
-      {
-        "variant": "bordered",
-        "newTheme": "primary",
-        "card_title": "A card here",
-        "card_href": "JavaScript:Void(0);",
-        "card_image": "https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg",
-        "card_text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit."
-      },
-      {
-        "variant": "bordered",
-        "newTheme": "primary",
-        "card_title": "Another card",
-        "card_href": "JavaScript:Void(0);",
-        "card_image": "https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg",
-        "card_text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?"
-      }
-    ]
-  }
-  %}
-  {% include "vf-core-components/vf-card-container/vf-card-container.njk" %}
-
-  <section class="embl-grid embl-grid--has-centered-content">
-    <div>
-      {%- render '@vf-section-header--default', {
-        "section_title": "You can include section headers too"
-      } -%}
-    </div>
-
-    <div>
-      {% render '@vf-content' %}
-    </div>
-  </section>
 
   {% include "./templates/source-link-boilerplate.njk" %}
 

--- a/tools/vf-component-library/src/site/patterns/boilerplate-generic.njk
+++ b/tools/vf-component-library/src/site/patterns/boilerplate-generic.njk
@@ -1,8 +1,8 @@
 ---
-title: Landing page
-subtitle: Use this boilerplate pattern for landing pages.
+title: Directory page
+subtitle: A gateway to many areas of child information and related content.
 section: patterns
-date: 2021-04-29 12:24:50
+date: 2021-09-22 12:24:50
 tags: posts
 layout: layouts/boilerplate.njk
 ---

--- a/tools/vf-component-library/src/site/patterns/home-page.njk
+++ b/tools/vf-component-library/src/site/patterns/home-page.njk
@@ -48,16 +48,6 @@ layout: layouts/boilerplate.njk
   %}
   {% include "vf-core-components/vf-navigation/vf-navigation.njk" %}
 
-  <style>
-  {# no gap when vf-hero + vf-fullbleed #}
-  .vf-hero + .vf-u-fullbleed {
-    margin-top: -1rem !important;
-  }
-  {# .vf-card-container__inner {
-    --vf-card-container__grid--size--overide: 18rem;
-  } #}
-  </style>
-
   {% set context = {
     "vf_hero_kicker": "",
     "spacing": 400,

--- a/tools/vf-component-library/src/site/patterns/home-page.njk
+++ b/tools/vf-component-library/src/site/patterns/home-page.njk
@@ -1,0 +1,142 @@
+---
+title: Home page
+subtitle: The home page sits at the top of website's information architecture.
+section: patterns
+date: 2021-09-22 12:24:50
+tags: posts
+layout: layouts/boilerplate.njk
+---
+<!DOCTYPE html>
+<html lang="en" class="vf-no-js">
+<head>
+  {% render "@vf-no-js" %}
+  <title>{{ pagination.items[0].name or title or (renderData and renderData.title)}} | {{ siteConfig.siteInformation.title }}</title>
+
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1, minimum-scale=1" name="viewport">
+
+  {% render "@vf-favicon" %}
+  {% render "@embl-content-meta-properties", {"meta_who": "Group Jane", "meta_where": "Barcelona", "meta_what": "research", "meta_active": "what"} %}
+
+  <link rel="stylesheet" media="all" href="{{ '/css/styles.css' | url }}" />
+</head>
+<body class="vf-body |  vf-stack vf-stack--400">
+  <header class="vf-header">
+    {% render "@vf-global-header" %}
+  </header>
+  {# {% include "./templates/breadcrumbs-boilerplate.njk" %} #}
+
+  {% set context = {
+    "component-type": "block",
+    "classModifier": "main",
+    "navigation": [
+      {
+        "text": "Quicklink 1",
+        "navigation_href": "JavaScript:Void(0);",
+        "currentPage": "balls"
+      },
+      {
+        "text": "Quicklink 2",
+        "navigation_href": "JavaScript:Void(0);"
+      },
+      {
+        "text": "Quicklink 3",
+        "navigation_href": "JavaScript:Void(0);"
+      }
+    ]
+  }
+  %}
+  {% include "vf-core-components/vf-navigation/vf-navigation.njk" %}
+
+  <style>
+  {# no gap when vf-hero + vf-fullbleed #}
+  .vf-hero + .vf-u-fullbleed {
+    margin-top: -1rem !important;
+  }
+  {# .vf-card-container__inner {
+    --vf-card-container__grid--size--overide: 18rem;
+  } #}
+  </style>
+
+  {% set context = {
+    "vf_hero_kicker": "",
+    "spacing": 400,
+    "vf_hero_heading": title,
+    "vf_hero_subheading": subtitle,
+    "vf_hero_text": [
+      "It is good to have a 20 to 40 words summary of the activity or action to be driven about the example pattern."
+    ],
+    "vf_hero_link_text": "Call to action",
+    "vf_hero_link_href": "/components",
+    "vf_hero_image": "url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/vf-hero-intense.png');"
+  }
+  %}
+  {% include "vf-core-components/vf-hero/vf-hero.njk" %}
+
+  {% set context = {
+    "modifier": "vf-u-background-color--grey--lightest vf-u-fullbleed",
+    "cards_aspect_ratio": "16 / 9",
+    "cards_per_row": "4",
+    "container_section__header": {
+      "section_title": "Second-tier actions",
+      "href": "",
+      "vf_section__content": false
+    },
+    "vf_cards": [
+      {
+        "variant": "bordered",
+        "newTheme": "primary",
+        "card_title": "One card",
+        "card_href": "JavaScript:Void(0);",
+        "card_image": "",
+        "card_text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit."
+      },
+      {
+        "variant": "bordered",
+        "newTheme": "primary",
+        "card_title": "A card here",
+        "card_href": "JavaScript:Void(0);",
+        "card_image": "",
+        "card_text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit."
+      },
+      {
+        "variant": "bordered",
+        "newTheme": "primary",
+        "card_title": "Another card",
+        "card_href": "JavaScript:Void(0);",
+        "card_image": "",
+        "card_text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit."
+      },
+      {
+        "variant": "bordered",
+        "newTheme": "primary",
+        "card_title": "Another card",
+        "card_href": "JavaScript:Void(0);",
+        "card_image": "",
+        "card_text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit."
+      }
+
+    ]
+  }
+  %}
+  {% include "vf-core-components/vf-card-container/vf-card-container.njk" %}
+
+  <section class="embl-grid embl-grid--has-centered-content">
+    <div>
+      {%- render '@vf-section-header--default', {
+        "section_title": "You can include section headers too"
+      } -%}
+    </div>
+
+    <div>
+      {% render '@vf-content' %}
+    </div>
+  </section>
+
+  {% include "./templates/source-link-boilerplate.njk" %}
+
+  {% render "@vf-footer" %}
+  {% include "./templates/notice-boilerplate.njk" %}
+  {% include "scripts.njk" %}
+</body>
+</html>

--- a/tools/vf-component-library/src/site/patterns/landing-page.njk
+++ b/tools/vf-component-library/src/site/patterns/landing-page.njk
@@ -50,13 +50,11 @@ layout: layouts/boilerplate.njk
 
   {% set context = {
     "vf_hero_kicker": "",
-    "spacing": 400,
+    "spacing": 800,
     "vf_hero_heading": title,
     "vf_hero_subheading": subtitle,
-    "vf_hero_text": [
-      "It is good to have a 20 to 40 words summary of the activity or action to be driven about the example pattern."
-    ],
-    "vf_hero_link_text": "Call to action",
+    "vf_hero_text": false,
+    "vf_hero_link_text": "Optional call to action link",
     "vf_hero_link_href": "/components",
     "vf_hero_image": "url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/vf-hero-intense.png');"
   }
@@ -113,17 +111,32 @@ layout: layouts/boilerplate.njk
 
   {% render "@vf-news-container--featured" %}
 
-  <section class="embl-grid embl-grid--has-centered-content">
-    <div>
-      {%- render '@vf-section-header--default', {
-        "section_title": "You can include section headers too"
-      } -%}
-    </div>
+  <hr class="vf-divider">
 
-    <div>
-      {% render '@vf-content' %}
-    </div>
-  </section>
+  {% render '@vf-section-header', {
+    "section_title": "Some additional things you might like",
+    "id": "additional",
+    "vf_section__content": ""
+  } %}
+
+  <div class="vf-grid vf-grid__col-3">
+  {% set context = {
+    "component-type": "block",
+    "card_heading": "A Striped Card Heading",
+    "card_subheading": "With sub–heading",
+    "variant": "striped",
+    "newTheme": "primary",
+    "card_image": "https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/2020/04/SCHOOLS_1011_ells-learninglab_hd_01_Cool_500px.jpg",
+    "card_text": "Lorem ipsum dolor sit amet, consectetur. Sapiente harum, omnis provident saepe aut eius aliquam sequi fugit incidunt reiciendis, mollitia quos?",
+    "card_image__alt": "Image alt text"
+  }
+  %}
+  {% include "vf-core-components/vf-card/vf-card.njk" %}
+  {% include "vf-core-components/vf-card/vf-card.njk" %}
+  {% include "vf-core-components/vf-card/vf-card.njk" %}
+  </div>
+
+  {% render "@vf-card-container" %}
 
   {% include "./templates/source-link-boilerplate.njk" %}
 

--- a/tools/vf-component-library/src/site/patterns/landing-page.njk
+++ b/tools/vf-component-library/src/site/patterns/landing-page.njk
@@ -1,6 +1,6 @@
 ---
-title: Home page
-subtitle: The home page sits at the top of website's information architecture.
+title: Landing page
+subtitle: Many types of users visit landing pages which guide users along their journey, and promote other content and actions.
 section: patterns
 date: 2021-09-22 12:24:50
 tags: posts

--- a/tools/vf-component-library/src/site/patterns/landing-page.njk
+++ b/tools/vf-component-library/src/site/patterns/landing-page.njk
@@ -111,6 +111,8 @@ layout: layouts/boilerplate.njk
   %}
   {% include "vf-core-components/vf-card-container/vf-card-container.njk" %}
 
+  {% render "@vf-news-container--featured" %}
+
   <section class="embl-grid embl-grid--has-centered-content">
     <div>
       {%- render '@vf-section-header--default', {

--- a/tools/vf-component-library/src/site/patterns/scientific-service.njk
+++ b/tools/vf-component-library/src/site/patterns/scientific-service.njk
@@ -49,14 +49,19 @@ layout: layouts/boilerplate.njk
     "banner__message": "This is a starting point for services that demonstrates an overall feel and how to structure the homepage navigation. Individual service design will vary greately depending on the needs addressed."
   } %}
 
+  <style>
+  /* vf-hero wih search is still a prototype concept */
+  .vf-hero--search .vf-hero__content {
+    min-width: 60%;
+  }
+  </style>
+
   <!-- prototype hero + search -->
-  <section class="vf-hero vf-hero--400 | vf-u-fullbleed"
+  <section class="vf-hero vf-hero--800 vf-hero--search | vf-u-fullbleed"
     style="--vf-hero--bg-image: url(&#39;https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/EBI_webbanner_test_V3.jpg&#39;);">
     <div class="vf-hero__content | vf-box | vf-stack vf-stack--400"><p class="vf-hero__kicker"><a href="//www.ebi.ac.uk/about">Categorisation (Optional)</a> | Structural Biology</p>
       <h2 class="vf-hero__heading">Online scientific resource</h2>
       <p class="vf-hero__subheading">Open data resources of code, functions and things of data</p>
-
-      <hr class="vf-divider">
 
       <form action="#" class="vf-form vf-form--search vf-form--search--mini | vf-sidebar vf-sidebar--end">
         <div class="vf-sidebar__inner">
@@ -97,7 +102,9 @@ layout: layouts/boilerplate.njk
       </form>
       {# <p class="vf-hero__text">An example landing page for an online scientific service such as a bioinformatics database, tool or similar.</p> #}
       <p class="vf-text-body--5">
-        We also offer an <a href="JavaScript:Void(0);" class="vf-link">advanced search</a> | Example searches: <a href="JavaScript:Void(0);" class="vf-link">Example</a>, <a href="JavaScript:Void(0);" class="vf-link">Example</a>, <a href="JavaScript:Void(0);" class="vf-link">Example</a>
+        Example searches: <a href="JavaScript:Void(0);" class="vf-link">Example</a>, <a href="JavaScript:Void(0);" class="vf-link">Example</a>, <a href="JavaScript:Void(0);" class="vf-link">Example</a>
+        |
+        <a href="JavaScript:Void(0);" class="vf-link">advanced search</a>
       </p>
 
       {# <a class="vf-hero__link" href="/components">See more Visual Framework patterns<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="" fill-rule="nonzero"></path></svg></a> #}
@@ -130,48 +137,55 @@ layout: layouts/boilerplate.njk
   <section class="vf-grid vf-grid__col-3 | vf-card-container | vf-u-fullbleed vf-u-background-color-ui--grey--light">
     <div class="vf-grid__col--span-2">
       <div class="vf-grid vf-grid__col-2">
-        {% render '@vf-section-header--has-a-link-and-text', {
-          "section_title": "Browse",
-          "href": "JavaScript:Void(0);",
-          "vf_section__content": [
-            "On the homepage, don't use a strip of navigation."
-          ]
+        {%- render '@vf-card', {
+          "newTheme": "primary",
+          "variant": "bordered",
+          "card_title": "Browse",
+          "card_href": "JavaScript:Void(0);",
+          "card_text": "On the homepage, don't use a strip of navigation",
+          "card_image__alt": ""
         } %}
 
-        {% render '@vf-section-header--has-a-link-and-text', {
-          "section_title": "Results",
-          "href": "JavaScript:Void(0);",
-          "vf_section__content": [
-            "It's more user friendly to put the navigation into sqaures like these."
-          ]
+        {%- render '@vf-card', {
+          "newTheme": "primary",
+          "variant": "bordered",
+          "card_title": "Results",
+          "card_href": "JavaScript:Void(0);",
+          "card_text": "It's more user friendly to put the navigation into squares like these",
+          "card_image__alt": ""
         } %}
 
-        {% render '@vf-section-header--has-a-link-and-text', {
-          "section_title": "Download",
-          "href": "JavaScript:Void(0);",
-          "vf_section__content": [
-            "It allows users to explore the content."
-          ]
+        {%- render '@vf-card', {
+          "newTheme": "primary",
+          "variant": "bordered",
+          "card_title": "Download",
+          "card_href": "JavaScript:Void(0);",
+          "card_text": "It allows users to explore the content",
+          "card_image__alt": ""
         } %}
 
-        {% render '@vf-section-header--has-a-link-and-text', {
-          "section_title": "Help",
-          "href": "JavaScript:Void(0);",
-          "vf_section__content": [
-            "And also read about what to expect in each section"
-          ]
+        {%- render '@vf-card', {
+          "newTheme": "primary",
+          "variant": "bordered",
+          "card_title": "Help",
+          "card_href": "JavaScript:Void(0);",
+          "card_text": "And also read about what to expect in each section",
+          "card_image__alt": ""
         } %}
+
       </div>
     </div>
 
     <div>
-      {% render '@vf-section-header--has-a-link-and-text', {
-        "section_title": "About this service",
-        "href": "JavaScript:Void(0);",
-        "vf_section__content": [
-          "A thing provides functional analysis of proteins by classifying them into families and predicting domains and important sites."
-        ]
+      {%- render '@vf-card', {
+        "newTheme": "primary",
+        "variant": "striped",
+        "card_title": "About this service",
+        "card_href": "JavaScript:Void(0);",
+        "card_text": "A thing provides functional analysis of proteins by classifying them into families and predicting domains and important sites.",
+        "card_image__alt": ""
       } %}
+
       {# <p class="vf-text-body vf-text-body--3">
         To classify proteins in this way, InterPro uses predictive models, known as signatures, provided by several different databases (referred to as member databases) that make up the InterPro consortium. We combine protein signatures from these member databases into a single searchable resource, capitalising on their individual strengths to produce a powerful integrated database and diagnostic tool.
       </p> #}

--- a/tools/vf-component-library/src/site/patterns/scientific-service.njk
+++ b/tools/vf-component-library/src/site/patterns/scientific-service.njk
@@ -1,6 +1,6 @@
 ---
-title: Online scientific resource
-subtitle: An example landing page for an online scientific service such as a bioinformatics database, tool or similar.
+title: Scientific resource landing page
+subtitle: Example landing page for an online scientific service such as a bioinformatics database, tool or similar where search is key.
 section: patterns
 date: 2018-08-22 12:24:50
 tags: posts
@@ -27,7 +27,7 @@ layout: layouts/boilerplate.njk
   {% include "./templates/breadcrumbs-boilerplate.njk" %}
 
   <!-- See the VF Hero docs: https://stable.visual-framework.dev/components/vf-hero/ -->
-  {% set context = {
+  {# {% set context = {
     "vf_hero_kicker": "<a href=\"//www.ebi.ac.uk/about\">Categorisation (Optional)</a> | Structural Biology",
     "spacing": 400,
     "vf_hero_heading": title,
@@ -40,10 +40,7 @@ layout: layouts/boilerplate.njk
     "vf_hero_image": "url('https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/EBI_webbanner_test_V3.jpg');"
   }
   %}
-  {% include "vf-core-components/vf-hero/vf-hero.njk" %}
-
-  <!-- See the VF Navigation docs: https://stable.visual-framework.dev/components/vf-navigation/ -->
-  {% render '@vf-navigation--main' %}
+  {% include "vf-core-components/vf-hero/vf-hero.njk" %} #}
 
   {% render '@vf-banner--info', {
     "alert_icon_text": "dismiss",
@@ -52,7 +49,66 @@ layout: layouts/boilerplate.njk
     "banner__message": "This is a starting point for services that demonstrates an overall feel and how to structure the homepage navigation. Individual service design will vary greately depending on the needs addressed."
   } %}
 
-  <section class="embl-grid embl-grid--has-centered-content | vf-u-padding__top--1200 vf-u-margin__top--800">
+  <!-- prototype hero + search -->
+  <section class="vf-hero vf-hero--400 | vf-u-fullbleed"
+    style="--vf-hero--bg-image: url(&#39;https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/EBI_webbanner_test_V3.jpg&#39;);">
+    <div class="vf-hero__content | vf-box | vf-stack vf-stack--400"><p class="vf-hero__kicker"><a href="//www.ebi.ac.uk/about">Categorisation (Optional)</a> | Structural Biology</p>
+      <h2 class="vf-hero__heading">Online scientific resource</h2>
+      <p class="vf-hero__subheading">Open data resources of code, functions and things of data</p>
+
+      <hr class="vf-divider">
+
+      <form action="#" class="vf-form vf-form--search vf-form--search--mini | vf-sidebar vf-sidebar--end">
+        <div class="vf-sidebar__inner">
+
+          <div class="vf-form__item">
+
+            <label class="vf-form__label vf-u-sr-only | vf-search__label" for="searchitem">Search</label>
+            <input type="search" placeholder="Search the service" id="searchitem" class="vf-form__input">
+          </div>
+
+          <div class="vf-form__item">
+
+            {# <label class="vf-form__label" for="vf-form__select">Choose a pet:</label> #}
+
+            <select class="vf-form__select" id="vf-form__select">
+              <option value="cat">Cat</option>
+              <option value="hamster">Hamster</option>
+              <option value="parrot">Parrot</option>
+              <option value="dog" selected>Dog</option>
+              <option value="spider">Spider</option>
+              <option value="goldfish">Goldfish</option>
+            </select>
+
+          </div>
+
+          <button type="submit" class="vf-search__button | vf-button vf-button--primary">
+            <span class="vf-button__text | vf-u-sr-only">Search</span>
+
+            <svg class="vf-icon vf-icon--search-btn | vf-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs" viewBox="0 0 140 140" width="140" height="140">
+              <g transform="matrix(5.833333333333333,0,0,5.833333333333333,0,0)">
+                <path d="M23.414,20.591l-4.645-4.645a10.256,10.256,0,1,0-2.828,2.829l4.645,4.644a2.025,2.025,0,0,0,2.828,0A2,2,0,0,0,23.414,20.591ZM10.25,3.005A7.25,7.25,0,1,1,3,10.255,7.258,7.258,0,0,1,10.25,3.005Z" fill="#FFFFFF" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="0"></path>
+              </g>
+            </svg>
+
+          </button>
+        </div>
+
+      </form>
+      {# <p class="vf-hero__text">An example landing page for an online scientific service such as a bioinformatics database, tool or similar.</p> #}
+      <p class="vf-text-body--5">
+        We also offer an <a href="JavaScript:Void(0);" class="vf-link">advanced search</a> | Example searches: <a href="JavaScript:Void(0);" class="vf-link">Example</a>, <a href="JavaScript:Void(0);" class="vf-link">Example</a>, <a href="JavaScript:Void(0);" class="vf-link">Example</a>
+      </p>
+
+      {# <a class="vf-hero__link" href="/components">See more Visual Framework patterns<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="" fill-rule="nonzero"></path></svg></a> #}
+    </div>
+  </section>
+
+  {# <!-- See the VF Navigation docs: https://stable.visual-framework.dev/components/vf-navigation/ --> #}
+  {# {% render '@vf-navigation--main' %} #}
+
+
+  {# <section class="embl-grid embl-grid--has-centered-content | vf-u-padding__top--1200 vf-u-margin__top--800">
     <div><!-- empty --></div>
     <div class="vf-u-border-color-ui--grey--light vf-box vf-box--r">
       {% render '@vf-search', {
@@ -69,9 +125,9 @@ layout: layouts/boilerplate.njk
       </p>
 
     </div>
-  </section>
+  </section> #}
 
-  <section class="vf-grid vf-grid__col-3 | vf-u-padding__top--200 vf-u-margin__bottom--1200">
+  <section class="vf-grid vf-grid__col-3 | vf-card-container | vf-u-fullbleed vf-u-background-color-ui--grey--light">
     <div class="vf-grid__col--span-2">
       <div class="vf-grid vf-grid__col-2">
         {% render '@vf-section-header--has-a-link-and-text', {
@@ -129,7 +185,7 @@ layout: layouts/boilerplate.njk
     </div>
   </section>
 
-  <hr class="vf-divider" />
+  {# <hr class="vf-divider" /> #}
 
   <section class="embl-grid | vf-u-margin__top--1200">
     {%- render '@vf-section-header--default', {

--- a/tools/vf-component-library/src/site/patterns/scientific-service.njk
+++ b/tools/vf-component-library/src/site/patterns/scientific-service.njk
@@ -20,7 +20,7 @@ layout: layouts/boilerplate.njk
 
   <link rel="stylesheet" media="all" href="{{ '/css/styles.css' | url }}" />
 </head>
-<body class="vf-body">
+<body class="vf-body | vf-stack vf-stack--400">
   <header class="vf-header">
     {% render "@vf-global-header" %}
   </header>

--- a/tools/vf-component-library/src/site/patterns/sidebar.njk
+++ b/tools/vf-component-library/src/site/patterns/sidebar.njk
@@ -21,7 +21,7 @@ layout: layouts/boilerplate.njk
 
   <link rel="stylesheet" media="all" href="{{ '/css/styles.css' | url }}" />
 </head>
-<body class="vf-body">
+<body class="vf-body | vf-stack vf-stack--400">
   <header class="vf-header">
     {% render "@vf-global-header" %}
   </header>

--- a/tools/vf-component-library/src/site/patterns/templates/notice-boilerplate.njk
+++ b/tools/vf-component-library/src/site/patterns/templates/notice-boilerplate.njk
@@ -1,11 +1,8 @@
-<!-- dismissible banner for information on using the design language -->
+{# <!-- dismissible banner for information on using the design language -->
 <!-- you can delete this on your page -->
 <div class="vf-banner vf-banner--fixed vf-banner--bottom vf-banner--phase"
 data-vf-js-banner
 data-vf-js-banner-state="dismissible"
-{# data-vf-js-banner-button-text="Close notice" #}
-{# data-vf-js-banner-cookie-name="environment-{{serverInfo.environment}}" #}
-{# data-vf-js-banner-cookie-version="0.1" #}
 data-vf-js-banner-auto-accept="false">
   <div class="vf-banner__content" data-vf-js-banner-text>
     <div class="vf-banner__text">
@@ -15,12 +12,10 @@ data-vf-js-banner-auto-accept="false">
       <input type="checkbox" id="checkbox-01" class="vf-form__checkbox" checked>
       <label for="checkbox-01" class="vf-form__label | vf-u-margin--0">Show notes and usability tips</label>
     </div>
-    {#
     <p class="vf-banner__text">Here's the core CSS and JS you need. Don't forget to <a href="{{ '/' | url }}" class="vf-banner__link">review the documentation</a> and <a href="{{ '/patterns' | url }}" class="vf-banner__link">see more boilerplates and patterns</a>.</p>
     {% codeblock 'html' -%}
 <link rel="stylesheet" href="https://{{ siteConfig.vfVersionPrefix }}assets.emblstatic.net/vf/{{ siteConfig.vfVersion }}/css/styles.css">
 <script src="https://{{ siteConfig.vfVersionPrefix }}assets.emblstatic.net/vf/{{ siteConfig.vfVersion }}/scripts/scripts.js"></script>
     {%- endcodeblock %}
-    #}
   </div>
-</div>
+</div> #}


### PR DESCRIPTION
This PR introduces a number of changes to facilitate the work on the VF September sprint:

- prototype landing page
- revised search-based service to include a prototype search in hero
- various long-due fixes in spacing around combined use cases of vf-hero+vf-u-fullbleed+vf-stack
- alignment of vf-news-container--featured and real-world usage (4 columns, no paragraph text)

## Component changes

These are all integration-focused changes to smooth out use cases where components are used in combinations that create oddities. 

vf-card container

* Halves vertical spacing between `vf-section-header` and vf-cards.
* Refines container vertical by using `--page-grid-gap)`.
* Adds 4 column card support for when cards have no imagery.

vf-hero

* Reduces vf-hero bottom margin.
* Makes vf-hero bottom margin "smarter" by no applying when the following element uses `vf-u-fullwidth` or `vf-navigation`. In these cases vf-stack is sufficient.

vf-news-container

 * Standardizes the featured news variant as 4 columns.

vf-stack

* vf-stack no longer applies between a `vf-hero` and `vf-u-fullbleed`.
* Gives more margin-top to `vf-u-fullbleed` after most items.

vf-summary

* Removes support for styling of `vf-summary` inside of `vf-box`. (this is no longer encouraged)
* Adds support for conditional display of `vf-summary__text`.

 vf-search

* Refine spacing when more than 1 inline `vf-form__item`.