### PR TITLE
Docs: Remove old email from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,3 @@ There are a few ways that we discuss and track ideas:
 
 - ⁉ General: [Chat us](https://join.slack.com/t/visual-framework/shared_invite/enQtNDAxNzY0NDg4NTY0LWFhMjEwNGY3ZTk3NWYxNWVjOWQ1ZWE4YjViZmY1YjBkMDQxMTNlNjQ0N2ZiMTQ1ZTZiMGM4NjU5Y2E0MjM3ZGQ) for general ideas and discussion
 - ⚙️ Technical: [GitHub issues here](https://github.com/visual-framework/vf-core/issues) for implementing deeply technical and specific issues, like the Sass build process, browser bugs
-- 🏢 E-mail: if you have a sweeping Big Idea™️, e-mail Ken Hawkins <ken.hawkins@embl.de>


### PR DESCRIPTION
Could be updated to a new email address, but I suspect the Slack and GitHub issues links are enough.