### PR TITLE
Bug: vf-divider fails to inherit vf-stack

### DIFF
--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.7.1
 
 * Make vf-divider respect vf-stack spacing.
+* https://github.com/visual-framework/vf-core/pull/1723
 
 ### 2.7.0
 

--- a/components/vf-sass-config/CHANGELOG.md
+++ b/components/vf-sass-config/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.7.1
+
+* Make vf-divider respect vf-stack spacing.
+
 ### 2.7.0
 
 * `@mixin set-type` margin-top now inherits any applicable vf-stack margin.

--- a/components/vf-sass-config/mixins/_divider.scss
+++ b/components/vf-sass-config/mixins/_divider.scss
@@ -10,5 +10,7 @@
   border: none;
   height: 1px;
   margin-block: 0 var(--vf-divider-margin--block-end, $margin--block-end);
+  margin-top: #{map-get($vf-spacing-map, vf-spacing--400)}; /* IE Fallback */
+  margin-top: var(--vf-stack-margin, #{map-get($vf-spacing-map, vf-spacing--400)});
   width: 100%;
 }


### PR DESCRIPTION
When vf-stack 3.0 stopped using `!important`, that also meant `vf-divder`'s margin top 0 was no longer being overriden.

this sorts that.