### PR TITLE
chore: drop-down and progress component cleanup

### DIFF
--- a/components/vf-dropdown/vf-dropdown.js
+++ b/components/vf-dropdown/vf-dropdown.js
@@ -3,15 +3,14 @@
 /**
  * Function for JS scroll to top functionality
  * That must be executed exactly once
- * @example vfBackToTop()
+ * @example vfDropdown()
  */
 export function vfDropdown() {
   const components = document.querySelectorAll("[data-vf-js-dropdown]");
 
   for (let component of components) {
-    component.addEventListener("click", (event) => {
+    component.addEventListener("click", () => {
       component.classList.toggle("vf-dropdown--open");
     });
   }
-
 }

--- a/components/vf-dropdown/vf-dropdown.njk
+++ b/components/vf-dropdown/vf-dropdown.njk
@@ -1,5 +1,10 @@
-{# Make sure any variables are listed inside the following if statement #}
-
+{%- if context %}
+  {% set width = context.width %}
+  {% set labelAlign = context.labelAlign %}
+  {% set label = context.label %}
+  {% set id = context.id %}
+  {% set menuItems = context.menuItems %}
+{%- endif -%}
 <div class="vf-dropdown" data-vf-js-dropdown style="width:{{width}}">
   <div class="vf-dropdown__label-container">
     <div class="vf-dropdown__label" style="text-align: {{labelAlign}}">{{label}}</div>

--- a/components/vf-dropdown/vf-dropdown.scss
+++ b/components/vf-dropdown/vf-dropdown.scss
@@ -30,7 +30,7 @@
   display: flex;
   font-weight: 600;
   justify-content: space-between;
-  padding: .8 rem;
+  padding: .8rem;
   position: relative;
   z-index: set-layer(vf-z-index--overlay-top-content);
 }

--- a/components/vf-dropdown/vf-dropdown.scss
+++ b/components/vf-dropdown/vf-dropdown.scss
@@ -32,11 +32,11 @@
   justify-content: space-between;
   padding: .8 rem;
   position: relative;
-  z-index: 8050;
+  z-index: set-layer(vf-z-index--overlay-top-content);
 }
 .vf-dropdown__label {
   flex: 1;
-  margin-right: .8 rem 1.5rem;
+  margin-right: .8rem 1.5rem;
   text-align: right;
 }
 .vf-dropdown__menu-container {
@@ -47,7 +47,7 @@
   box-shadow: 0px 3px 6px 1px neutral(100);
   padding: .5rem 0;
   position: relative;
-  z-index: 8050;
+  z-index: set-layer(vf-z-index--overlay-top-content);
 }
 .vf-dropdown__menu-item {
   cursor: pointer;
@@ -70,7 +70,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 8000;
+  z-index: set-layer(vf-z-index--overlay);
 }
 
 .vf-dropdown--open {

--- a/components/vf-dropdown/vf-dropdown.scss
+++ b/components/vf-dropdown/vf-dropdown.scss
@@ -30,13 +30,13 @@
   display: flex;
   font-weight: 600;
   justify-content: space-between;
-  padding: 0.8 rem;
+  padding: .8 rem;
   position: relative;
   z-index: 8050;
 }
 .vf-dropdown__label {
   flex: 1;
-  margin-right: 0.8 rem 1.5rem;
+  margin-right: .8 rem 1.5rem;
   text-align: right;
 }
 .vf-dropdown__menu-container {
@@ -45,7 +45,7 @@
 .vf-dropdown__menu {
   border-top: 1px solid neutral(200);
   box-shadow: 0px 3px 6px 1px neutral(100);
-  padding: 0.5 rem 0;
+  padding: .5rem 0;
   position: relative;
   z-index: 8050;
 }

--- a/components/vf-dropdown/vf-dropdown.scss
+++ b/components/vf-dropdown/vf-dropdown.scss
@@ -24,57 +24,53 @@
 
 .vf-dropdown {
   display: inline-block;
-  .vf-dropdown__label-container {
-    padding: 0.8rem;
-    display: flex;
-    justify-content: space-between;
+}
+.vf-dropdown__label-container {
+  cursor: pointer;
+  display: flex;
+  font-weight: 600;
+  justify-content: space-between;
+  padding: 0.8 rem;
+  position: relative;
+  z-index: 8050;
+}
+.vf-dropdown__label {
+  flex: 1;
+  margin-right: 0.8 rem 1.5rem;
+  text-align: right;
+}
+.vf-dropdown__menu-container {
+  display: none;
+}
+.vf-dropdown__menu {
+  border-top: 1px solid neutral(200);
+  box-shadow: 0px 3px 6px 1px neutral(100);
+  padding: 0.5 rem 0;
+  position: relative;
+  z-index: 8050;
+}
+.vf-dropdown__menu-item {
+  cursor: pointer;
+  padding: 1rem 1.5rem;
+  &:hover {
+    /* No token for this color yet, according to cindy */
+    background-color: #CDE3F8;
+  }
+  &.active {
     font-weight: 600;
-    cursor: pointer;
-    z-index: 8050;
-    position: relative;
   }
-  .vf-dropdown__label {
-    flex: 1;
-    text-align: right;
-    margin-right: 0.8rem 1.5rem;
-  }
-  .vf-dropdown__menu-container {
-    display: none;
-
-  }
-  .vf-dropdown__menu {
-    border-top: 1px solid neutral(200);
-    position: relative;
-    z-index: 8050;
-    box-shadow: 0px 3px 6px 1px neutral(100);
-    padding: 0.5rem 0;
-
-  }
-  .vf-dropdown__menu-item {
-    padding: 1rem 1.5rem;
-    cursor: pointer;
-
-    &:hover {
-      /* No token for this color yet, according to cindy */
-      background-color: #CDE3F8;
-    }
-
-    &.active {
-      font-weight: 600;
-    }
-  }
-  .vf-dropdown__menu-item-link {
-    text-decoration: none;
-    color: var(--vf-color__text--primary);
-  }
-  .vf-dropdown-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    z-index: 8000;
-  }
+}
+.vf-dropdown__menu-item-link {
+  color: var(--vf-color__text--primary);
+  text-decoration: none;
+}
+.vf-dropdown-overlay {
+  height: 100%;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 8000;
 }
 
 .vf-dropdown--open {

--- a/components/vf-progress-indicator/vf-progress-indicator.jsx
+++ b/components/vf-progress-indicator/vf-progress-indicator.jsx
@@ -8,14 +8,14 @@ export function VFProgressIndicator({ helperText = "", progressPercent = 0 }) {
   return (
     <div
       class="vf-progress-indicator"
-      style={{"width": width || '100%'}}
+      style={{"--vf-progress-indicator__width": width || '100%'}}
     >
       <div
         class="vf-progress-indicator__mark"
-        style={{"width": progressPercent+"%"}}
+        style={{"--vf-progress-indicator__percent": progressPercent+"%"}}
       ></div>
       {helperText && (
-        <div class="vf-progress-indicator__helper-text">{helperText}</div>
+        <p class="vf-progress-indicator__helper-text">{helperText}</p>
       )}
     </div>
   );

--- a/components/vf-progress-indicator/vf-progress-indicator.njk
+++ b/components/vf-progress-indicator/vf-progress-indicator.njk
@@ -1,8 +1,14 @@
-{# Make sure any variables are listed inside the following if statement #}
-<div class="vf-progress-indicator" style="width: {% if width %} {{width}} {% else %} var(--vf-progress-indicator__width) {% endif %}">
-  <div class="vf-progress-indicator__mark" style="width: {{progressPercent}}%"></div>
-  {% if helperText %}
-  <div class="vf-progress-indicator__helper-text"> some helper text
-  {% endif %}
-  </div>
+{%- if context %}
+  {% set width = context.width %}
+  {% set helperText = context.helperText %}
+  {% set progressPercent = context.progressPercent %}
+  {% set id = context.id %}
+{%- endif -%}
+<div
+  role="progressbar" aria-valuenow="{{progressPercent}}" aria-valuemin="0" aria-valuemax="100"
+  class="vf-progress-indicator"{% if width %} style="--vf-progress-indicator__width: {{width}}"{% endif %}>
+  <div class="vf-progress-indicator__mark" style="--vf-progress-indicator__percent: {{progressPercent}}%"></div>
+  {% if helperText -%}
+  <p class="vf-progress-indicator__helper-text">{{helperText}}</p>
+  {%- endif %}
 </div>

--- a/components/vf-progress-indicator/vf-progress-indicator.scss
+++ b/components/vf-progress-indicator/vf-progress-indicator.scss
@@ -23,22 +23,22 @@
 // @import 'vf-progress-indicator/vf-progress-indicator.scss';
 .vf-progress-indicator {
   --vf-progress-indicator__width: 100%;
-  height: 0.5rem;
-  margin-top: 1rem;
   background-color: neutral(200);
+  height: .5rem;
+  margin-top: 1rem;
   width: 100%; // IE11 fallback
   width: var(--vf-progress-indicator__width, 100%);
 }
 .vf-progress-indicator__mark {
-  --vf-progress-indicator__percent: 1%
-  height: 100%;
+  --vf-progress-indicator__percent: 1%;
   background-color: color(green);
   border-left: 1.5px solid color(green);
+  height: .5rem;
   width: 1%; // IE11 fallback
   width: var(--vf-progress-indicator__percent, 1%);
 }
 .vf-progress-indicator__helper-text {
   @include set-type(text-body--5, $custom-margin-bottom: 0);
-  margin-top: 0.5rem;
+  margin-top: .5rem;
   text-align: right;
 }

--- a/components/vf-progress-indicator/vf-progress-indicator.scss
+++ b/components/vf-progress-indicator/vf-progress-indicator.scss
@@ -22,18 +22,23 @@
 // You need to add this Sass file to ./components/vf-componenet-rollup/index.scss
 // @import 'vf-progress-indicator/vf-progress-indicator.scss';
 .vf-progress-indicator {
-  width: 100%;
+  --vf-progress-indicator__width: 100%;
   height: 0.5rem;
   margin-top: 1rem;
   background-color: neutral(200);
+  width: 100%; // IE11 fallback
+  width: var(--vf-progress-indicator__width, 100%);
 }
 .vf-progress-indicator__mark {
+  --vf-progress-indicator__percent: 1%
   height: 100%;
   background-color: color(green);
   border-left: 1.5px solid color(green);
+  width: 1%; // IE11 fallback
+  width: var(--vf-progress-indicator__percent, 1%);
 }
 .vf-progress-indicator__helper-text {
+  @include set-type(text-body--5, $custom-margin-bottom: 0);
   margin-top: 0.5rem;
-  font-size: small;
   text-align: right;
 }

--- a/components/vf-progress-indicator/vf-progress-indicator.variables.scss
+++ b/components/vf-progress-indicator/vf-progress-indicator.variables.scss
@@ -8,7 +8,3 @@
 
 // $vf-progress-indicator--example-bg-color: set-color(vf-color--yellow);
 // $vf-progress-indicator--example2-bg-color: set-ui-color(vf-ui-color--grey);
-
-:root {
-  --vf-progress-indicator__width: 100%;
-}


### PR DESCRIPTION
Following work on #1682 and #1679 to introduce the new alpha components this cleans up a pair of rough edges.

- css custom prop usage
- ie11 fallback
- njk typo
- njk whitespace control
- add aria progress  bar role
  - maybe more work to do there in the future https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_progressbar_role
- add context conditionals
- z-index tokens
- remove unused `event` in `vf-dropdown.js`

@nitinja I thought it might be easier to show a few of these rather than explain all of them. If you like we can also discuss during the next VF call.

## Screenshots

Just as information

![image](https://user-images.githubusercontent.com/928100/135251146-7ac1fa43-e0e9-429f-a527-a44d092cd231.png)

![image](https://user-images.githubusercontent.com/928100/135251191-0aee473e-5a0e-46ba-bd03-502f6a1fb0e8.png)
