### PR TITLE
feature: vf-extensions support for eleventy version 1

### DIFF
--- a/tools/vf-component-library/src/site/updates/2021-11-23-component-updates.njk
+++ b/tools/vf-component-library/src/site/updates/2021-11-23-component-updates.njk
@@ -34,7 +34,7 @@ layout: layouts/post.njk
 
 {% markdown %}
 
-<span class="" id="overview"></span>Hot on the heels of the [2.5.4 release](../2021-11-22-component-updates/), this release focus on technical tooling by updating dependencies and preparing [for the Eleventy 1.0 release](https://www.11ty.dev/blog/eleventy-v1-beta/).
+<span class="" id="overview"></span>Hot on the heels of the [2.5.4 release](../2021-11-22-component-updates/), this release focuses on technical tooling by updating dependencies and preparing [for the Eleventy 1.0 release](https://www.11ty.dev/blog/eleventy-v1-beta/).
 
 To opt-in to using an Eleventy 1.0 beta, you'll need to update `vf-extensions` to at least version `2.0.0-alpha.1`
 

--- a/tools/vf-extensions/11ty/eleventy-cmd.js
+++ b/tools/vf-extensions/11ty/eleventy-cmd.js
@@ -98,20 +98,21 @@ try {
       .then(function () {
         try {
           if (argv.serve) {
-            let startBrowsersync = true;
-            elev
-              .watch()
-              .catch((e) => {
-                // Build failed but error message already displayed.
-                startBrowsersync = false;
-                // A build error occurred and we aren’t going to --serve
-              })
-              .then(function () {
-                if (startBrowsersync) {
-                  // elev.watch(argv.port);
-                  elev.serve(argv.port);
-                }
-              });
+            // we'll do our watch from gulp-eleventy
+            // let startBrowsersync = true;
+            // elev
+            //   .watch()
+            //   .catch((e) => {
+            //     // Build failed but error message already displayed.
+            //     startBrowsersync = false;
+            //     // A build error occurred and we aren’t going to --serve
+            //   })
+            //   .then(function () {
+            //     if (startBrowsersync) {
+            //       // elev.watch(argv.port);
+            //       elev.serve(argv.port);
+            //     }
+            //   });
           } else if (argv.watch) {
             elev.watch().catch((e) => {
               // A build error occurred and we aren’t going to --watch

--- a/tools/vf-extensions/CHANGELOG.md
+++ b/tools/vf-extensions/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.0-alpha.2
 
 * Further revises integration with eleventy-cmd.js to allow more control from gulp.
+* https://github.com/visual-framework/vf-core/pull/1721
 
 ## 2.0.0-alpha.1
 

--- a/tools/vf-extensions/CHANGELOG.md
+++ b/tools/vf-extensions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-alpha.2
+
+* Further revises integration with eleventy-cmd.js to allow more control from gulp.
+
 ## 2.0.0-alpha.1
 
 * Support Eleventy 1.0.0 change in how its build process works

--- a/tools/vf-extensions/gulp-tasks/gulp-eleventy.js
+++ b/tools/vf-extensions/gulp-tasks/gulp-eleventy.js
@@ -23,6 +23,14 @@ module.exports = function(gulp) {
     process.argv.push("--serve");
     process.env.ELEVENTY_ENV = "development";
     elev = require("../11ty/eleventy-cmd.js");
+    elev.init()
+      .then(function () {
+        elev.watch().then(function() {
+          console.log("Started 11ty");
+          elev.serve(3030);
+          done();
+        });
+      });
   });
 
   // Run eleventy as a static build
@@ -49,4 +57,3 @@ module.exports = function(gulp) {
 
   return gulp;
 };
-


### PR DESCRIPTION
Further revises integration with eleventy-cmd.js to allow more control from gulp.

This isn't strictly required, but allows for more fine-grained control when running `gulp dev`

Follows work done in #1257