### PR TITLE
Docs: Rename "Visual Framework 2.0" to just "Visual Framework"

### DIFF
--- a/components/vf-favicon/assets/site.webmanifest
+++ b/components/vf-favicon/assets/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "Visual Framework 2.0",
-    "short_name": "VF 2.0",
+    "name": "Visual Framework",
+    "short_name": "VF",
     "icons": [
         {
             "src": "https://dev.assets.emblstatic.net/vf/develop/assets/vf-favicon/assets/android-chrome-192x192.png",

--- a/components/vf-logo/vf-logo.config.yml
+++ b/components/vf-logo/vf-logo.config.yml
@@ -24,8 +24,8 @@ variants:
 context:
   # custom-values: passed as {{custom-values}}
   component-type: element
-  logo_href: http://www.embl.de
-  logo_text: Visual Framework 2.0
+  logo_href: https://stable.visual-framework.dev/
+  logo_text: Visual Framework
   image: https://assets.emblstatic.net/vf/v2.4.6/assets/vf-logo/assets/logo.svg
   # image: ../../assets/vf-component-name/assets/vf-component-name.png
   # - note on paths: be sure to prefix with `../../`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@visual-framework/vf-core-repo",
   "version": "2.2.0-alpha.0",
-  "description": "Visual Framework 2.0",
+  "description": "Visual Framework",
   "main": "index.js",
   "dependencies": {
     "gulp": "4.0.2"

--- a/tools/vf-component-generator/index.js
+++ b/tools/vf-component-generator/index.js
@@ -5,7 +5,7 @@ var path = require("path");
 var config = require(path.resolve(".","package.json"));
 
 config.vfConfig = config.vfConfig || [];
-vfName = config.vfConfig.vfName || "Visual Framework 2.0";
+vfName = config.vfConfig.vfName || "Visual Framework";
 vfNamespace = config.vfConfig.vfNamespace || "vf-";
 vfComponentPath = config.vfConfig.vfComponentPath || path.resolve(__dirname, "../../components");
 

--- a/tools/vf-component-initialization/package.json
+++ b/tools/vf-component-initialization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@visual-framework/vf-component-initialization",
   "version": "1.1.7",
-  "description": "Initialise a data object of Visual Framework 2.0 components.",
+  "description": "Initialise a data object of Visual Framework components.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tools/vf-component-library/README.md
+++ b/tools/vf-component-library/README.md
@@ -1,6 +1,6 @@
-# Visual Framework 2.0 component library
+# Visual Framework component library
 
-The homepage, welcome and onboarding site for the Visual Framework 2.0 and its components.
+The homepage, welcome and onboarding site for the Visual Framework and its components.
 
 ## What's the Visual Framework?
 

--- a/tools/vf-component-library/package.json
+++ b/tools/vf-component-library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@visual-framework/vf-component-library",
   "version": "1.2.0",
-  "description": "Generate a static-html site of Visual Framework 2.0 components and docs.",
+  "description": "Generate a static-html site of Visual Framework components and docs.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tools/vf-component-library/src/site/_data/siteConfig.js
+++ b/tools/vf-component-library/src/site/_data/siteConfig.js
@@ -3,7 +3,7 @@ const { DateTime } = require("luxon");
 // Some various reusable configuration
 module.exports = {
   siteInformation: {
-    title: "The Visual Framework 2.0",
+    title: "The Visual Framework",
     short_description: "A front-end toolkit to quickly and collaboratively build better life science websites.",
     url: "https://stable.visual-framework.dev/",
     author: "Visual Framework system",

--- a/tools/vf-component-library/src/site/_includes/layouts/base.njk
+++ b/tools/vf-component-library/src/site/_includes/layouts/base.njk
@@ -42,7 +42,7 @@
     {%- endif -%}
 
     <!-- Feed -->
-    <link href="https://stable.visual-framework.dev/feed.xml" type="application/rss+xml" rel="alternate" title="Visual Framework 2.0 Updates">
+    <link href="https://stable.visual-framework.dev/feed.xml" type="application/rss+xml" rel="alternate" title="Visual Framework updates and announcements">
   </head>
   <body class="{{ bodyClass }} vf-body | vf-stack">
     <header class="vf-global-header vf-mega-menu" data-vf-js-mega-menu role="menubar">
@@ -64,7 +64,7 @@
             </a>
           </li>
           <li class="vf-navigation__item">
-            <a class="vf-navigation__link vf-mega-menu__link vf-mega-menu__link--has-section" data-vf-js-mega-menu-section-id="components-content-section" href="/organization">
+            <a class="vf-navigation__link vf-mega-menu__link vf-mega-menu__link--has-section" data-vf-js-mega-menu-section-id="components-content-section" href="/components">
               Components
             </a>
           </li>

--- a/tools/vf-component-library/src/site/developing/components/updating-a-component.njk
+++ b/tools/vf-component-library/src/site/developing/components/updating-a-component.njk
@@ -1,6 +1,6 @@
 ---
 title: Updating, versioning a component
-subtitle: "Like the Visual Framework 2.0, components follow [semantic versioning](https://semver.org/) by increasing their full version number every time they have breaking changes."
+subtitle: "Like the Visual Framework, components follow [semantic versioning](https://semver.org/) by increasing their full version number every time they have breaking changes."
 intro: "However the version number of components its not tied to the version number of the Visual Framework's `vf-core`; that is:"
 date: 2019-04-09 12:24:50
 layout: layouts/post.njk

--- a/tools/vf-component-library/src/site/developing/index.njk
+++ b/tools/vf-component-library/src/site/developing/index.njk
@@ -21,7 +21,7 @@ templateEngineOverride: njk
   <article class="vf-grid__col--span-2 | vf-content ">
 {% markdown %}
 
-If you'd like to contribute code, components or documentation to the Visual Framework 2.0,
+If you'd like to contribute code, components or documentation to the Visual Framework,
 first of all: thanks! We welcome ideas, bug reports, opinions and pull requests.
 
 - Not writing new components and need to just make a VF-powered site?

--- a/tools/vf-component-library/src/site/updates.njk
+++ b/tools/vf-component-library/src/site/updates.njk
@@ -15,7 +15,7 @@ layout: layouts/base.njk
 <div>
   <h1 class="vf-intro__heading">{{ title }}</h1>
   <p class="vf-lede">{{ subtitle | safe }}</p>
-  <p class="vf-intro__text">Here on the <a class="vf-link" href="{{ '/updates' | url }}">updates blog</a> you can now expect to find what's new in each release of the Visual Framework 2.0 components.</p>
+  <p class="vf-intro__text">Here on the <a class="vf-link" href="{{ '/updates' | url }}">updates blog</a> you can now expect to find what's new in each release of the Visual Framework components and tooling.</p>
   <p class="vf-intro__text">You can also subscribe to <a class="vf-link" href="{{ '/feed.xml' | url }}">the RSS feed</a>.</p>
 </div>
 </section>

--- a/tools/vf-component-library/src/site/updates/2020-09-11-communicating-more.md
+++ b/tools/vf-component-library/src/site/updates/2020-09-11-communicating-more.md
@@ -1,6 +1,6 @@
 ---
 title: Updates on Visual Framework component changes
-subtitle: The Visual Framework 2.0 is maturing and we're working to do a better job communicating changes and individual component release notes.
+subtitle: The Visual Framework is maturing and we're working to do a better job communicating changes and individual component release notes.
 date: 2020-09-11 11:24:50
 tags:
   - posts

--- a/tools/vf-config/index.js
+++ b/tools/vf-config/index.js
@@ -38,7 +38,7 @@ if (config.name === "@visual-framework/vf-core") {
 }
 
 config.vfConfig = config.vfConfig || [];
-global.vfName = config.vfConfig.vfName || "Visual Framework 2.0";
+global.vfName = config.vfConfig.vfName || "Visual Framework";
 global.vfNamespace = config.vfConfig.vfNamespace || "vf-";
 global.vfComponentPath = config.vfConfig.vfComponentPath || path.resolve(".", "components");
 global.vfBuildDestination = config.vfConfig.vfBuildDestination || "temp/build-files";

--- a/tools/vf-core/docs/getting-started/right-place.njk
+++ b/tools/vf-core/docs/getting-started/right-place.njk
@@ -3,18 +3,18 @@ title: In the right place?
 label: none
 context:
   lede: None yet
-  intro: This site is designed as a demonstration of all the components bundled with the Visual Framework 2.0 core.
+  intro: This site is designed as a demonstration of all the components bundled with the Visual Framework.
 order: 99
 isIndex: true
 ---
 
 You most likely don't need to clone the
 [`vf-core`](https://github.com/visual-framework/vf-core) unless you're
-interested in improving the architecure of the system or contributing a global
+interested in improving the architecture of the system or contributing a global
 component for all users of the Visual Framework.
 
 Most developers will want to build a site or design system that use the Visual
-Framework architecure and components, for those users we recommend:
+Framework architecture and components, for those users we recommend:
 
 1. Reviewing the links below and components on this site; and
 2. Utilising the [`vf-eleventy`](https://visual-framework.github.io/vf-eleventy/) templates.

--- a/tools/vf-core/package.json
+++ b/tools/vf-core/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@visual-framework/vf-core",
   "version": "2.2.36",
-  "description": "Common dependencies for the Visual Framework 2.0.",
+  "description": "Common dependencies for the Visual Framework.",
   "engines": {
     "node": ">=12.0.0"
   },
   "main": "index.js",
   "vfConfig": {
     "vfNamespace": "vf-",
-    "vfName": "Visual Framework 2.0",
+    "vfName": "Visual Framework",
     "vfHomepage": "https://stable.visual-framework.dev",
     "vfBuildFractalMode": "normal",
     "vfThemePath": "@frctl/mandelbrot",

--- a/tools/vf-sass-compilation/README.md
+++ b/tools/vf-sass-compilation/README.md
@@ -1,11 +1,11 @@
 # vf-sass-compilation
 
-Build the Sass for Visual Framework 2.0 projects
+Build the Sass for Visual Framework projects
 
 ## To do
 
 This component is in early development and will be used to break apart the previously
-monolitihic functionality of vf-core.
+monolithic functionality of vf-core.
 
 - Break this component into build process for JS and Nunjucks templates (and perhaps more)
 - Move the relevant Gulp scripts to this component

--- a/tools/vf-sass-compilation/package.json
+++ b/tools/vf-sass-compilation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@visual-framework/vf-sass-compilation",
   "version": "1.1.18",
-  "description": "Build the Sass for Visual Framework 2.0 projects.",
+  "description": "Build the Sass for Visual Framework projects.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
There are still a few places we use "Visual Framework 2.0". Some time back we switched to just "Visual Framework".

To be slipped in between release tags (no need to generate npm updates for these).