### PR TITLE
chore: increase vf-navigation--on-this-page margin

### DIFF
--- a/components/vf-navigation/CHANGELOG.md
+++ b/components/vf-navigation/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 3.0.0-rc.1
 
 * Give vf-navigation--on-this-page a bigger bottom margin on desktop as vf-u-fullbleed eats a bit of bottom margin by its nature.
+* https://github.com/visual-framework/vf-core/pull/1732
 
 ### 3.0.0-rc.0
 

--- a/components/vf-navigation/CHANGELOG.md
+++ b/components/vf-navigation/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.0.0-rc.1
+
+* Give vf-navigation--on-this-page a bigger bottom margin on desktop as vf-u-fullbleed eats a bit of bottom margin by its nature.
+
 ### 3.0.0-rc.0
 
 * Introduces `vf-navigation--on-this-page`.

--- a/components/vf-navigation/vf-navigation.scss
+++ b/components/vf-navigation/vf-navigation.scss
@@ -92,6 +92,7 @@
 
 @media only screen and (min-width: $vf-breakpoint--md) {
   .vf-navigation--on-this-page.vf-u-fullbleed {
+    margin-bottom: map-get($vf-spacing-map, vf-spacing--800); // fullbleed eats about 1em of bottom margin
     overflow: unset; // allow shadow to bleed out
     &::before {
       box-shadow: 0 0 2px 1px rgba(0, 0, 0, .2);


### PR DESCRIPTION
Give vf-navigation--on-this-page a bigger bottom margin on desktop as vf-u-fullbleed eats a bit of bottom margin by its nature.