### PR TITLE
Fix: Vf-dropdown - Not clickable links in Safari

### DIFF
--- a/components/vf-dropdown/CHANGELOG.md
+++ b/components/vf-dropdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.0-alpha.8
+* Fix: Check for a truthy value of e.relatedTarget while focusing out of the dropdown. Avoid issue in Safari
+  * https://github.com/visual-framework/vf-core/issues/1973
+
 ### 1.0.0-alpha.7
 
 * Feat: Add keyboard navigation

--- a/components/vf-dropdown/vf-dropdown.config.yml
+++ b/components/vf-dropdown/vf-dropdown.config.yml
@@ -19,6 +19,8 @@ variants:
           link_href: JavaScript:Void(0);
         - text: Logout
           link_href: JavaScript:Void(0);
+        - text: EBI Home
+          link_href: https://www.ebi.ac.uk/
 # Global component context
 context:
   component-type: block

--- a/components/vf-dropdown/vf-dropdown.js
+++ b/components/vf-dropdown/vf-dropdown.js
@@ -31,7 +31,8 @@ export function vfDropdown() {
     component.setAttribute("aria-expanded", "false");
     component.addEventListener("focusout", function(e) {
       // if dropdown loses focus to another element that aren't its own links
-      if (!e.currentTarget.contains(e.relatedTarget)) {
+      // check for relatedTarget to avoid bug with Safari
+      if (e.relatedTarget && !e.currentTarget.contains(e.relatedTarget)) {
         component.setAttribute("aria-expanded", "false");
         component.classList.remove("vf-dropdown--open");
         currentPos = null;


### PR DESCRIPTION
Hi all,

@lilim-ebi from ENA discovered a bug for the Vf-dropdown. If you open https://www.covid19dataportal.org/ or https://www.pathogensportal.org/ and try to click a link on one of the dropdown's (like About or Tools), it works in Chrome and Firefox except in Safari.
It's related to the keyboard navigation functionality I added in one of the sprints lead by Niki.
I added the fix and updated the configuration to reproduce the issue in the VF component library.