### PR TITLE
Bug: vf-analytics remove leftover console.log

### DIFF
--- a/components/vf-analytics-google/vf-analytics-google.js
+++ b/components/vf-analytics-google/vf-analytics-google.js
@@ -74,6 +74,7 @@ function vfGaIndicateLoaded(vfGaTrackOptions,numberOfGaChecksLimit,numberOfGaChe
       vfGaIndicateUnloaded();
     }
 
+    // check to see if gtag is loaded, and then if UA is loaded, and if neither, check once more (to a limit)
     if (typeof gtag !== "undefined") {
       vfGaLogMessage('ga4 found');
       if (el.getAttribute("data-vf-google-analytics-loaded") != "true") {
@@ -96,7 +97,6 @@ function vfGaIndicateLoaded(vfGaTrackOptions,numberOfGaChecksLimit,numberOfGaChe
     }
   } catch (err) {
     vfGaLogMessage('error in vfGaIndicateLoaded');
-    console.log(err)
     if (numberOfGaChecks <= numberOfGaChecksLimit) {
       setTimeout(function () {
         vfGaIndicateLoaded(vfGaTrackOptions,numberOfGaChecksLimit,numberOfGaChecks,checkTimeout);


### PR DESCRIPTION
As mentioned at https://github.com/visual-framework/vf-core/pull/1814#issuecomment-1322115496 -- there is an error that is meant to be silently handled by a `try` but was being output by a leftover `console.log)