### PR TITLE
bug: vf-stack inheritance for contentHub

### DIFF
--- a/components/embl-content-hub-loader/CHANGELOG.md
+++ b/components/embl-content-hub-loader/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.2.0
+
+* contentHub html responses are nested deep in many layers of divs, so we ensure a default vf--stack applies to grid containers.
+* https://github.com/visual-framework/vf-core/pull/1725
+
 ### 1.1.1
 
 * Avoid a null variable issue when contentHub returns no results.

--- a/components/embl-content-hub-loader/embl-content-hub-loader.scss
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.scss
@@ -41,14 +41,16 @@
 
 // contentHub html responses are nested deep in divitis,
 // so we ensure a default vf--stack applies to grid containers
-.vf-stack > .vf-content-hub-html > * > .embl-grid,
-.vf-stack > .vf-content-hub-html > * > .vf-grid {
-  margin-top:var(--vf-stack-margin--custom, var(--vf-stack-margin, 1rem));
+.vf-stack .vf-content-hub-html .embl-grid,
+.vf-stack .vf-content-hub-html .vf-grid,
+.vf-stack .vf-content-hub-html .vf-content > * {
   --vf-stack-margin: 1rem;
   --vf-stack-margin--custom: 1rem;
+  margin-top: var(--vf-stack-margin, 1rem);
 }
-.vf-stack > .vf-content-hub-html > * > .embl-grid > *,
-.vf-stack > .vf-content-hub-html > * > .vf-grid > * {
-  --vf-stack-margin: 0;
-  --vf-stack-margin--custom: 0;
+.vf-stack .vf-content-hub-html .embl-grid > *,
+.vf-stack .vf-content-hub-html .vf-grid > *,
+.vf-stack .vf-content-hub-html .vf-content > * > * {
+ --vf-stack-margin: 0;
+ --vf-stack-margin--custom: 0
 }

--- a/components/embl-content-hub-loader/embl-content-hub-loader.scss
+++ b/components/embl-content-hub-loader/embl-content-hub-loader.scss
@@ -18,11 +18,11 @@
 .vf-grid > .embl-content-hub-html {
   grid-column: 1 / -1;
   // @todo: this should probably just be .embl-content-hub-html, but that requires a
-  //        disruptive change in the contenthub itself and will impact many systems.
+  //        disruptive change in the contentHub itself and will impact many systems.
   //        that change will require coordination
 }
 // contentHub html is sometimes placed as a direct child of `vf-body` which needs a
-// different grid-column ruleset.
+// different grid-column rule set.
 .vf-body > .vf-content-hub-html,
 .vf-body > .embl-content-hub-html {
   grid-column: main;
@@ -36,5 +36,19 @@
 // targets anything that's loaded from content hub
 // as nine times out of ten - it's ok.
 .vf-content-hub-html {
+  --vf-stack-margin--custom: 0;
+}
+
+// contentHub html responses are nested deep in divitis,
+// so we ensure a default vf--stack applies to grid containers
+.vf-stack > .vf-content-hub-html > * > .embl-grid,
+.vf-stack > .vf-content-hub-html > * > .vf-grid {
+  margin-top:var(--vf-stack-margin--custom, var(--vf-stack-margin, 1rem));
+  --vf-stack-margin: 1rem;
+  --vf-stack-margin--custom: 1rem;
+}
+.vf-stack > .vf-content-hub-html > * > .embl-grid > *,
+.vf-stack > .vf-content-hub-html > * > .vf-grid > * {
+  --vf-stack-margin: 0;
   --vf-stack-margin--custom: 0;
 }


### PR DESCRIPTION
contentHub html responses are nested deep in many layers of divs, so we ensure a default vf--stack applies to grid containers.