### PR TITLE
bug: section-header links should still be h2

### DIFF
--- a/components/vf-section-header/CHANGELOG.md
+++ b/components/vf-section-header/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.5.2
+
+* Accessibility: When section header is a link, it should still be wrapped an `h2`
+  * https://github.com/visual-framework/vf-core/issues/1683
+* Whitespace control
+
 ### 1.5.1
 
 * Fixes the vertical centering of the svg arrow on vf-section-header. Also aligns better with the Figma design kit.

--- a/components/vf-section-header/vf-section-header.njk
+++ b/components/vf-section-header/vf-section-header.njk
@@ -1,26 +1,26 @@
-{% if context %}
+{%- if context %}
 {% set id = context.id %}
 {% set href = context.href %}
 {% set section_title = context.section_title %}
 {% set section__subheading = context.section__subheading %}
 {% set vf_section__content = context.vf_section__content %}
-{% endif %}
+{% endif -%}
 
-{# Determine type of element to use, if not explicitly set -#}
 {% spaceless %}
 
+{# in the future we may allow a choice of h2 or h3 #}
+{% set tags = 'h2' %}
 {% if href %}
-  {% set tags = 'a' %}
-{% else %}
-  {% set tags = 'h2' %}
 {% endif %}
 
 <div class="vf-section-header">
   <{{tags}}
-    class="vf-section-header__heading{% if href %} vf-section-header__heading--is-link{% endif %}" {% if href %}href="{{href}}"{% endif -%}
+    class="vf-section-header__heading{% if href %} vf-section-header__heading--is-link{% endif %}"
     {%- if id %} id="{{id}}"{% endif -%}
   >
+    {% if href %}<a href="{{href}}">{% endif %}
     {{- section_title -}}
+    {% if href %}</a>{% endif %}
 
     {%- if href %}
       <svg aria-hidden="true" class="vf-section-header__icon | vf-icon vf-icon-arrow--inline-end" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="" fill-rule="nonzero"></path></svg>
@@ -28,7 +28,6 @@
 
   </{{tags}}>
   {% if section__subheading %}
-
     <p class="vf-section-header__subheading">{{ section__subheading }}</p>
   {% endif %}
 


### PR DESCRIPTION
* Accessibility: When section header is a link, it should still be wrapped an `h2`
  * https://github.com/visual-framework/vf-core/issues/1683
* Whitespace control

![image](https://user-images.githubusercontent.com/928100/135273015-e44de661-3689-4be7-87e0-83d3e536ef11.png)
