### PR TITLE
Bug: GA4 feature

### DIFF
--- a/components/vf-analytics-google/vf-analytics-google.js
+++ b/components/vf-analytics-google/vf-analytics-google.js
@@ -252,7 +252,7 @@ function vfGaLinkTrackingInit() {
     if (evt.target) {
       if (evt.target.tagName) {
         let clickedElementTag = evt.target.tagName.toLowerCase();
-        let actionElements = ["a", "button", "label", "input", "select", "textarea", "details"];
+        let actionElements = ["a", "button", "label", "input", "select", "textarea", "details", "area"];
         if (actionElements.indexOf(clickedElementTag) > -1) {
           vfGaTrackInteraction(evt.target);
           return;
@@ -507,7 +507,7 @@ function vfGaTrackInteraction(actedOnItem, customEventName) {
         "vf_analytics": "true",
         "page_container": parentContainer,
         "event_label": linkName,
-        "event_category": "UI " + parentContainer,
+        "event_category": "UI ",
         "event_type": "Webform",
         "link_text": linkName
       });

--- a/components/vf-analytics-google/vf-analytics-google.js
+++ b/components/vf-analytics-google/vf-analytics-google.js
@@ -507,7 +507,7 @@ function vfGaTrackInteraction(actedOnItem, customEventName) {
         "vf_analytics": "true",
         "page_container": parentContainer,
         "event_label": linkName,
-        "event_category": "UI ",
+        "event_category": "UI",
         "event_type": "Webform",
         "link_text": linkName
       });


### PR DESCRIPTION
Following https://github.com/visual-framework/vf-core/pull/1777, i noticed two things:

- remove extra string in event_category for webform logging
- support imagemap `area` links (this is not a new bug from the GA4 work)

I've not updated the changelog, as I don't think this feature has shipped to npm yet.

ping @sandykadam  @nitinja 